### PR TITLE
chore: fix prettier incompatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1861,9 +1861,9 @@
       }
     },
     "@nodelib/fs.stat": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
-      "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
+      "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
       "dev": true
     },
     "@protobufjs/aspromise": {
@@ -2288,7 +2288,7 @@
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
         "make-dir": "1.3.0",
-        "matcher": "1.1.0",
+        "matcher": "1.1.1",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
         "ms": "2.0.0",
@@ -2298,7 +2298,7 @@
         "package-hash": "2.0.0",
         "pkg-conf": "2.1.0",
         "plur": "2.1.2",
-        "pretty-ms": "3.1.0",
+        "pretty-ms": "3.2.0",
         "require-precompiled": "0.1.0",
         "resolve-cwd": "2.0.0",
         "safe-buffer": "5.1.2",
@@ -2584,7 +2584,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "espower-location-detector": "1.0.0",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -2731,7 +2731,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -2755,7 +2755,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -2974,9 +2974,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -3088,7 +3088,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "deep-equal": "1.0.1",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -3449,7 +3449,7 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
+        "buffer-from": "1.1.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -3517,9 +3517,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "copy-descriptor": {
@@ -3539,9 +3539,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
@@ -3565,7 +3565,7 @@
       "requires": {
         "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -3588,7 +3588,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.44"
       }
     },
     "dashdash": {
@@ -3647,9 +3647,9 @@
       "dev": true
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -3949,7 +3949,7 @@
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "empower-core": "0.6.2"
       }
     },
@@ -3969,7 +3969,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "encoding": {
@@ -4040,9 +4040,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.44",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.44.tgz",
+      "integrity": "sha512-TO4Vt9IhW3FzDKLDOpoA8VS9BCV4b9WTf6BqvMOgfoa8wX73F3Kh3y2J7yTstTaXlQ0k1vq4DH2vw6RSs42z+g==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -4063,7 +4063,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4074,7 +4074,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4088,7 +4088,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4101,7 +4101,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.44"
       }
     },
     "es6-weak-map": {
@@ -4111,7 +4111,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.44",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4586,7 +4586,7 @@
       "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "esquery": {
@@ -4626,7 +4626,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.44"
       }
     },
     "execa": {
@@ -4731,7 +4731,7 @@
       "dev": true,
       "requires": {
         "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.0.2",
+        "@nodelib/fs.stat": "1.1.0",
         "glob-parent": "3.1.0",
         "is-glob": "4.0.0",
         "merge2": "1.2.2",
@@ -6004,7 +6004,7 @@
         "globby": "8.0.1",
         "google-auto-auth": "0.10.1",
         "google-proto-files": "0.15.1",
-        "grpc": "1.11.3",
+        "grpc": "1.12.2",
         "is-stream-ended": "0.1.4",
         "lodash": "4.17.10",
         "protobufjs": "6.8.6",
@@ -6118,9 +6118,9 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.3.tgz",
-      "integrity": "sha512-7fJ40USpnP7hxGK0uRoEhJz6unA5VUdwInfwAY2rK2+OVxdDJSdTZQ/8/M+1tW68pHZYgHvg2ohvJ+clhW3ANg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.12.2.tgz",
+      "integrity": "sha512-oDrW7TPuP+u9+RboUx8XupS1GOPCdLSmldyMHmlaB5wu38nOzzyDxzLsmleROw5/0XyfyuwsmFX6UUr7FaXN2w==",
       "dev": true,
       "requires": {
         "lodash": "4.17.10",
@@ -6231,7 +6231,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "2.3.3"
           }
         },
         "fs.realpath": {
@@ -6273,9 +6273,12 @@
           "dev": true
         },
         "iconv-lite": {
-          "version": "0.4.19",
+          "version": "0.4.23",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
         },
         "ignore-walk": {
           "version": "3.0.1",
@@ -6331,11 +6334,11 @@
           "dev": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
           }
         },
@@ -6344,7 +6347,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "2.3.3"
           }
         },
         "mkdirp": {
@@ -6373,7 +6376,7 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "iconv-lite": "0.4.19",
+            "iconv-lite": "0.4.23",
             "sax": "1.2.4"
           }
         },
@@ -6391,7 +6394,7 @@
             "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
