### PR TITLE
Updated generateSignedUrl example to use a unix timestamp

### DIFF
--- a/samples/files.js
+++ b/samples/files.js
@@ -330,7 +330,7 @@ function generateSignedUrl(bucketName, filename) {
   // These options will allow temporary read access to the file
   const options = {
     action: 'read',
-    expires: '03-17-2025',
+    expires: new Date("March 17 2025").getTime(),
   };
 
   // Get a signed URL for the file

--- a/samples/files.js
+++ b/samples/files.js
@@ -330,7 +330,7 @@ function generateSignedUrl(bucketName, filename) {
   // These options will allow temporary read access to the file
   const options = {
     action: 'read',
-    expires: new Date("March 17 2025").getTime(),
+    expires: new Date('March 17 2025').getTime(),
   };
 
   // Get a signed URL for the file


### PR DESCRIPTION
The existing generateSignedUrl example results in the following error when trying to view the resource as the config object should contain a unix timestamp.
```
<Error>
  <Code>SignatureDoesNotMatch</Code>
  <Message>
    The request signature we calculated does not match the signature you provided. Check your Google secret key and signing method.
  </Message>
</Error>
```

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
