### PR TITLE
0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/storage",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/storage",
   "description": "Cloud Storage Client Library for Node.js",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -173,7 +173,7 @@
       }
     },
     "@google-cloud/storage": {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "requires": {
         "@google-cloud/common": "0.17.0",
         "arrify": "1.0.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "*",
-    "@google-cloud/storage": "1.6.0",
+    "@google-cloud/storage": "1.7.0",
     "safe-buffer": "5.1.1",
     "uuid": "3.1.0",
     "yargs": "10.0.3"


### PR DESCRIPTION
# Do not merge
I think we're broken.

## Features

- (#165): Check if `$HOME` is writable before starting a resumable upload.
- (#174): Introduce a `directory` option to `getFiles()`.

## Fixes

- (#160): Return `apiResponse` argument from `bucket.upload()`. (Thanks for pointing this out, @scragg0x!)
- (#168): Don't require a content type for `bucket.combine()`. (Thanks, @zbjornson!) 
- (#169): Properly encode signed URLs. (Thanks again to @zbjornson!)
