### PR TITLE
don't require contentType for bucket.combine

### DIFF
--- a/src/bucket.js
+++ b/src/bucket.js
@@ -274,7 +274,6 @@ util.inherits(Bucket, common.ServiceObject);
  * @throws {Error} if a non-array is provided as sources argument.
  * @throws {Error} if less than two sources are provided.
  * @throws {Error} if no destination is provided.
- * @throws {Error} if content type can't be determined for the destination file.
  *
  * @param {string[]|File[]} sources The source files that will be
  *     combined.
@@ -334,10 +333,6 @@ Bucket.prototype.combine = function(sources, destination, options, callback) {
 
     if (destinationContentType) {
       destination.metadata.contentType = destinationContentType;
-    } else {
-      throw new Error(
-        'A content type could not be detected for the destination file.'
-      );
     }
   }
 

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -352,12 +352,6 @@ describe('Bucket', function() {
       bucket.combine(['1', '2'], destination);
     });
 
-    it('should throw if content type cannot be determined', function() {
-      assert.throws(function() {
-        bucket.combine(['1', '2'], 'destination');
-      }, /A content type could not be detected for the destination file\./);
-    });
-
     it('should make correct API request', function(done) {
       var sources = [bucket.file('1.txt'), bucket.file('2.txt')];
       var destination = bucket.file('destination.txt');


### PR DESCRIPTION
Fixes #166

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
