### PR TITLE
samples: tests: Test stdout, not stderr.

### DIFF
--- a/samples/system-test/encryption.test.js
+++ b/samples/system-test/encryption.test.js
@@ -113,5 +113,5 @@ test.serial(`should rotate keys`, async t => {
     `${cmd} rotate ${bucketName} ${fileName} ${key} ${newKey}`,
     cwd
   );
-  t.is(results.stdout + results.stderr, 'Encryption key rotated successfully.');
+  t.is(results.stdout, 'Encryption key rotated successfully.');
 });


### PR DESCRIPTION
We've been getting an error on CI, and I think this should fix it.

Error: https://circleci.com/gh/googleapis/nodejs-storage/2149