### PR TITLE
properly encode signed URLs

### DIFF
--- a/test/file.js
+++ b/test/file.js
@@ -2280,6 +2280,13 @@ describe('File', function() {
       file.getSignedUrl(CONFIG, function(err, signedUrl) {
         assert.ifError(err);
         assert.equal(typeof signedUrl, 'string');
+        var expires = Math.round(CONFIG.expires / 1000);
+        var expected =
+          'https://storage.googleapis.com/bucket-name/file-name.png?' +
+          'GoogleAccessId=client-email&Expires=' +
+          expires +
+          '&Signature=signature';
+        assert.equal(signedUrl, expected);
         done();
       });
     });
@@ -2402,7 +2409,7 @@ describe('File', function() {
             promptSaveAs: 'fname.ext',
           },
           function(err, signedUrl) {
-            assert(signedUrl.indexOf(disposition) > -1);
+            assert(signedUrl.indexOf(encodeURIComponent(disposition)) > -1);
             done();
           }
         );


### PR DESCRIPTION
Fixes #167

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

This uses the native `url` module to build the URL, which I think is less brittle than the existing string-building method.