-            "tar": "4.4.2"
+            "tar": "4.4.3"
           }
         },
         "nopt": {
@@ -6516,7 +6519,7 @@
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
@@ -6530,7 +6533,12 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
           "bundled": true,
           "dev": true
         },
@@ -6569,7 +6577,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
@@ -6586,24 +6594,17 @@
           "dev": true
         },
         "tar": {
-          "version": "4.4.2",
+          "version": "4.4.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
+            "minipass": "2.3.3",
             "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
             "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "util-deprecate": {
@@ -7817,9 +7818,9 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "lolex": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
-      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
     },
     "long": {
@@ -7904,9 +7905,9 @@
       "dev": true
     },
     "matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
-      "integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+      "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
@@ -8335,7 +8336,7 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -11585,7 +11586,7 @@
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -11597,7 +11598,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
@@ -11608,7 +11609,7 @@
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "estraverse": "4.2.0"
       }
     },
@@ -11618,7 +11619,7 @@
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -11649,7 +11650,7 @@
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "diff-match-patch": "1.0.1",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -11662,7 +11663,7 @@
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -11705,19 +11706,18 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
-      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.2.tgz",
+      "integrity": "sha512-D9oFKkJ7g76fRxkRh9MWBh4j2vbNGO4rtEUJbj46zId5wnm0dwHruoyg4Od9Zqh3WNl0jwxnWSlEGAnl+/thWA==",
       "dev": true
     },
     "pretty-ms": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
-      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
+      "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "1.0.1",
-        "plur": "2.1.2"
+        "parse-ms": "1.0.1"
       },
       "dependencies": {
         "parse-ms": {
@@ -11891,12 +11891,12 @@
       }
     },
     "rc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.5.1",
+        "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
@@ -12032,7 +12032,7 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.7",
+        "rc": "1.2.8",
         "safe-buffer": "5.1.2"
       }
     },
@@ -12042,7 +12042,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.7"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -12497,7 +12497,7 @@
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.5.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "nise": "1.3.3",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
@@ -12680,7 +12680,7 @@
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
+        "buffer-from": "1.1.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
@@ -12886,7 +12886,7 @@
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -12956,7 +12956,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
+        "cookiejar": "2.1.2",
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
@@ -13528,9 +13528,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -1807,7 +1807,7 @@
           }
         },
         "@nodelib/fs.stat": {
-          "version": "1.0.2",
+          "version": "1.1.0",
           "bundled": true
         },
         "@protobufjs/aspromise": {
@@ -2133,7 +2133,7 @@
             "lodash.flatten": "4.4.0",
             "loud-rejection": "1.6.0",
             "make-dir": "1.3.0",
-            "matcher": "1.1.0",
+            "matcher": "1.1.1",
             "md5-hex": "2.0.0",
             "meow": "3.7.0",
             "ms": "2.0.0",
@@ -2143,7 +2143,7 @@
             "package-hash": "2.0.0",
             "pkg-conf": "2.1.0",
             "plur": "2.1.2",
-            "pretty-ms": "3.1.0",
+            "pretty-ms": "3.2.0",
             "require-precompiled": "0.1.0",
             "resolve-cwd": "2.0.0",
             "safe-buffer": "5.1.2",
@@ -2382,7 +2382,7 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "espower-location-detector": "1.0.0",
             "espurify": "1.8.0",
             "estraverse": "4.2.0"
@@ -2499,7 +2499,7 @@
           "requires": {
             "babel-core": "6.26.3",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.10",
             "mkdirp": "0.5.1",
@@ -2519,7 +2519,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2694,7 +2694,7 @@
           "bundled": true
         },
         "buffer-from": {
-          "version": "1.0.0",
+          "version": "1.1.0",
           "bundled": true
         },
         "builtin-modules": {
@@ -2785,7 +2785,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "deep-equal": "1.0.1",
             "espurify": "1.8.0",
             "estraverse": "4.2.0"
@@ -3060,7 +3060,7 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "buffer-from": "1.0.0",
+            "buffer-from": "1.1.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.6",
             "typedarray": "0.0.6"
@@ -3117,7 +3117,7 @@
           "bundled": true
         },
         "cookiejar": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true
         },
         "copy-descriptor": {
@@ -3133,7 +3133,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.6",
+          "version": "2.5.7",
           "bundled": true
         },
         "core-util-is": {
@@ -3153,7 +3153,7 @@
           "requires": {
             "lru-cache": "4.1.3",
             "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "which": "1.3.1"
           }
         },
         "crypto-random-string": {
@@ -3171,7 +3171,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "es5-ext": "0.10.42"
+            "es5-ext": "0.10.44"
           }
         },
         "dashdash": {
@@ -3216,7 +3216,7 @@
           "bundled": true
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true
         },
         "deep-is": {
@@ -3453,7 +3453,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "empower-core": "0.6.2"
           }
         },
