### PR TITLE
[Requester-Pays] Remove skip comment for Requester Pays system tests. 

### DIFF
--- a/system-test/storage.js
+++ b/system-test/storage.js
@@ -922,9 +922,6 @@ describe('storage', function() {
         });
       });
 
-      // These tests are skipped because after multiple days of trying, we
-      // flatly can not figure out the magic incantation of appropriate
-      // IAM permissions to make them work. - lukesneeringer@, 2017-09-07
       describe('methods that accept userProject', function() {
         var file;
         var USER_PROJECT_OPTIONS = {


### PR DESCRIPTION
Remove comment about requester pays system tests being skipped as they're now enabled and passing since [PR#42](https://github.com/googleapis/nodejs-storage/pull/42). The fix was to grant roles/Storage.Admin at project-level IAM Policy instead of bucket-level IAM Policy.

There will be a follow-up review in two weeks to assign this role only at Bucket-level to allow for Storage.buckets.delete operation which failed before. No code should be necessary.

- [ ] Tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
