### PR TITLE
Typescript: add 'any' type to suppress compiler error

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -387,8 +387,8 @@ class Acl extends AclRoleAccessorMethods {
    * region_tag:storage_add_bucket_default_owner
    * Example of adding a default owner to a bucket:
    */
-  add(options, callback) {
-    const query = {};
+  add(options: any, callback) {
+    const query: any = {};
 
     if (options.generation) {
       query.generation = options.generation;
@@ -479,8 +479,8 @@ class Acl extends AclRoleAccessorMethods {
    * region_tag:storage_remove_file_owner
    * Example of removing an owner from a bucket:
    */
-  delete(options, callback) {
-    const query = {};
+  delete(options: any, callback) {
+    const query: any = {};
 
     if (options.generation) {
       query.generation = options.generation;
@@ -585,9 +585,9 @@ class Acl extends AclRoleAccessorMethods {
    * region_tag:storage_print_bucket_acl_for_user
    * Example of printing a bucket's ACL for a specific user:
    */
-  get(options, callback) {
+  get(options: any, callback) {
     let path = '';
-    const query = {};
+    const query: any = {};
 
     if (is.fn(options)) {
       callback = options;
@@ -685,8 +685,8 @@ class Acl extends AclRoleAccessorMethods {
    *   const apiResponse = data[1];
    * });
    */
-  update(options, callback) {
-    const query = {};
+  update(options: any, callback) {
+    const query: any = {};
 
     if (options.generation) {
       query.generation = options.generation;
@@ -722,7 +722,7 @@ class Acl extends AclRoleAccessorMethods {
    * @private
    */
   makeAclObject_(accessControlObject) {
-    const obj = {
+    const obj: any = {
       entity: accessControlObject.entity,
       role: accessControlObject.role,
     };

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -403,7 +403,7 @@ class Bucket extends common.ServiceObject {
           sourceObjects: sources.map(source => {
             const sourceObject = {
               name: source.name,
-            };
+            } as any;
 
             if (source.metadata && source.metadata.generation) {
               sourceObject.generation = source.metadata.generation;
@@ -632,7 +632,7 @@ class Bucket extends common.ServiceObject {
       body.payloadFormat = 'JSON_API_V1';
     }
 
-    const query = {};
+    const query = {} as any;
 
     if (body.userProject) {
       query.userProject = body.userProject;
@@ -789,10 +789,10 @@ class Bucket extends common.ServiceObject {
       query = {};
     }
 
-    query = query || {};
+    query = query || {} as any;
 
     const MAX_PARALLEL_LIMIT = 10;
-    const errors = [];
+    const errors = [] as Error[];
 
     this.getFiles(query, (err, files) => {
       if (err) {
@@ -801,7 +801,7 @@ class Bucket extends common.ServiceObject {
       }
 
       const deleteFile = (file, callback) => {
-        file.delete(query, err => {
+        file.delete(query, (err: Error) => {
           if (err) {
             if (query.force) {
               errors.push(err);
@@ -1170,7 +1170,7 @@ class Bucket extends common.ServiceObject {
     this.getMetadata(options, (err, metadata) => {
       if (err) {
         if (err.code === 404 && autoCreate) {
-          const args = [];
+          const args = [] as any[];
 
           if (!is.empty(options)) {
             args.push(options);
@@ -1316,7 +1316,7 @@ class Bucket extends common.ServiceObject {
         }
 
         const files = arrify(resp.items).map(file => {
-          const options = {};
+          const options = {} as any;
 
           if (query.versions) {
             options.generation = file.generation;
@@ -1636,7 +1636,7 @@ class Bucket extends common.ServiceObject {
     const setPredefinedAcl = done => {
       const query = {
         predefinedAcl: 'projectPrivate',
-      };
+      } as any;
 
       if (options.userProject) {
         query.userProject = options.userProject;
@@ -2259,7 +2259,7 @@ class Bucket extends common.ServiceObject {
    * Example of uploading an encrypted file:
    */
   upload(pathString, options, callback) {
-    if (global.GCLOUD_SANDBOX_ENV) {
+    if ((global as any).GCLOUD_SANDBOX_ENV) {
       return;
     }
 
@@ -2379,8 +2379,8 @@ class Bucket extends common.ServiceObject {
    */
   makeAllFilesPublicPrivate_(options, callback) {
     const MAX_PARALLEL_LIMIT = 10;
-    const errors = [];
-    const updatedFiles = [];
+    const errors = [] as Error[];
+    const updatedFiles = [] as File[];
 
     this.getFiles(options, (err, files) => {
       if (err) {
@@ -2388,7 +2388,7 @@ class Bucket extends common.ServiceObject {
         return;
       }
 
-      const processFile = (file, callback) => {
+      const processFile = (file: File, callback) => {
         const processedCallback = err => {
           if (err) {
             if (options.force) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -49,8 +49,11 @@ class Channel extends common.ServiceObject {
 
     super(config);
 
-    this.metadata.id = id;
-    this.metadata.resourceId = resourceId;
+    // TODO: remove type cast to any once ServiceObject's type declaration has been fixed.
+    // https://github.com/googleapis/nodejs-common/issues/176
+    const metadata: any = this.metadata as any;
+    metadata.id = id;
+    metadata.resourceId = resourceId;
   }
 
   /**

--- a/src/file.ts
+++ b/src/file.ts
@@ -1558,7 +1558,7 @@ class File extends common.ServiceObject {
       {
         bucket: this.bucket.name,
       },
-    ];
+    ] as any[];
 
     if (is.array(options.equals)) {
       if (!is.array(options.equals[0])) {

--- a/src/file.ts
+++ b/src/file.ts
@@ -31,6 +31,7 @@ import once from 'once';
 import os from 'os';
 import pumpify from 'pumpify';
 import resumableUpload from 'gcs-resumable-upload';
+import { Stream } from 'stream';
 import streamEvents from 'stream-events';
 import through from 'through2';
 import xdgBasedir from 'xdg-basedir';
@@ -359,7 +360,7 @@ class File extends common.ServiceObject {
       throw noDestinationError;
     }
 
-    const query = {};
+    const query = {} as any;
     if (is.defined(this.generation)) {
       query.sourceGeneration = this.generation;
     }
@@ -420,7 +421,7 @@ class File extends common.ServiceObject {
         if (resp.rewriteToken) {
           const options = {
             token: resp.rewriteToken,
-          };
+          } as any;
 
           if (query.userProject) {
             options.userProject = query.userProject;
@@ -563,10 +564,10 @@ class File extends common.ServiceObject {
         uri: '',
         headers: {
           'Accept-Encoding': 'gzip',
-        },
+        } as any,
         qs: {
           alt: 'media',
-        },
+        } as any,
       };
 
       if (this.generation) {
@@ -621,7 +622,7 @@ class File extends common.ServiceObject {
 
         const shouldRunValidation = !rangeRequest && (crc32c || md5);
 
-        const throughStreams = [];
+        const throughStreams = [] as Stream[];
 
         if (shouldRunValidation) {
           validateStream = hashStreamValidation({crc32c, md5});
@@ -667,8 +668,8 @@ class File extends common.ServiceObject {
         }
 
         const hashes = {
-          crc32c: this.metadata.crc32c,
-          md5: this.metadata.md5Hash,
+          crc32c: (this.metadata as any).crc32c,
+          md5: (this.metadata as any).md5Hash,
         };
 
         // If we're doing validation, assume the worst-- a data integrity
@@ -1025,7 +1026,7 @@ class File extends common.ServiceObject {
       // https://github.com/yeoman/configstore/blob/f09f067e50e6a636cfc648a6fc36a522062bd49d/index.js#L11
       const configDir = xdgBasedir.config || os.tmpdir();
 
-      fs.access(configDir, fs.W_OK, err => {
+      fs.access(configDir, (fs as any).W_OK, err => {
         if (err) {
           if (options.resumable) {
             const error = new ResumableUploadError(
@@ -1062,7 +1063,7 @@ class File extends common.ServiceObject {
 
     // Compare our hashed version vs the completed upload's version.
     fileWriteStream.on('complete', () => {
-      const metadata = this.metadata;
+      const metadata = this.metadata as any;
 
       // If we're doing validation, assume the worst-- a data integrity mismatch.
       // If not, these tests won't be performed, and we can assume the best.
@@ -1808,7 +1809,7 @@ class File extends common.ServiceObject {
             GoogleAccessId: credentials.client_email,
             Expires: expiresInSeconds,
             Signature: signature,
-          };
+          } as any;
 
           if (is.string(config.responseType)) {
             query['response-content-type'] = config.responseType;
@@ -1898,7 +1899,7 @@ class File extends common.ServiceObject {
 
     const query = {
       predefinedAcl: options.strict ? 'private' : 'projectPrivate',
-    };
+    } as any;
 
     if (options.userProject) {
       query.userProject = options.userProject;
@@ -1955,7 +1956,7 @@ class File extends common.ServiceObject {
   makePublic(callback) {
     callback = callback || common.util.noop;
 
-    this.acl.add(
+    (this.acl as any).add(
       {
         entity: 'allUsers',
         role: 'READER',
@@ -2433,7 +2434,7 @@ class File extends common.ServiceObject {
     const reqOpts = {
       qs: {
         name: this.name,
-      },
+      } as any,
       uri: `${STORAGE_UPLOAD_BASE_URL}/${this.bucket.name}/o`,
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,7 +404,7 @@ class Storage extends common.Service {
 
     const query = {
       project: this.projectId,
-    };
+    } as any;
 
     if (body.userProject) {
       query.userProject = body.userProject;

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -244,7 +244,7 @@ class Notification extends common.ServiceObject {
     this.getMetadata(options, (err, metadata) => {
       if (err) {
         if (err.code === 404 && autoCreate) {
-          const args = [];
+          const args = [] as any[];
 
           if (!is.empty(options)) {
             args.push(options);


### PR DESCRIPTION
Another PR to address tsc compilation errors, specifically errors that takes the form:

> Property 'x' does not exist on type 'y' of z.

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)