### PR TITLE
fix: test meant to assert err msg exists, but instead asserted msg greater than -1

### DIFF
--- a/test/file.js
+++ b/test/file.js
@@ -1740,7 +1740,7 @@ describe('File', function() {
 
         writable.on('error', function(err) {
           assert.equal(err.code, 'FILE_NO_UPLOAD_DELETE');
-          assert(err.message.indexOf(deleteErrorMessage > -1));
+          assert(err.message.indexOf(deleteErrorMessage) > -1);
           done();
         });
       });


### PR DESCRIPTION
A minor test bug that produced false negative result:

test/file.ts
```js
assert(err.message.indexOf(deleteErrorMessage > -1));
```

should be 
```js
assert(err.message.indexOf(deleteErrorMessage) > -1);
```
