### PR TITLE
Kiricon/upload from url

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mime-types": "^2.0.8",
     "once": "^1.3.1",
     "pumpify": "^1.3.3",
+    "request": "^2.83.0",
     "safe-buffer": "^5.1.1",
     "snakeize": "^0.1.0",
     "stream-events": "^1.0.1",
@@ -96,7 +97,6 @@
     "prop-assign": "^1.0.0",
     "propprop": "^0.3.0",
     "proxyquire": "^1.8.0",
-    "request": "^2.70.0",
     "semistandard": "^11.0.0",
     "tmp": "^0.0.33",
     "uuid": "^3.1.0"

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -27,6 +27,7 @@ var path = require('path');
 var snakeize = require('snakeize');
 var util = require('util');
 var request = require('request');
+var url = require('url');
 
 var Acl = require('./acl.js');
 var File = require('./file.js');
@@ -2241,7 +2242,11 @@ Bucket.prototype.upload = function(pathString, options, callback) {
     });
   } else {
     // Resort to using the name of the incoming file.
-    newFile = this.file(path.basename(pathString), {
+    var destination = path.basename(pathString);
+    if (isURL) {
+      destination = new url.parse(pathString).pathname;
+    }
+    newFile = this.file(destination, {
       encryptionKey: options.encryptionKey,
     });
   }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -2048,7 +2048,7 @@ Bucket.prototype.setUserProject = function(userProject) {
  * @see [Upload Options (Simple or Resumable)]{@link https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload#uploads}
  * @see [Objects: insert API Documentation]{@link https://cloud.google.com/storage/docs/json_api/v1/objects/insert}
  *
- * @param {string} localPath The fully qualified path to the file you wish to
+ * @param {string} path The fully qualified path or url to the file you wish to
  *     upload to your bucket.
  * @param {object} [options] Configuration options.
  * @param {string|File} [options.destination] The place to save
@@ -2056,7 +2056,7 @@ Bucket.prototype.setUserProject = function(userProject) {
  *     using the string as a filename. When given a File object, your local file
  *     will be uploaded to the File object's bucket and under the File object's
  *     name. Lastly, when this argument is omitted, the file is uploaded to your
- *     bucket using the name of the local file.
+ *     bucket using the name of the local file or the path of the url relative to it's domain.
  * @param {string} [options.encryptionKey] A custom encryption key. See
  *     [Customer-supplied Encryption Keys](https://cloud.google.com/storage/docs/encryption#customer-supplied).
  * @param {boolean} [options.gzip] Automatically gzip the file. This will set
@@ -2113,6 +2113,15 @@ Bucket.prototype.setUserProject = function(userProject) {
  * bucket.upload('/local/path/image.png', function(err, file, apiResponse) {
  *   // Your bucket now contains:
  *   // - "image.png" (with the contents of `/local/path/image.png')
+ *
+ *   // `file` is an instance of a File object that refers to your new file.
+ * });
+ * 
+ * //or
+ * 
+ * bucket.upload('https://example.com/images/image.png', function(err, file, apiResponse) {
+ *   // Your bucket now contains:
+ *   // - "image.png" (with the contents of `/images/image.png')
  *
  *   // `file` is an instance of a File object that refers to your new file.
  * });

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -2225,9 +2225,7 @@ Bucket.prototype.upload = function(pathString, options, callback) {
     return;
   }
 
-  var isURL =
-    !fs.existsSync(path.basename(pathString)) &&
-    /^(http|https):/.test(pathString);
+  var isURL = /^(http|https):/.test(pathString);
 
   if (is.fn(options)) {
     callback = options;
@@ -2253,7 +2251,7 @@ Bucket.prototype.upload = function(pathString, options, callback) {
     // Resort to using the name of the incoming file.
     var destination = path.basename(pathString);
     if (isURL) {
-      destination = new url.parse(pathString).pathname;
+      destination = path.basename(new url.parse(pathString).pathname);
     }
     newFile = this.file(destination, {
       encryptionKey: options.encryptionKey,

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -2292,7 +2292,11 @@ Bucket.prototype.upload = function(pathString, options, callback) {
   }
 
   function uploadFromURL() {
-    request(pathString)
+    request
+      .get(pathString)
+      .on('error', function(err) {
+        callback(err);
+      })
       .pipe(newFile.createWriteStream(options))
       .on('error', function(err) {
         callback(err);

--- a/system-test/storage.js
+++ b/system-test/storage.js
@@ -518,6 +518,25 @@ describe('storage', function() {
           }
         );
       });
+
+      it('should upload a file from a URL', function(done) {
+        var url =
+          'https://pbs.twimg.com/profile_images/839721704163155970/LI_TRk1z_400x400.jpg';
+
+        bucket.upload(url, function(err, file) {
+          assert.ifError(err);
+
+          file.download(function(err, contents) {
+            assert.ifError(err);
+
+            request(url, function(err, resp, body) {
+              assert.ifError(err);
+              assert.strictEqual(body.toString(), contents.toString());
+              done();
+            });
+          });
+        });
+      });
     });
   });
 

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -1929,7 +1929,7 @@ describe('Bucket', function() {
       bucket.upload(urlpath, function(err, file) {
         assert.ifError(err);
         assert.equal(file.bucket.name, bucket.name);
-        assert.equal(file.name, urlBasename);
+        assert.equal(file.name, 'testfile.json');
         done();
       });
     });

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -30,7 +30,7 @@ var request = require('request');
 var snakeize = require('snakeize');
 var stream = require('stream');
 var through = require('through2');
-var util = require('@google-cloud/common').util;
+var util = common.util;
 
 var ServiceObject = common.ServiceObject;
 
@@ -1895,7 +1895,7 @@ describe('Bucket', function() {
     });
   });
 
-  describe.only('upload', function() {
+  describe('upload', function() {
     var basename = 'testfile.json';
     var filepath = path.join(__dirname, 'testdata/' + basename);
     var textFilepath = path.join(__dirname, 'testdata/textfile.txt');


### PR DESCRIPTION
Fixes #58 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

A new method called `uploadFromURL` has been added to the `Bucket` object.
The method does the same thing the `upload` method does, save the `localpath` argument is now meant to be a url string.

Due to the file being remotely hosted, the `option`  property `resumable` it not being taken in to account.

I'm sure of the best way to go about writing them up considering the majority of shared functionality between the `upload` and `uploadFromURL` methods.

Let me know what I can improve and I'll be glad to make the change. This is a feature I've been needing for a very long time. 