@@ -3469,7 +3469,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.6"
+            "core-js": "2.5.7"
           }
         },
         "encoding": {
@@ -3526,7 +3526,7 @@
           }
         },
         "es5-ext": {
-          "version": "0.10.42",
+          "version": "0.10.44",
           "bundled": true,
           "requires": {
             "es6-iterator": "2.0.3",
@@ -3543,7 +3543,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-symbol": "3.1.1"
           }
         },
@@ -3552,7 +3552,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-iterator": "2.0.3",
             "es6-set": "0.1.5",
             "es6-symbol": "3.1.1",
@@ -3564,7 +3564,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1",
             "event-emitter": "0.3.5"
@@ -3575,7 +3575,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42"
+            "es5-ext": "0.10.44"
           }
         },
         "es6-weak-map": {
@@ -3583,7 +3583,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42",
+            "es5-ext": "0.10.44",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1"
           }
@@ -3968,7 +3968,7 @@
           "version": "1.8.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6"
+            "core-js": "2.5.7"
           }
         },
         "esquery": {
@@ -3998,7 +3998,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.42"
+            "es5-ext": "0.10.44"
           }
         },
         "execa": {
@@ -4082,7 +4082,7 @@
           "bundled": true,
           "requires": {
             "@mrmlnc/readdir-enhanced": "2.2.1",
-            "@nodelib/fs.stat": "1.0.2",
+            "@nodelib/fs.stat": "1.1.0",
             "glob-parent": "3.1.0",
             "is-glob": "4.0.0",
             "merge2": "1.2.2",
@@ -4675,7 +4675,7 @@
             "globby": "8.0.1",
             "google-auto-auth": "0.10.1",
             "google-proto-files": "0.15.1",
-            "grpc": "1.11.3",
+            "grpc": "1.12.2",
             "is-stream-ended": "0.1.4",
             "lodash": "4.17.10",
             "protobufjs": "6.8.6",
@@ -4773,7 +4773,7 @@
           "bundled": true
         },
         "grpc": {
-          "version": "1.11.3",
+          "version": "1.12.2",
           "bundled": true,
           "requires": {
             "lodash": "4.17.10",
@@ -4866,7 +4866,7 @@
               "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "2.3.3"
               }
             },
             "fs.realpath": {
@@ -4904,8 +4904,11 @@
               "bundled": true
             },
             "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
+              "version": "0.4.23",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": "2.1.2"
+              }
             },
             "ignore-walk": {
               "version": "3.0.1",
@@ -4953,10 +4956,10 @@
               "bundled": true
             },
             "minipass": {
-              "version": "2.2.4",
+              "version": "2.3.3",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "yallist": "3.0.2"
               }
             },
@@ -4964,7 +4967,7 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "2.3.3"
               }
             },
             "mkdirp": {
@@ -4989,7 +4992,7 @@
               "bundled": true,
               "requires": {
                 "debug": "2.6.9",
-                "iconv-lite": "0.4.19",
+                "iconv-lite": "0.4.23",
                 "sax": "1.2.4"
               }
             },
@@ -5006,7 +5009,7 @@
                 "rc": "1.2.7",
                 "rimraf": "2.6.2",
                 "semver": "5.5.0",
-                "tar": "4.4.2"
+                "tar": "4.4.3"
               }
             },
             "nopt": {
@@ -5113,7 +5116,7 @@
                 "inherits": "2.0.3",
                 "isarray": "1.0.0",
                 "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "string_decoder": "1.1.1",
                 "util-deprecate": "1.0.2"
               }
