### PR TITLE
Typescript: misc. fixes to make tsc happy

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -306,6 +306,7 @@ class AclRoleAccessorMethods {
  * @param {object} options Configuration options.
  */
 class Acl extends AclRoleAccessorMethods {
+  default: Acl;
   pathPrefix;
   request_;
 

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -306,7 +306,7 @@ class AclRoleAccessorMethods {
  * @param {object} options Configuration options.
  */
 class Acl extends AclRoleAccessorMethods {
-  default: Acl;
+  default?: Acl;
   pathPrefix;
   request_;
 

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -27,7 +27,6 @@ import path from 'path';
 import snakeize from 'snakeize';
 import request from 'request';
 
-import Storage from './index';
 import {Acl} from './acl';
 import {File} from './file';
 import {Iam} from './iam';
@@ -71,7 +70,7 @@ class Bucket extends common.ServiceObject {
    * @name Bucket#storage
    * @type {string}
    */
-  storage: Storage;
+  storage: any;
 
   /**
    * A user project to apply to each request from this bucket.

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -236,7 +236,7 @@ class Bucket extends common.ServiceObject {
    */
   getFilesStream: Function;
 
-  constructor(storage, name, options) {
+  constructor(storage, name, options?) {
     options = options || {};
 
     name = name.replace(/^gs:\/\//, '');

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -276,7 +276,7 @@ class Bucket extends common.ServiceObject {
       id: name,
       createMethod: storage.createBucket.bind(storage),
       methods,
-    });
+    } as any);
 
     this.name = name;
 
@@ -697,7 +697,7 @@ class Bucket extends common.ServiceObject {
    * region_tag:storage_delete_bucket
    * Another example:
    */
-  delete(options, callback) {
+  delete(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -875,7 +875,7 @@ class Bucket extends common.ServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  deleteLabels(labels, callback) {
+  deleteLabels(labels, callback?) {
     if (is.fn(labels)) {
       callback = labels;
       labels = [];
@@ -1005,7 +1005,7 @@ class Bucket extends common.ServiceObject {
    * region_tag:storage_enable_requester_pays
    * Example of enabling requester pays:
    */
-  enableRequesterPays(callback) {
+  enableRequesterPays(callback?) {
     this.setMetadata(
       {
         billing: {
@@ -1047,7 +1047,7 @@ class Bucket extends common.ServiceObject {
    *   const exists = data[0];
    * });
    */
-  exists(options, callback) {
+  exists(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1091,7 +1091,7 @@ class Bucket extends common.ServiceObject {
    * const bucket = storage.bucket('albums');
    * const file = bucket.file('my-existing-file.png');
    */
-  file(name, options) {
+  file(name, options?) {
     if (!name) {
       throw Error('A file name must be specified.');
     }
@@ -1142,7 +1142,7 @@ class Bucket extends common.ServiceObject {
    *   const apiResponse = data[1];
    * });
    */
-  get(options, callback) {
+  get(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1384,7 +1384,7 @@ class Bucket extends common.ServiceObject {
    *   const labels = data[0];
    * });
    */
-  getLabels(options, callback) {
+  getLabels(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1442,7 +1442,7 @@ class Bucket extends common.ServiceObject {
    * region_tag:storage_get_requester_pays_status
    * Example of retrieving the requester pays status of a bucket:
    */
-  getMetadata(options, callback) {
+  getMetadata(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1821,7 +1821,9 @@ class Bucket extends common.ServiceObject {
    * @param {object} reqOpts - The request options.
    * @param {function} callback - The callback function.
    */
-  request(reqOpts, callback) {
+  request(reqOpts): Promise<request.Response>;
+  request(reqOpts, callback): void;
+  request(reqOpts, callback?): void|Promise<request.Response> {
     if (this.userProject && (!reqOpts.qs || !reqOpts.qs.userProject)) {
       reqOpts.qs = extend(reqOpts.qs, {userProject: this.userProject});
     }
@@ -1873,7 +1875,7 @@ class Bucket extends common.ServiceObject {
    *   const metadata = data[0];
    * });
    */
-  setLabels(labels, options, callback) {
+  setLabels(labels, options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -1946,7 +1948,7 @@ class Bucket extends common.ServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  setMetadata(metadata, options, callback) {
+  setMetadata(metadata, options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1769,7 +1769,7 @@ class Bucket extends common.ServiceObject {
     };
 
     const addDefaultAclPermissions = done => {
-      this.acl.default.add(
+      this.acl.default!.add(
         {
           entity: 'allUsers',
           role: 'READER',

--- a/src/file.ts
+++ b/src/file.ts
@@ -39,7 +39,6 @@ import zlib from 'zlib';
 import url from 'url';
 import r from 'request';
 
-import Storage from './index';
 import {Bucket} from './bucket';
 import {Acl} from './acl';
 
@@ -144,7 +143,7 @@ class File extends common.ServiceObject {
   acl: Acl;
 
   bucket: Bucket;
-  storage: Storage;
+  storage: any;
   kmsKeyName: string;
   userProject: string;
   name: string;

--- a/src/file.ts
+++ b/src/file.ts
@@ -1548,7 +1548,7 @@ class File extends common.ServiceObject {
   getSignedPolicy(options, callback) {
     const expires = new Date(options.expires);
 
-    if (expires < Date.now()) {
+    if (expires.valueOf() < Date.now()) {
       throw new Error('An expiration date cannot be in the past.');
     }
 
@@ -1758,12 +1758,13 @@ class File extends common.ServiceObject {
    * Another example:
    */
   getSignedUrl(config, callback) {
-    const expires = new Date(config.expires);
-    const expiresInSeconds = Math.round(expires / 1000); // The API expects seconds.
+    const expiresInMSeconds = new Date(config.expires).valueOf();
 
-    if (expires < Date.now()) {
+    if (expiresInMSeconds < Date.now()) {
       throw new Error('An expiration date cannot be in the past.');
     }
+
+    const expiresInSeconds = Math.round(expiresInMSeconds / 1000); // The API expects seconds.
 
     config = extend({}, config);
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -29,7 +29,7 @@ import is from 'is';
 import mime from 'mime';
 import once from 'once';
 import os from 'os';
-import pumpify from 'pumpify';
+const pumpify = require('pumpify');
 import resumableUpload from 'gcs-resumable-upload';
 import {Stream, Duplex} from 'stream';
 import streamEvents from 'stream-events';

--- a/src/file.ts
+++ b/src/file.ts
@@ -148,13 +148,13 @@ class File extends common.ServiceObject {
   kmsKeyName: string;
   userProject: string;
   name: string;
-  generation: number;
-  requestQueryObject: {generation: number};
+  generation?: number;
+  requestQueryObject?: {generation: number};
 
-  private encryptionKey: string | Buffer;
-  private encryptionKeyBase64: string;
-  private encryptionKeyHash: string;
-  private encryptionKeyInterceptor: {
+  private encryptionKey?: string | Buffer;
+  private encryptionKeyBase64?: string;
+  private encryptionKeyHash?: string;
+  private encryptionKeyInterceptor?: {
     request: (reqOpts: r.OptionsWithUri) => r.OptionsWithUri;
   };
 

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -45,7 +45,7 @@ class Iam {
 
   constructor(bucket: Bucket) {
     this.request_ = bucket.request.bind(bucket);
-    this.resourceId_ = 'buckets/' + bucket.id;
+    this.resourceId_ = 'buckets/' + (bucket as any).id;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ class Storage extends common.Service {
    * const albums = storage.bucket('albums');
    * const photos = storage.bucket('photos');
    */
-  bucket(name, options) {
+  bucket(name, options?) {
     if (!name) {
       throw new Error('A bucket name is needed to use Cloud Storage.');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -649,7 +649,6 @@ common.util.promisifyAll(Storage, {
  * Full quickstart example:
  */
 // Allow creating a `Storage` instance without using the `new` keyword. (#173)
-// eslint-disable-next-line no-class-assign
 export = new Proxy(Storage, {
   apply(target, thisArg, [options]) {
     return new target(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -542,14 +542,6 @@ class Storage extends common.Service {
   }
 }
 
-// Allow creating a `Storage` instance without using the `new` keyword. (#173)
-// eslint-disable-next-line no-class-assign
-Storage = new Proxy(Storage, {
-  apply(target, thisArg, argumentsList) {
-    return new target(...argumentsList);
-  },
-});
-
 /**
  * Cloud Storage uses access control lists (ACLs) to manage object and
  * bucket access. ACLs are the mechanism you use to share objects with other
@@ -656,4 +648,10 @@ common.util.promisifyAll(Storage, {
  * region_tag:storage_quickstart
  * Full quickstart example:
  */
-export = Storage;
+// Allow creating a `Storage` instance without using the `new` keyword. (#173)
+// eslint-disable-next-line no-class-assign
+export = new Proxy(Storage, {
+  apply(target, thisArg, argumentsList) {
+    return new target(...argumentsList);
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -651,7 +651,7 @@ common.util.promisifyAll(Storage, {
 // Allow creating a `Storage` instance without using the `new` keyword. (#173)
 // eslint-disable-next-line no-class-assign
 export = new Proxy(Storage, {
-  apply(target, thisArg, argumentsList) {
-    return new target(...argumentsList);
+  apply(target, thisArg, [options]) {
+    return new target(options);
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -627,33 +627,6 @@ common.util.promisifyAll(Storage, {
 });
 
 /**
- * {@link Bucket} class.
- *
- * @name Storage.Bucket
- * @see Bucket
- * @type {Constructor}
- */
-Storage.Bucket = Bucket;
-
-/**
- * {@link Channel} class.
- *
- * @name Storage.Channel
- * @see Channel
- * @type {Constructor}
- */
-Storage.Channel = Channel;
-
-/**
- * {@link File} class.
- *
- * @name Storage.File
- * @see File
- * @type {Constructor}
- */
-Storage.File = File;
-
-/**
  * The default export of the `@google-cloud/storage` package is the
  * {@link Storage} class, which also serves as a factory function which produces
  * {@link Storage} instances.

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -119,7 +119,7 @@ class Notification extends common.ServiceObject {
       id: id.toString(),
       createMethod: bucket.createNotification.bind(bucket),
       methods,
-    });
+    } as any);
   }
 
   /**
@@ -160,7 +160,7 @@ class Notification extends common.ServiceObject {
    * region_tag:storage_delete_notification
    * Another example:
    */
-  delete(options, callback) {
+  delete(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -218,7 +218,7 @@ class Notification extends common.ServiceObject {
    *   const apiResponse = data[1];
    * });
    */
-  get(options, callback) {
+  get(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};
@@ -305,7 +305,7 @@ class Notification extends common.ServiceObject {
    * region_tag:storage_notifications_get_metadata
    * Another example:
    */
-  getMetadata(options, callback) {
+  getMetadata(options, callback?) {
     if (is.fn(options)) {
       callback = options;
       options = {};


### PR DESCRIPTION
`tsc` compiles successfully following this PR.

This PR addresses the following (and more):
 - optional callback?
 - type cast to `any` if incompatible types can't easily be fixed
 - fixes imports/exports
 - comparing `Date`'s using `.valueOf()`