### PR TITLE
Perform the entire CircleCI workflow on tags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,22 +20,34 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node4
-      - node6
-      - node7
-      - node8
+      - node4:
+          tags:
+            only: /.*/
+      - node6:
+          tags:
+            only: /.*/
+      - node7:
+          tags:
+            only: /.*/
+      - node8:
+          tags:
+            only: /.*/
       - lint:
           requires:
             - node4
             - node6
             - node7
             - node8
+          tags:
+            only: /.*/
       - docs:
           requires:
             - node4
             - node6
             - node7
             - node8
+          tags:
+            only: /.*/
       - system_tests:
           requires:
             - lint
@@ -107,7 +119,7 @@ jobs:
             cd samples/
             npm install
             npm link @google-cloud/storage
-            cd ..    
+            cd ..
       - run:
           name: Run linting.
           command: npm run lint


### PR DESCRIPTION
This _should_ make it such that CircleCI runs on tag builds (and thus can push to npm).