@@ -5126,7 +5129,11 @@
               }
             },
             "safe-buffer": {
-              "version": "5.1.1",
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
               "bundled": true
             },
             "sax": {
@@ -5158,7 +5165,7 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
               }
             },
             "strip-ansi": {
@@ -5173,22 +5180,16 @@
               "bundled": true
             },
             "tar": {
-              "version": "4.4.2",
+              "version": "4.4.3",
               "bundled": true,
               "requires": {
                 "chownr": "1.0.1",
                 "fs-minipass": "1.2.5",
-                "minipass": "2.2.4",
+                "minipass": "2.3.3",
                 "minizlib": "1.1.0",
                 "mkdirp": "0.5.1",
                 "safe-buffer": "5.1.2",
                 "yallist": "3.0.2"
-              },
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.1.2",
-                  "bundled": true
-                }
               }
             },
             "util-deprecate": {
@@ -6117,7 +6118,7 @@
           "bundled": true
         },
         "lolex": {
-          "version": "2.6.0",
+          "version": "2.7.0",
           "bundled": true
         },
         "long": {
@@ -6182,7 +6183,7 @@
           "bundled": true
         },
         "matcher": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "escape-string-regexp": "1.0.5"
@@ -6519,7 +6520,7 @@
           "requires": {
             "@sinonjs/formatio": "2.0.0",
             "just-extend": "1.1.27",
-            "lolex": "2.6.0",
+            "lolex": "2.7.0",
             "path-to-regexp": "1.7.0",
             "text-encoding": "0.6.4"
           }
@@ -9300,7 +9301,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -9310,7 +9311,7 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "espurify": "1.8.0",
             "estraverse": "4.2.0"
           }
@@ -9319,7 +9320,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "estraverse": "4.2.0"
           }
         },
