### PR TITLE
Typescript: tests (2)

### DIFF
--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -31,7 +31,7 @@ import snakeize from 'snakeize';
 import stream from 'stream';
 import through from 'through2';
 
-function FakeFile(bucket, name, options) {
+function FakeFile(bucket, name, options?) {
   const self = this;
 
   this.calledWith_ = arguments;
@@ -44,7 +44,7 @@ function FakeFile(bucket, name, options) {
   this.createWriteStream = function(options) {
     self.metadata = options.metadata;
     const ws = new stream.Writable();
-    ws.write = function() {
+    (ws as any).write = function() {
       ws.emit('complete');
       ws.end();
     };
@@ -62,15 +62,15 @@ let requestOverride;
 function fakeRequest() {
   return (requestOverride || requestCached).apply(null, arguments);
 }
-fakeRequest.defaults = function() {
+(fakeRequest as any).defaults = function() {
   // Ignore the default values, so we don't have to test for them in every API
   // call.
   return fakeRequest;
 };
-fakeRequest.get = function() {
+(fakeRequest as any).get = function() {
   return (requestOverride.get || fakeRequest).apply(null, arguments);
 };
-fakeRequest.head = function() {
+(fakeRequest as any).head = function() {
   return (requestOverride.head || fakeRequest).apply(null, arguments);
 };
 
@@ -1959,9 +1959,9 @@ describe('Bucket', function() {
     });
 
     it('should return early in snippet sandbox', function() {
-      global.GCLOUD_SANDBOX_ENV = true;
+      (global as any).GCLOUD_SANDBOX_ENV = true;
       const returnValue = bucket.upload(filepath, assert.ifError);
-      delete global.GCLOUD_SANDBOX_ENV;
+      delete (global as any).GCLOUD_SANDBOX_ENV;
       assert.strictEqual(returnValue, undefined);
     });
 
@@ -2106,7 +2106,7 @@ describe('Bucket', function() {
       const options = {destination: fakeFile};
       fakeFile.createWriteStream = function(options) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           const expectedContentType = 'application/json; charset=utf-8';
           assert.equal(options.metadata.contentType, expectedContentType);
@@ -2122,7 +2122,7 @@ describe('Bucket', function() {
       const options = {destination: fakeFile};
       fakeFile.createWriteStream = function(options) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           const expectedContentType = 'text/plain; charset=utf-8';
           assert.equal(options.metadata.contentType, expectedContentType);
@@ -2138,7 +2138,7 @@ describe('Bucket', function() {
       const options = {destination: fakeFile, resumable: true};
       fakeFile.createWriteStream = function(options_) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           assert.strictEqual(options_.resumable, options.resumable);
           done();
@@ -2153,7 +2153,7 @@ describe('Bucket', function() {
       const options = {destination: fakeFile, resumable: true};
       fakeFile.createWriteStream = function(options_) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           assert.strictEqual(options_.resumable, options.resumable);
           done();
@@ -2175,7 +2175,7 @@ describe('Bucket', function() {
       const fakeFile = new FakeFile(bucket, 'file-name');
       fakeFile.createWriteStream = function(options) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           assert.strictEqual(options.resumable, true);
           done();
@@ -2198,7 +2198,7 @@ describe('Bucket', function() {
       const fakeFile = new FakeFile(bucket, 'file-name');
       fakeFile.createWriteStream = function(options) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           assert.strictEqual(options.resumable, false);
           done();
@@ -2215,7 +2215,7 @@ describe('Bucket', function() {
       const options = {destination: fakeFile, metadata: metadata};
       fakeFile.createWriteStream = function(options) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           assert.equal(options.metadata.contentType, metadata.contentType);
           done();
@@ -2234,7 +2234,7 @@ describe('Bucket', function() {
       };
       fakeFile.createWriteStream = function(options_) {
         const ws = new stream.Writable();
-        ws.write = util.noop;
+        (ws as any).write = util.noop;
         setImmediate(function() {
           assert.strictEqual(options_.a, options.a);
           assert.strictEqual(options_.c, options.c);

--- a/test/file.ts
+++ b/test/file.ts
@@ -66,7 +66,7 @@ let requestOverride;
 function fakeRequest() {
   return (requestOverride || requestCached).apply(null, arguments);
 }
-fakeRequest.defaults = function(defaultConfiguration) {
+(fakeRequest as any).defaults = function(defaultConfiguration) {
   // Ignore the default values, so we don't have to test for them in every API
   // call.
   REQUEST_DEFAULT_CONF = defaultConfiguration;
@@ -92,7 +92,7 @@ function fakeResumableUpload() {
     return resumableUploadOverride || resumableUpload;
   };
 }
-fakeResumableUpload.createURI = function() {
+(fakeResumableUpload as any).createURI = function() {
   let createURI = resumableUpload.createURI;
 
   if (resumableUploadOverride && resumableUploadOverride.createURI) {
@@ -101,7 +101,7 @@ fakeResumableUpload.createURI = function() {
 
   return createURI.apply(null, arguments);
 };
-fakeResumableUpload.upload = function() {
+(fakeResumableUpload as any).upload = function() {
   let upload = resumableUpload.upload;
   if (resumableUploadOverride && resumableUploadOverride.upload) {
     upload = resumableUploadOverride.upload;
@@ -629,10 +629,10 @@ describe('File', function() {
   });
 
   describe('createReadStream', function() {
-    function getFakeRequest(data) {
+    function getFakeRequest(data?) {
       let requestOptions;
 
-      function FakeRequest(_requestOptions) {
+      function FakeRequest(_requestOptions?) {
         if (!(this instanceof FakeRequest)) {
           return new FakeRequest(_requestOptions);
         }
@@ -649,7 +649,7 @@ describe('File', function() {
       }
       nodeutil.inherits(FakeRequest, stream.Readable);
 
-      FakeRequest.getRequestOptions = function() {
+      (FakeRequest as any).getRequestOptions = function() {
         return requestOptions;
       };
 
@@ -704,7 +704,7 @@ describe('File', function() {
     beforeEach(function() {
       handleRespOverride = function(err, res, body, callback) {
         const rawResponseStream = through();
-        rawResponseStream.toJSON = function() {
+        (rawResponseStream as any).toJSON = function() {
           return {headers: {}};
         };
         callback(null, null, rawResponseStream);
@@ -930,7 +930,7 @@ describe('File', function() {
       beforeEach(function() {
         handleRespOverride = function(err, res, body, callback) {
           const rawResponseStream = through();
-          rawResponseStream.toJSON = function() {
+          (rawResponseStream as any).toJSON = function() {
             return {
               headers: {
                 'content-encoding': 'gzip',
@@ -1291,7 +1291,7 @@ describe('File', function() {
     const METADATA = {a: 'b', c: 'd'};
 
     beforeEach(function() {
-      fakeFs.access = function(dir, check, callback) {
+      (fakeFs as any).access = function(dir, check, callback) {
         // Assume that the required config directory is writable.
         callback();
       };
@@ -1357,7 +1357,7 @@ describe('File', function() {
 
       xdgConfigOverride = fakeDir;
 
-      fakeFs.access = function(dir) {
+      (fakeFs as any).access = function(dir) {
         assert.strictEqual(dir, fakeDir);
         done();
       };
@@ -1374,7 +1374,7 @@ describe('File', function() {
         return fakeDir;
       };
 
-      fakeFs.access = function(dir) {
+      (fakeFs as any).access = function(dir) {
         assert.strictEqual(dir, fakeDir);
         done();
       };
@@ -1385,7 +1385,7 @@ describe('File', function() {
     it('should fail if resumable requested but not writable', function(done) {
       const error = new Error('Error.');
 
-      fakeFs.access = function(dir, check, callback) {
+      (fakeFs as any).access = function(dir, check, callback) {
         callback(error);
       };
 
@@ -1424,7 +1424,7 @@ describe('File', function() {
         done();
       };
 
-      fakeFs.access = function(dir, check, callback) {
+      (fakeFs as any).access = function(dir, check, callback) {
         callback(new Error('Error.'));
       };
 
@@ -3173,10 +3173,10 @@ describe('File', function() {
 
   describe('setEncryptionKey', function() {
     const KEY = crypto.randomBytes(32);
-    const KEY_BASE64 = Buffer.from(KEY).toString('base64');
+    const KEY_BASE64 = Buffer.from(KEY as any).toString('base64');
     const KEY_HASH = crypto
       .createHash('sha256')
-      .update(KEY_BASE64, 'base64')
+      .update(KEY_BASE64, 'base64' as any)
       .digest('base64');
     let _file;
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -2458,7 +2458,7 @@ describe('File', function() {
       const file = new File(BUCKET, 'name', {generation: generation});
 
       file.getSignedUrl(CONFIG, function(err, signedUrl) {
-        assert(signedUrl.indexOf(encodeURIComponent(generation)) > -1);
+        assert(signedUrl.indexOf(encodeURIComponent(generation.toString())) > -1);
         done();
       });
     });
@@ -2557,7 +2557,7 @@ describe('File', function() {
     describe('expires', function() {
       it('should accept Date objects', function(done) {
         const expires = new Date(Date.now() + 1000 * 60);
-        const expectedExpires = Math.round(expires / 1000);
+        const expectedExpires = Math.round(expires.valueOf() / 1000);
 
         file.getSignedUrl(
           {
@@ -2575,7 +2575,7 @@ describe('File', function() {
 
       it('should accept numbers', function(done) {
         const expires = Date.now() + 1000 * 60;
-        const expectedExpires = Math.round(new Date(expires) / 1000);
+        const expectedExpires = Math.round(new Date(expires).valueOf() / 1000);
 
         file.getSignedUrl(
           {
@@ -2593,7 +2593,7 @@ describe('File', function() {
 
       it('should accept strings', function(done) {
         const expires = '12-12-2099';
-        const expectedExpires = Math.round(new Date(expires) / 1000);
+        const expectedExpires = Math.round(new Date(expires).valueOf() / 1000);
 
         file.getSignedUrl(
           {

--- a/test/notification.ts
+++ b/test/notification.ts
@@ -89,7 +89,7 @@ describe('Notification', function() {
           assert.strictEqual(context, BUCKET);
           return bound;
         },
-      };
+      } as any;
 
       const notification = new Notification(BUCKET, ID);
       const calledWith = notification.calledWith_[0];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "noImplicitThis": false
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
Finish converting tests to typescript by:
 - (Temporarily) disable `noImplicitThis`
 - Cast to `any` when tsc complains
 - Add optional (?) to arguments where # of arguments mismatches
 - Fix date comparison by calling `Date#.valueOf()` to get milliseconds from Date object and compare the two numbers
 - Request fakes to use class syntax and Proxy hack to allow creating an object without `new`