### PR TITLE
Update gcs-resumable-upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6372,9 +6372,9 @@
       }
     },
     "gcs-resumable-upload": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.10.0.tgz",
-      "integrity": "sha512-MHysRpJSIW0JrUSdsyVD0DmbI2yZh2i73jpKYeFysG2czhMlD++rDjc7xJMmMUUCrC82pHhBplQMQ0oi1f3HBg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.10.1.tgz",
+      "integrity": "sha512-dNhDKV9dyY+htlx2/3fLcJ2dmmzSdZtX7yEQxJqbK19nO7OKAlIJlWuJ97DyCxYh+sPEUMizot+5yxraHzHA/A==",
       "requires": {
         "configstore": "3.1.2",
         "google-auto-auth": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "create-error-class": "^3.0.2",
     "duplexify": "^3.5.0",
     "extend": "^3.0.0",
-    "gcs-resumable-upload": "^0.10.0",
+    "gcs-resumable-upload": "^0.10.1",
     "hash-stream-validation": "^0.2.1",
     "is": "^3.0.1",
     "mime": "^2.2.0",

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -183,7 +183,7 @@
         "create-error-class": "3.0.2",
         "duplexify": "3.5.4",
         "extend": "3.0.1",
-        "gcs-resumable-upload": "0.10.0",
+        "gcs-resumable-upload": "0.10.1",
         "hash-stream-validation": "0.2.1",
         "is": "3.2.1",
         "mime": "2.3.1",
@@ -4675,7 +4675,7 @@
           }
         },
         "gcs-resumable-upload": {
-          "version": "0.10.0",
+          "version": "0.10.1",
           "bundled": true,
           "requires": {
             "configstore": "3.1.2",


### PR DESCRIPTION
Includes https://github.com/stephenplusplus/gcs-resumable-upload/pull/47 to fix https://circleci.com/gh/googleapis/nodejs-storage/3661