@@ -9327,7 +9328,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -9352,7 +9353,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "diff-match-patch": "1.0.1",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
@@ -9363,7 +9364,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -9396,15 +9397,14 @@
           "bundled": true
         },
         "prettier": {
-          "version": "1.12.1",
+          "version": "1.13.2",
           "bundled": true
         },
         "pretty-ms": {
-          "version": "3.1.0",
+          "version": "3.2.0",
           "bundled": true,
           "requires": {
-            "parse-ms": "1.0.1",
-            "plur": "2.1.2"
+            "parse-ms": "1.0.1"
           },
           "dependencies": {
             "parse-ms": {
@@ -9544,10 +9544,10 @@
           }
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.5.1",
+            "deep-extend": "0.6.0",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -9656,7 +9656,7 @@
           "version": "3.3.2",
           "bundled": true,
           "requires": {
-            "rc": "1.2.7",
+            "rc": "1.2.8",
             "safe-buffer": "5.1.2"
           }
         },
@@ -9664,7 +9664,7 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "rc": "1.2.7"
+            "rc": "1.2.8"
           }
         },
         "regjsgen": {
@@ -10024,7 +10024,7 @@
             "@sinonjs/formatio": "2.0.0",
             "diff": "3.5.0",
             "lodash.get": "4.4.2",
-            "lolex": "2.6.0",
+            "lolex": "2.7.0",
             "nise": "1.3.3",
             "supports-color": "5.4.0",
             "type-detect": "4.0.8"
@@ -10168,7 +10168,7 @@
           "version": "0.5.6",
           "bundled": true,
           "requires": {
-            "buffer-from": "1.0.0",
+            "buffer-from": "1.1.0",
             "source-map": "0.6.1"
           },
           "dependencies": {
@@ -10330,7 +10330,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.6",
+            "core-js": "2.5.7",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
@@ -10383,7 +10383,7 @@
           "bundled": true,
           "requires": {
             "component-emitter": "1.2.1",
-            "cookiejar": "2.1.1",
+            "cookiejar": "2.1.2",
             "debug": "3.1.0",
             "extend": "3.0.1",
             "form-data": "2.3.2",
@@ -10828,7 +10828,7 @@
           "bundled": true
         },
         "which": {
-          "version": "1.3.0",
+          "version": "1.3.1",
           "bundled": true,
           "requires": {
             "isexe": "2.0.0"
@@ -11007,9 +11007,9 @@
       }
     },
     "@nodelib/fs.stat": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
-      "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
+      "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -11481,7 +11481,7 @@
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
         "make-dir": "1.3.0",
-        "matcher": "1.1.0",
+        "matcher": "1.1.1",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
         "ms": "2.0.0",
@@ -11491,7 +11491,7 @@
         "package-hash": "2.0.0",
         "pkg-conf": "2.1.0",
         "plur": "2.1.2",
-        "pretty-ms": "3.1.0",
+        "pretty-ms": "3.2.0",
         "require-precompiled": "0.1.0",
         "resolve-cwd": "2.0.0",
         "safe-buffer": "5.1.1",
@@ -11818,7 +11818,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "espower-location-detector": "1.0.0",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -11959,7 +11959,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -11972,7 +11972,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -12213,9 +12213,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -12293,7 +12293,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "deep-equal": "1.0.1",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
@@ -12627,7 +12627,7 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
+        "buffer-from": "1.1.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -12679,9 +12679,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "copy-descriptor": {
@@ -12700,9 +12700,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -12724,7 +12724,7 @@
       "requires": {
         "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -12793,9 +12793,9 @@
       "dev": true
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "define-properties": {
@@ -12939,7 +12939,7 @@
       "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "empower-core": "0.6.2"
       }
     },
@@ -12949,7 +12949,7 @@
       "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "end-of-stream": {
@@ -13015,7 +13015,7 @@
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
       "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "requires": {
-        "core-js": "2.5.6"
+        "core-js": "2.5.7"
       }
     },
     "estraverse": {
@@ -13239,7 +13239,7 @@
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.0.2",
+        "@nodelib/fs.stat": "1.1.0",
         "glob-parent": "3.1.0",
         "is-glob": "4.0.0",
         "merge2": "1.2.2",
@@ -14053,7 +14053,7 @@
         "globby": "8.0.1",
         "google-auto-auth": "0.10.1",
         "google-proto-files": "0.15.1",
-        "grpc": "1.11.3",
+        "grpc": "1.12.2",
         "is-stream-ended": "0.1.4",
         "lodash": "4.17.10",
         "protobufjs": "6.8.6",
@@ -14136,9 +14136,9 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.3.tgz",
-      "integrity": "sha512-7fJ40USpnP7hxGK0uRoEhJz6unA5VUdwInfwAY2rK2+OVxdDJSdTZQ/8/M+1tW68pHZYgHvg2ohvJ+clhW3ANg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.12.2.tgz",
+      "integrity": "sha512-oDrW7TPuP+u9+RboUx8XupS1GOPCdLSmldyMHmlaB5wu38nOzzyDxzLsmleROw5/0XyfyuwsmFX6UUr7FaXN2w==",
       "requires": {
         "lodash": "4.17.10",
         "nan": "2.10.0",
@@ -14221,7 +14221,7 @@
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "2.3.3"
           }
         },
         "fs.realpath": {
@@ -14259,8 +14259,11 @@
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
         },
         "ignore-walk": {
           "version": "3.0.1",
@@ -14308,10 +14311,10 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
           }
         },
@@ -14319,7 +14322,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "2.3.3"
           }
         },
         "mkdirp": {
@@ -14344,7 +14347,7 @@
           "bundled": true,
           "requires": {
             "debug": "2.6.9",
-            "iconv-lite": "0.4.19",
+            "iconv-lite": "0.4.23",
             "sax": "1.2.4"
           }
         },
@@ -14361,7 +14364,7 @@
             "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
-            "tar": "4.4.2"
+            "tar": "4.4.3"
           }
         },
         "nopt": {
@@ -14462,7 +14465,7 @@
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
@@ -14475,7 +14478,11 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
           "bundled": true
         },
         "sax": {
@@ -14507,7 +14514,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
@@ -14522,22 +14529,16 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.2",
+          "version": "4.4.3",
           "bundled": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
+            "minipass": "2.3.3",
             "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
             "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            }
           }
         },
         "util-deprecate": {
@@ -15428,9 +15429,9 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "lolex": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
-      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
     },
     "long": {
@@ -15507,9 +15508,9 @@
       }
     },
     "matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
