### PR TITLE
Fix broken link in file documentation.

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -657,8 +657,8 @@ File.prototype.createReadStream = function(options) {
  * <h4>Note</h4>
  *
  * If you are just looking to perform a resumable upload without worrying about
- * any of the details, see {module:storage/createWriteStream}. Resumable uploads
- * are performed by default.
+ * any of the details, see {module:storage/file#createWriteStream}. Resumable
+ * uploads are performed by default.
  *
  * @see [Resumable upload guide]{@link https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload}
  *


### PR DESCRIPTION
From @jergason in https://github.com/GoogleCloudPlatform/google-cloud-node/pull/2608:

> The `file.createResumableUpload` documentation says to refer to `storage.createWriteStream`, but this method doesn't exist. I assume this should actually refer to `file.createWriteStream`, which appears to exist.