### PR TITLE
Fix stale test.

### DIFF
--- a/system-test/storage.js
+++ b/system-test/storage.js
@@ -1530,7 +1530,6 @@ describe('storage', function() {
       var file = bucket.file('hi.jpg');
       file.download(function(err) {
         assert.strictEqual(err.code, 404);
-        assert(err.message.indexOf('Not Found') > -1);
         done();
       });
     });
@@ -1541,7 +1540,6 @@ describe('storage', function() {
       };
 
       var expectedContents = fs.readFileSync(FILES.html.path, 'utf-8');
-      ``;
 
       bucket.upload(FILES.html.path, options, function(err, file) {
         assert.ifError(err);


### PR DESCRIPTION
A 404 error for an object used to return an error message that said something like "Not found". It now returns "No such object". I removed our test that checked for specific messaging, and instead just confirm that the code is 404.