### PR TITLE
docs: un-document `apiResponse` from list operations.

### DIFF
--- a/src/bucket.js
+++ b/src/bucket.js
@@ -1153,8 +1153,8 @@ Bucket.prototype.get = function(options, callback) {
  * Query object for listing files.
  *
  * @typedef {object} GetFilesRequest
- * @property {boolean} [autoPaginate] Have pagination handled automatically.
- *     Default: true.
+ * @property {boolean} [autoPaginate=true] Have pagination handled
+ *     automatically.
  * @property {string} [delimiter] Results will contain only objects whose
  *     names, aside from the prefix, do not contain delimiter. Objects whose
  *     names, aside from the prefix, contain delimiter will have their name
@@ -1175,13 +1175,11 @@ Bucket.prototype.get = function(options, callback) {
 /**
  * @typedef {array} GetFilesResponse
  * @property {File[]} 0 Array of {@link File} instances.
- * @property {object} 1 The full API response.
- */
+  */
 /**
  * @callback GetFilesCallback
  * @param {?Error} err Request error, if any.
  * @param {File[]} files Array of {@link File} instances.
- * @param {object} apiResponse The full API response.
  */
 /**
  * Get {@link File} objects for the files currently in the bucket.

--- a/src/index.js
+++ b/src/index.js
@@ -383,13 +383,11 @@ Storage.prototype.createBucket = function(name, metadata, callback) {
 /**
  * @typedef {array} GetBucketsResponse
  * @property {Bucket[]} 0 Array of {@link Bucket} instances.
- * @property {object} 1 The full API response.
  */
 /**
  * @callback GetBucketsCallback
  * @param {?Error} err Request error, if any.
  * @param {Bucket[]} buckets Array of {@link Bucket} instances.
- * @param {object} apiResponse The full API response.
  */
 /**
  * Get Bucket objects for all of the buckets in your project.


### PR DESCRIPTION
RE: #26 

It was pointed out in #26 that our JSDocs say `getBuckets()` and `getFiles()` return an `apiResponse` argument to the callback/promise. However, that is only true when `options.autoPaginate = false`. To avoid confusion, it seems best to remove the line about `apiResponse`, and instead only show that it exists in the example documentation for `autoPaginate`.