### PR TITLE
fix: remove trailing slashes from bucket name.

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -302,7 +302,8 @@ class Bucket extends ServiceObject {
   constructor(storage, name, options?) {
     options = options || {};
 
-    name = name.replace(/^gs:\/\//, '');
+    // Allow for "gs://"-style input, and strip any trailing slashes.
+    name = name.replace(/^gs:\/\//, '').replace(/\/+$/, '');
 
     const methods = {
       /**

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -178,9 +178,9 @@ describe('Bucket', () => {
     });
 
     it('should remove a trailing /', () => {
-     const bucket = new Bucket(STORAGE, 'bucket-name/');
-     assert.strictEqual(bucket.name, 'bucket-name');
-   });
+      const bucket = new Bucket(STORAGE, 'bucket-name/');
+      assert.strictEqual(bucket.name, 'bucket-name');
+    });
 
     it('should localize the name', () => {
       assert.strictEqual(bucket.name, BUCKET_NAME);

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -177,6 +177,11 @@ describe('Bucket', () => {
       assert.strictEqual(bucket.name, 'bucket-name');
     });
 
+    it('should remove a trailing /', () => {
+     const bucket = new Bucket(STORAGE, 'bucket-name/');
+     assert.strictEqual(bucket.name, 'bucket-name');
+   });
+
     it('should localize the name', () => {
       assert.strictEqual(bucket.name, BUCKET_NAME);
     });


### PR DESCRIPTION
Fixes #170 

This cleans up the fragments of a gs:// URL, should the user provide one to the Bucket constructor.