-      "integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+      "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
@@ -15837,7 +15838,7 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -17958,7 +17959,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -17969,7 +17970,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
@@ -17979,7 +17980,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "estraverse": "4.2.0"
       }
     },
@@ -17988,7 +17989,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -18016,7 +18017,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "diff-match-patch": "1.0.1",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -18028,7 +18029,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -18063,13 +18064,12 @@
       "dev": true
     },
     "pretty-ms": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
-      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
+      "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "1.0.1",
-        "plur": "2.1.2"
+        "parse-ms": "1.0.1"
       }
     },
     "private": {
@@ -18149,12 +18149,12 @@
       }
     },
     "rc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.5.1",
+        "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
@@ -18300,7 +18300,7 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.7",
+        "rc": "1.2.8",
         "safe-buffer": "5.1.1"
       }
     },
@@ -18310,7 +18310,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.7"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -18563,7 +18563,7 @@
         "diff": "3.5.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "nise": "1.3.3",
         "supports-color": "4.5.0",
         "type-detect": "4.0.8"
@@ -18884,7 +18884,7 @@
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -18944,7 +18944,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
+        "cookiejar": "2.1.2",
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
@@ -19459,9 +19459,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "2.0.0"
       }

--- a/src/file.js
+++ b/src/file.js
@@ -622,7 +622,10 @@ File.prototype.createReadStream = function(options) {
         rawResponseStream = rawResponseStream.pipe(pumpify.obj(throughStreams));
       }
 
-      rawResponseStream.on('end', onComplete).pipe(throughStream, {end: false});
+      rawResponseStream.on('end', onComplete).pipe(
+        throughStream,
+        {end: false}
+      );
     }
 
     // This is hooked to the `complete` event from the request stream. This is

--- a/system-test/storage.js
+++ b/system-test/storage.js
@@ -1445,8 +1445,7 @@ describe('storage', function() {
         const file = FILES[filesKey];
         const hash = crypto.createHash('md5');
 
-        fs
-          .createReadStream(file.path)
+        fs.createReadStream(file.path)
           .on('data', hash.update.bind(hash))
           .on('end', function() {
             file.hash = hash.digest('base64');
@@ -1504,8 +1503,8 @@ describe('storage', function() {
 
         const fileSize = file.metadata.size;
         const byteRange = {
-          start: Math.floor(fileSize * 1 / 3),
-          end: Math.floor(fileSize * 2 / 3),
+          start: Math.floor((fileSize * 1) / 3),
+          end: Math.floor((fileSize * 2) / 3),
         };
         const expectedContentSize = byteRange.start + 1;
 
@@ -1618,8 +1617,7 @@ describe('storage', function() {
     describe('stream write', function() {
       it('should stream write, then remove file (3mb)', function(done) {
         const file = bucket.file('LargeFile');
-        fs
-          .createReadStream(FILES.big.path)
+        fs.createReadStream(FILES.big.path)
           .pipe(file.createWriteStream({resumable: false}))
           .on('error', done)
           .on('finish', function() {
@@ -1668,8 +1666,7 @@ describe('storage', function() {
             const ws = file.createWriteStream();
             let sizeStreamed = 0;
 
-            fs
-              .createReadStream(FILES.big.path)
+            fs.createReadStream(FILES.big.path)
               .pipe(
                 through(function(chunk, enc, next) {
                   sizeStreamed += chunk.length;
@@ -2509,8 +2506,7 @@ describe('storage', function() {
 
     before(function(done) {
       file = bucket.file('LogoToSign.jpg');
-      fs
-        .createReadStream(FILES.logo.path)
+      fs.createReadStream(FILES.logo.path)
         .pipe(file.createWriteStream())
         .on('error', done)
         .on('finish', done.bind(null, null));
@@ -2558,8 +2554,7 @@ describe('storage', function() {
 
     before(function(done) {
       file = bucket.file('LogoToSign.jpg');
-      fs
-        .createReadStream(FILES.logo.path)
+      fs.createReadStream(FILES.logo.path)
         .pipe(file.createWriteStream())
         .on('error', done)
         .on('finish', done.bind(null, null));


### PR DESCRIPTION
`lint` tasks started failing in nightly because new prettier minor release had an incompatible change in formatting rules. Fixing that and updating lock files to force using the new version.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
