### PR TITLE
Typescript: tests function() to arrow =>

### DIFF
--- a/test/acl.ts
+++ b/test/acl.ts
@@ -24,7 +24,7 @@ import { util } from '@google-cloud/common';
 
 let Acl;
 let AclRoleAccessorMethods;
-describe('storage/acl', function() {
+describe('storage/acl', () => {
   let promisified = false;
   const fakeUtil = extend({}, util, {
     promisifyAll(Class) {
@@ -43,7 +43,7 @@ describe('storage/acl', function() {
   const ROLE = Storage.acl.OWNER_ROLE;
   const ENTITY = 'user-user@example.com';
 
-  before(function() {
+  before(() => {
     const aclModule = proxyquire('../src/acl.js', {
       '@google-cloud/common': {
         util: fakeUtil,
@@ -53,41 +53,41 @@ describe('storage/acl', function() {
     AclRoleAccessorMethods = aclModule.AclRoleAccessorMethods;
   });
 
-  beforeEach(function() {
-    acl = new Acl({request: MAKE_REQ, pathPrefix: PATH_PREFIX});
+  beforeEach(() => {
+    acl = new Acl({ request: MAKE_REQ, pathPrefix: PATH_PREFIX });
   });
 
-  describe('initialization', function() {
-    it('should promisify all the things', function() {
+  describe('initialization', () => {
+    it('should promisify all the things', () => {
       assert(promisified);
     });
 
-    it('should assign makeReq and pathPrefix', function() {
+    it('should assign makeReq and pathPrefix', () => {
       assert.strictEqual(acl.pathPrefix, PATH_PREFIX);
       assert.strictEqual(acl.request_, MAKE_REQ);
     });
   });
 
-  describe('add', function() {
-    it('should make the correct api request', function(done) {
-      acl.request = function(reqOpts) {
+  describe('add', () => {
+    it('should make the correct api request', done => {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '');
-        assert.deepEqual(reqOpts.json, {entity: ENTITY, role: ROLE});
+        assert.deepEqual(reqOpts.json, { entity: ENTITY, role: ROLE });
         done();
       };
 
-      acl.add({entity: ENTITY, role: ROLE}, assert.ifError);
+      acl.add({ entity: ENTITY, role: ROLE }, assert.ifError);
     });
 
-    it('should set the generation', function(done) {
+    it('should set the generation', done => {
       const options = {
         entity: ENTITY,
         role: ROLE,
         generation: 8,
       };
 
-      acl.request = function(reqOpts) {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.generation, options.generation);
         done();
       };
@@ -95,14 +95,14 @@ describe('storage/acl', function() {
       acl.add(options, assert.ifError);
     });
 
-    it('should set the userProject', function(done) {
+    it('should set the userProject', done => {
       const options = {
         entity: ENTITY,
         role: ROLE,
         userProject: 'grape-spaceship-123',
       };
 
-      acl.request = function(reqOpts) {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -110,70 +110,70 @@ describe('storage/acl', function() {
       acl.add(options, assert.ifError);
     });
 
-    it('should execute the callback with an ACL object', function(done) {
-      const apiResponse = {entity: ENTITY, role: ROLE};
-      const expectedAclObject = {entity: ENTITY, role: ROLE};
+    it('should execute the callback with an ACL object', done => {
+      const apiResponse = { entity: ENTITY, role: ROLE };
+      const expectedAclObject = { entity: ENTITY, role: ROLE };
 
-      acl.makeAclObject_ = function(obj) {
+      acl.makeAclObject_ = obj => {
         assert.deepEqual(obj, apiResponse);
         return expectedAclObject;
       };
 
-      acl.request = function(reqOpts, callback) {
+      acl.request = (reqOpts, callback) => {
         callback(null, apiResponse);
       };
 
-      acl.add({entity: ENTITY, role: ROLE}, function(err, aclObject) {
+      acl.add({ entity: ENTITY, role: ROLE }, (err, aclObject) => {
         assert.ifError(err);
         assert.deepEqual(aclObject, expectedAclObject);
         done();
       });
     });
 
-    it('should execute the callback with an error', function(done) {
-      acl.request = function(reqOpts, callback) {
+    it('should execute the callback with an error', done => {
+      acl.request = (reqOpts, callback) => {
         callback(ERROR);
       };
 
-      acl.add({entity: ENTITY, role: ROLE}, function(err) {
+      acl.add({ entity: ENTITY, role: ROLE }, err => {
         assert.deepEqual(err, ERROR);
         done();
       });
     });
 
-    it('should execute the callback with apiResponse', function(done) {
-      const resp = {success: true};
+    it('should execute the callback with apiResponse', done => {
+      const resp = { success: true };
 
-      acl.request = function(reqOpts, callback) {
+      acl.request = (reqOpts, callback) => {
         callback(null, resp);
       };
 
-      acl.add({entity: ENTITY, role: ROLE}, function(err, acls, apiResponse) {
+      acl.add({ entity: ENTITY, role: ROLE }, (err, acls, apiResponse) => {
         assert.deepEqual(resp, apiResponse);
         done();
       });
     });
   });
 
-  describe('delete', function() {
-    it('should make the correct api request', function(done) {
-      acl.request = function(reqOpts) {
+  describe('delete', () => {
+    it('should make the correct api request', done => {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.method, 'DELETE');
         assert.strictEqual(reqOpts.uri, '/' + encodeURIComponent(ENTITY));
 
         done();
       };
 
-      acl.delete({entity: ENTITY}, assert.ifError);
+      acl.delete({ entity: ENTITY }, assert.ifError);
     });
 
-    it('should set the generation', function(done) {
+    it('should set the generation', done => {
       const options = {
         entity: ENTITY,
         generation: 8,
       };
 
-      acl.request = function(reqOpts) {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.generation, options.generation);
         done();
       };
@@ -181,14 +181,14 @@ describe('storage/acl', function() {
       acl.delete(options, assert.ifError);
     });
 
-    it('should set the userProject', function(done) {
+    it('should set the userProject', done => {
       const options = {
         entity: ENTITY,
         role: ROLE,
         userProject: 'grape-spaceship-123',
       };
 
-      acl.request = function(reqOpts) {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -196,35 +196,35 @@ describe('storage/acl', function() {
       acl.delete(options, assert.ifError);
     });
 
-    it('should execute the callback with an error', function(done) {
-      acl.request = function(reqOpts, callback) {
+    it('should execute the callback with an error', done => {
+      acl.request = (reqOpts, callback) => {
         callback(ERROR);
       };
 
-      acl.delete({entity: ENTITY}, function(err) {
+      acl.delete({ entity: ENTITY }, err => {
         assert.deepEqual(err, ERROR);
         done();
       });
     });
 
-    it('should execute the callback with apiResponse', function(done) {
-      const resp = {success: true};
+    it('should execute the callback with apiResponse', done => {
+      const resp = { success: true };
 
-      acl.request = function(reqOpts, callback) {
+      acl.request = (reqOpts, callback) => {
         callback(null, resp);
       };
 
-      acl.delete({entity: ENTITY}, function(err, apiResponse) {
+      acl.delete({ entity: ENTITY }, (err, apiResponse) => {
         assert.deepEqual(resp, apiResponse);
         done();
       });
     });
   });
 
-  describe('get', function() {
-    describe('all ACL objects', function() {
-      it('should make the correct API request', function(done) {
-        acl.request = function(reqOpts) {
+  describe('get', () => {
+    describe('all ACL objects', () => {
+      it('should make the correct API request', done => {
+        acl.request = reqOpts => {
           assert.strictEqual(reqOpts.uri, '');
 
           done();
@@ -233,42 +233,42 @@ describe('storage/acl', function() {
         acl.get(assert.ifError);
       });
 
-      it('should accept a configuration object', function(done) {
+      it('should accept a configuration object', done => {
         const generation = 1;
 
-        acl.request = function(reqOpts) {
+        acl.request = reqOpts => {
           assert.strictEqual(reqOpts.qs.generation, generation);
 
           done();
         };
 
-        acl.get({generation}, assert.ifError);
+        acl.get({ generation }, assert.ifError);
       });
 
-      it('should pass an array of acl objects to the callback', function(done) {
+      it('should pass an array of acl objects to the callback', done => {
         const apiResponse = {
           items: [
-            {entity: ENTITY, role: ROLE},
-            {entity: ENTITY, role: ROLE},
-            {entity: ENTITY, role: ROLE},
+            { entity: ENTITY, role: ROLE },
+            { entity: ENTITY, role: ROLE },
+            { entity: ENTITY, role: ROLE },
           ],
         };
 
         const expectedAclObjects = [
-          {entity: ENTITY, role: ROLE},
-          {entity: ENTITY, role: ROLE},
-          {entity: ENTITY, role: ROLE},
+          { entity: ENTITY, role: ROLE },
+          { entity: ENTITY, role: ROLE },
+          { entity: ENTITY, role: ROLE },
         ];
 
-        acl.makeAclObject_ = function(obj, index) {
+        acl.makeAclObject_ = (obj, index) => {
           return expectedAclObjects[index];
         };
 
-        acl.request = function(reqOpts, callback) {
+        acl.request = (reqOpts, callback) => {
           callback(null, apiResponse);
         };
 
-        acl.get(function(err, aclObjects) {
+        acl.get((err, aclObjects) => {
           assert.ifError(err);
           assert.deepEqual(aclObjects, expectedAclObjects);
           done();
@@ -276,36 +276,36 @@ describe('storage/acl', function() {
       });
     });
 
-    describe('ACL object for an entity', function() {
-      it('should get a specific ACL object', function(done) {
-        acl.request = function(reqOpts) {
+    describe('ACL object for an entity', () => {
+      it('should get a specific ACL object', done => {
+        acl.request = reqOpts => {
           assert.strictEqual(reqOpts.uri, '/' + encodeURIComponent(ENTITY));
 
           done();
         };
 
-        acl.get({entity: ENTITY}, assert.ifError);
+        acl.get({ entity: ENTITY }, assert.ifError);
       });
 
-      it('should accept a configuration object', function(done) {
+      it('should accept a configuration object', done => {
         const generation = 1;
 
-        acl.request = function(reqOpts) {
+        acl.request = reqOpts => {
           assert.strictEqual(reqOpts.qs.generation, generation);
 
           done();
         };
 
-        acl.get({entity: ENTITY, generation}, assert.ifError);
+        acl.get({ entity: ENTITY, generation }, assert.ifError);
       });
 
-      it('should set the userProject', function(done) {
+      it('should set the userProject', done => {
         const options = {
           entity: ENTITY,
           userProject: 'grape-spaceship-123',
         };
 
-        acl.request = function(reqOpts) {
+        acl.request = reqOpts => {
           assert.strictEqual(reqOpts.qs.userProject, options.userProject);
           done();
         };
@@ -313,19 +313,19 @@ describe('storage/acl', function() {
         acl.get(options, assert.ifError);
       });
 
-      it('should pass an acl object to the callback', function(done) {
-        const apiResponse = {entity: ENTITY, role: ROLE};
-        const expectedAclObject = {entity: ENTITY, role: ROLE};
+      it('should pass an acl object to the callback', done => {
+        const apiResponse = { entity: ENTITY, role: ROLE };
+        const expectedAclObject = { entity: ENTITY, role: ROLE };
 
-        acl.makeAclObject_ = function() {
+        acl.makeAclObject_ = () => {
           return expectedAclObject;
         };
 
-        acl.request = function(reqOpts, callback) {
+        acl.request = (reqOpts, callback) => {
           callback(null, apiResponse);
         };
 
-        acl.get({entity: ENTITY}, function(err, aclObject) {
+        acl.get({ entity: ENTITY }, (err, aclObject) => {
           assert.ifError(err);
           assert.deepEqual(aclObject, expectedAclObject);
           done();
@@ -333,52 +333,52 @@ describe('storage/acl', function() {
       });
     });
 
-    it('should execute the callback with an error', function(done) {
-      acl.request = function(reqOpts, callback) {
+    it('should execute the callback with an error', done => {
+      acl.request = (reqOpts, callback) => {
         callback(ERROR);
       };
 
-      acl.get(function(err) {
+      acl.get(err => {
         assert.deepEqual(err, ERROR);
         done();
       });
     });
 
-    it('should execute the callback with apiResponse', function(done) {
-      const resp = {success: true};
+    it('should execute the callback with apiResponse', done => {
+      const resp = { success: true };
 
-      acl.request = function(reqOpts, callback) {
+      acl.request = (reqOpts, callback) => {
         callback(null, resp);
       };
 
-      acl.get(function(err, acls, apiResponse) {
+      acl.get((err, acls, apiResponse) => {
         assert.deepEqual(resp, apiResponse);
         done();
       });
     });
   });
 
-  describe('update', function() {
-    it('should make the correct API request', function(done) {
-      acl.request = function(reqOpts) {
+  describe('update', () => {
+    it('should make the correct API request', done => {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.method, 'PUT');
         assert.strictEqual(reqOpts.uri, '/' + encodeURIComponent(ENTITY));
-        assert.deepEqual(reqOpts.json, {role: ROLE});
+        assert.deepEqual(reqOpts.json, { role: ROLE });
 
         done();
       };
 
-      acl.update({entity: ENTITY, role: ROLE}, assert.ifError);
+      acl.update({ entity: ENTITY, role: ROLE }, assert.ifError);
     });
 
-    it('should set the generation', function(done) {
+    it('should set the generation', done => {
       const options = {
         entity: ENTITY,
         role: ROLE,
         generation: 8,
       };
 
-      acl.request = function(reqOpts) {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.generation, options.generation);
         done();
       };
@@ -386,14 +386,14 @@ describe('storage/acl', function() {
       acl.update(options, assert.ifError);
     });
 
-    it('should set the userProject', function(done) {
+    it('should set the userProject', done => {
       const options = {
         entity: ENTITY,
         role: ROLE,
         userProject: 'grape-spaceship-123',
       };
 
-      acl.request = function(reqOpts) {
+      acl.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -401,53 +401,53 @@ describe('storage/acl', function() {
       acl.update(options, assert.ifError);
     });
 
-    it('should pass an acl object to the callback', function(done) {
-      const apiResponse = {entity: ENTITY, role: ROLE};
-      const expectedAclObject = {entity: ENTITY, role: ROLE};
+    it('should pass an acl object to the callback', done => {
+      const apiResponse = { entity: ENTITY, role: ROLE };
+      const expectedAclObject = { entity: ENTITY, role: ROLE };
 
-      acl.makeAclObject_ = function() {
+      acl.makeAclObject_ = () => {
         return expectedAclObject;
       };
 
-      acl.request = function(reqOpts, callback) {
+      acl.request = (reqOpts, callback) => {
         callback(null, apiResponse);
       };
 
-      acl.update({entity: ENTITY, role: ROLE}, function(err, aclObject) {
+      acl.update({ entity: ENTITY, role: ROLE }, (err, aclObject) => {
         assert.ifError(err);
         assert.deepEqual(aclObject, expectedAclObject);
         done();
       });
     });
 
-    it('should execute the callback with an error', function(done) {
-      acl.request = function(reqOpts, callback) {
+    it('should execute the callback with an error', done => {
+      acl.request = (reqOpts, callback) => {
         callback(ERROR);
       };
 
-      acl.update({entity: ENTITY, role: ROLE}, function(err) {
+      acl.update({ entity: ENTITY, role: ROLE }, err => {
         assert.deepEqual(err, ERROR);
         done();
       });
     });
 
-    it('should execute the callback with apiResponse', function(done) {
-      const resp = {success: true};
+    it('should execute the callback with apiResponse', done => {
+      const resp = { success: true };
 
-      acl.request = function(reqOpts, callback) {
+      acl.request = (reqOpts, callback) => {
         callback(null, resp);
       };
 
-      const config = {entity: ENTITY, role: ROLE};
-      acl.update(config, function(err, acls, apiResponse) {
+      const config = { entity: ENTITY, role: ROLE };
+      acl.update(config, (err, acls, apiResponse) => {
         assert.deepEqual(resp, apiResponse);
         done();
       });
     });
   });
 
-  describe('makeAclObject_', function() {
-    it('should return an ACL object from an API response', function() {
+  describe('makeAclObject_', () => {
+    it('should return an ACL object from an API response', () => {
       const projectTeam = {
         projectNumber: '283748374',
         team: 'awesome',
@@ -469,15 +469,15 @@ describe('storage/acl', function() {
     });
   });
 
-  describe('request', function() {
-    it('should make the correct request', function(done) {
+  describe('request', () => {
+    it('should make the correct request', done => {
       const uri = '/uri';
 
       const reqOpts = {
         uri,
       };
 
-      acl.request_ = function(reqOpts_, callback) {
+      acl.request_ = (reqOpts_, callback) => {
         assert.strictEqual(reqOpts_, reqOpts);
         assert.strictEqual(reqOpts_.uri, PATH_PREFIX + uri);
         callback(); // done()
@@ -488,15 +488,15 @@ describe('storage/acl', function() {
   });
 });
 
-describe('storage/AclRoleAccessorMethods', function() {
+describe('storage/AclRoleAccessorMethods', () => {
   let aclEntity;
 
-  beforeEach(function() {
+  beforeEach(() => {
     aclEntity = new AclRoleAccessorMethods();
   });
 
-  describe('initialization', function() {
-    it('should assign access methods for every role object', function() {
+  describe('initialization', () => {
+    it('should assign access methods for every role object', () => {
       const expectedApi = [
         'addAllAuthenticatedUsers',
         'deleteAllAuthenticatedUsers',
@@ -528,12 +528,12 @@ describe('storage/AclRoleAccessorMethods', function() {
     });
   });
 
-  describe('_assignAccessMethods', function() {
-    it('should call parent method', function(done) {
+  describe('_assignAccessMethods', () => {
+    it('should call parent method', done => {
       const userName = 'email@example.com';
       const role = 'fakerole';
 
-      aclEntity.add = function(options, callback) {
+      aclEntity.add = (options, callback) => {
         assert.deepEqual(options, {
           entity: 'user-' + userName,
           role,
@@ -542,7 +542,7 @@ describe('storage/AclRoleAccessorMethods', function() {
         callback();
       };
 
-      aclEntity.delete = function(options, callback) {
+      aclEntity.delete = (options, callback) => {
         assert.deepEqual(options, {
           entity: 'allUsers',
           role,
@@ -554,23 +554,21 @@ describe('storage/AclRoleAccessorMethods', function() {
       aclEntity._assignAccessMethods(role);
 
       async.parallel(
-        [
-          function(next) {
-            // The method name should be in plural form. (fakeroles vs fakerole)
-            aclEntity.fakeroles.addUser(userName, next);
-          },
-          function(next) {
-            aclEntity.fakeroles.deleteAllUsers(next);
-          },
+        [next => {
+          // The method name should be in plural form. (fakeroles vs fakerole)
+          aclEntity.fakeroles.addUser(userName, next);
+        }, next => {
+          aclEntity.fakeroles.deleteAllUsers(next);
+        },
         ],
         done
       );
     });
 
-    it('should return the parent methods return value', function() {
+    it('should return the parent methods return value', () => {
       const fakeReturn = {};
 
-      aclEntity.add = function() {
+      aclEntity.add = () => {
         return fakeReturn;
       };
 
@@ -580,8 +578,8 @@ describe('storage/AclRoleAccessorMethods', function() {
       assert.strictEqual(value, fakeReturn);
     });
 
-    it('should not pass in the callback if undefined', function(done) {
-      aclEntity.add = function() {
+    it('should not pass in the callback if undefined', done => {
+      aclEntity.add = () => {
         assert.strictEqual(arguments.length, 1);
         done();
       };
@@ -590,7 +588,7 @@ describe('storage/AclRoleAccessorMethods', function() {
       aclEntity.fakeroles.addUser('email@example.com', undefined);
     });
 
-    it('should optionally accept options', function(done) {
+    it('should optionally accept options', done => {
       const fakeRole = 'fakerole';
       const fakeUser = 'email@example.com';
       const fakeOptions = {
@@ -605,7 +603,7 @@ describe('storage/AclRoleAccessorMethods', function() {
         fakeOptions
       );
 
-      aclEntity.add = function(options) {
+      aclEntity.add = options => {
         assert.deepEqual(options, expectedOptions);
         done();
       };

--- a/test/acl.ts
+++ b/test/acl.ts
@@ -579,8 +579,8 @@ describe('storage/AclRoleAccessorMethods', () => {
     });
 
     it('should not pass in the callback if undefined', done => {
-      aclEntity.add = () => {
-        assert.strictEqual(arguments.length, 1);
+      aclEntity.add = (...args) => {
+        assert.strictEqual(args.length, 1);
         done();
       };
 

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -67,18 +67,18 @@ function fakeRequest() {
   // call.
   return fakeRequest;
 };
-(fakeRequest as any).get = () => {
-  return (requestOverride.get || fakeRequest).apply(null, arguments);
+(fakeRequest as any).get = (...args) => {
+  return (requestOverride.get || fakeRequest).apply(null, args);
 };
-(fakeRequest as any).head = () => {
-  return (requestOverride.head || fakeRequest).apply(null, arguments);
+(fakeRequest as any).head = (...args) => {
+  return (requestOverride.head || fakeRequest).apply(null, args);
 };
 
 let eachLimitOverride;
 
 const fakeAsync = extend({}, async);
-fakeAsync.eachLimit = () => {
-  (eachLimitOverride || async.eachLimit).apply(null, arguments);
+fakeAsync.eachLimit = (...args) => {
+  (eachLimitOverride || async.eachLimit).apply(null, args);
 };
 
 let promisified = false;
@@ -1769,11 +1769,13 @@ describe('Bucket', () => {
     it('should call ServiceObject#request correctly', done => {
       const options = {};
 
-      FakeServiceObject.prototype.request = (reqOpts, callback) => {
-        assert.strictEqual(this, bucket);
-        assert.strictEqual(reqOpts, options);
-        callback(); // done fn
-      };
+      extend(FakeServiceObject.prototype, {
+        request(reqOpts, callback) {
+          assert.strictEqual(this, bucket);
+          assert.strictEqual(reqOpts, options);
+          callback(); // done fn
+        },
+      });
 
       bucket.request(options, done);
     });

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -19,7 +19,7 @@
 import arrify from 'arrify';
 import assert from 'assert';
 import async from 'async';
-import {ServiceObject, util} from '@google-cloud/common';
+import { ServiceObject, util } from '@google-cloud/common';
 import extend from 'extend';
 import mime from 'mime-types';
 import nodeutil from 'util';
@@ -41,10 +41,10 @@ function FakeFile(bucket, name, options?) {
   this.options = options;
   this.metadata = {};
 
-  this.createWriteStream = function(options) {
+  this.createWriteStream = options => {
     self.metadata = options.metadata;
     const ws = new stream.Writable();
-    (ws as any).write = function() {
+    (ws as any).write = () => {
       ws.emit('complete');
       ws.end();
     };
@@ -62,22 +62,22 @@ let requestOverride;
 function fakeRequest() {
   return (requestOverride || requestCached).apply(null, arguments);
 }
-(fakeRequest as any).defaults = function() {
+(fakeRequest as any).defaults = () => {
   // Ignore the default values, so we don't have to test for them in every API
   // call.
   return fakeRequest;
 };
-(fakeRequest as any).get = function() {
+(fakeRequest as any).get = () => {
   return (requestOverride.get || fakeRequest).apply(null, arguments);
 };
-(fakeRequest as any).head = function() {
+(fakeRequest as any).head = () => {
   return (requestOverride.head || fakeRequest).apply(null, arguments);
 };
 
 let eachLimitOverride;
 
 const fakeAsync = extend({}, async);
-fakeAsync.eachLimit = function() {
+fakeAsync.eachLimit = () => {
   (eachLimitOverride || async.eachLimit).apply(null, arguments);
 };
 
@@ -125,7 +125,7 @@ function FakeServiceObject() {
 
 nodeutil.inherits(FakeServiceObject, ServiceObject);
 
-describe('Bucket', function() {
+describe('Bucket', () => {
   let Bucket;
   let bucket;
 
@@ -134,7 +134,7 @@ describe('Bucket', function() {
   };
   const BUCKET_NAME = 'test-bucket';
 
-  before(function() {
+  before(() => {
     Bucket = proxyquire('../src/bucket.js', {
       async: {
         default: fakeAsync
@@ -152,46 +152,46 @@ describe('Bucket', function() {
     }).Bucket;
   });
 
-  beforeEach(function() {
+  beforeEach(() => {
     requestOverride = null;
     eachLimitOverride = null;
     bucket = new Bucket(STORAGE, BUCKET_NAME);
   });
 
-  describe('instantiation', function() {
-    it('should extend the correct methods', function() {
+  describe('instantiation', () => {
+    it('should extend the correct methods', () => {
       assert(extended); // See `fakePaginator.extend`
     });
 
-    it('should streamify the correct methods', function() {
+    it('should streamify the correct methods', () => {
       assert.strictEqual(bucket.getFilesStream, 'getFiles');
     });
 
-    it('should promisify all the things', function() {
+    it('should promisify all the things', () => {
       assert(promisified);
     });
 
-    it('should remove a leading gs://', function() {
+    it('should remove a leading gs://', () => {
       const bucket = new Bucket(STORAGE, 'gs://bucket-name');
       assert.strictEqual(bucket.name, 'bucket-name');
     });
 
-    it('should localize the name', function() {
+    it('should localize the name', () => {
       assert.strictEqual(bucket.name, BUCKET_NAME);
     });
 
-    it('should localize the storage instance', function() {
+    it('should localize the storage instance', () => {
       assert.strictEqual(bucket.storage, STORAGE);
     });
 
-    describe('ACL objects', function() {
+    describe('ACL objects', () => {
       let _request;
 
-      before(function() {
+      before(() => {
         _request = Bucket.prototype.request;
       });
 
-      beforeEach(function() {
+      beforeEach(() => {
         Bucket.prototype.request = {
           bind(ctx) {
             return ctx;
@@ -201,18 +201,18 @@ describe('Bucket', function() {
         bucket = new Bucket(STORAGE, BUCKET_NAME);
       });
 
-      after(function() {
+      after(() => {
         Bucket.prototype.request = _request;
       });
 
-      it('should create an ACL object', function() {
+      it('should create an ACL object', () => {
         assert.deepEqual(bucket.acl.calledWith_[0], {
           request: bucket,
           pathPrefix: '/acl',
         });
       });
 
-      it('should create a default ACL object', function() {
+      it('should create a default ACL object', () => {
         assert.deepEqual(bucket.acl.default.calledWith_[0], {
           request: bucket,
           pathPrefix: '/defaultObjectAcl',
@@ -220,7 +220,7 @@ describe('Bucket', function() {
       });
     });
 
-    it('should inherit from ServiceObject', function(done) {
+    it('should inherit from ServiceObject', done => {
       const storageInstance = extend({}, STORAGE, {
         createBucket: {
           bind(context) {
@@ -243,12 +243,12 @@ describe('Bucket', function() {
       });
     });
 
-    it('should localize an Iam instance', function() {
+    it('should localize an Iam instance', () => {
       assert(bucket.iam instanceof FakeIam);
       assert.deepStrictEqual(bucket.iam.calledWith_[0], bucket);
     });
 
-    it('should localize userProject if provided', function() {
+    it('should localize userProject if provided', () => {
       const fakeUserProject = 'grape-spaceship-123';
       const bucket = new Bucket(STORAGE, BUCKET_NAME, {
         userProject: fakeUserProject,
@@ -258,30 +258,30 @@ describe('Bucket', function() {
     });
   });
 
-  describe('combine', function() {
-    it('should throw if invalid sources are not provided', function() {
-      assert.throws(function() {
+  describe('combine', () => {
+    it('should throw if invalid sources are not provided', () => {
+      assert.throws(() => {
         bucket.combine();
       }, /You must provide at least two source files\./);
 
-      assert.throws(function() {
+      assert.throws(() => {
         bucket.combine(['1']);
       }, /You must provide at least two source files\./);
     });
 
-    it('should throw if a destination is not provided', function() {
-      assert.throws(function() {
+    it('should throw if a destination is not provided', () => {
+      assert.throws(() => {
         bucket.combine(['1', '2']);
       }, /A destination file must be specified\./);
     });
 
-    it('should accept string or file input for sources', function(done) {
+    it('should accept string or file input for sources', done => {
       const file1 = bucket.file('1.txt');
       const file2 = '2.txt';
       const destinationFileName = 'destination.txt';
 
       const originalFileMethod = bucket.file;
-      bucket.file = function(name) {
+      bucket.file = name => {
         const file = originalFileMethod(name);
 
         if (name === '2.txt') {
@@ -290,7 +290,7 @@ describe('Bucket', function() {
 
         assert.strictEqual(name, destinationFileName);
 
-        file.request = function(reqOpts) {
+        file.request = reqOpts => {
           assert.strictEqual(reqOpts.method, 'POST');
           assert.strictEqual(reqOpts.uri, '/compose');
           assert.strictEqual(reqOpts.json.sourceObjects[0].name, file1.name);
@@ -305,10 +305,10 @@ describe('Bucket', function() {
       bucket.combine([file1, file2], destinationFileName);
     });
 
-    it('should use content type from the destination metadata', function(done) {
+    it('should use content type from the destination metadata', done => {
       const destination = bucket.file('destination.txt');
 
-      destination.request = function(reqOpts) {
+      destination.request = reqOpts => {
         assert.strictEqual(
           reqOpts.json.destination.contentType,
           mime.contentType(destination.name)
@@ -320,11 +320,11 @@ describe('Bucket', function() {
       bucket.combine(['1', '2'], destination);
     });
 
-    it('should use content type from the destination metadata', function(done) {
+    it('should use content type from the destination metadata', done => {
       const destination = bucket.file('destination.txt');
-      destination.metadata = {contentType: 'content-type'};
+      destination.metadata = { contentType: 'content-type' };
 
-      destination.request = function(reqOpts) {
+      destination.request = reqOpts => {
         assert.strictEqual(
           reqOpts.json.destination.contentType,
           destination.metadata.contentType
@@ -336,10 +336,10 @@ describe('Bucket', function() {
       bucket.combine(['1', '2'], destination);
     });
 
-    it('should detect dest content type if not in metadata', function(done) {
+    it('should detect dest content type if not in metadata', done => {
       const destination = bucket.file('destination.txt');
 
-      destination.request = function(reqOpts) {
+      destination.request = reqOpts => {
         assert.strictEqual(
           reqOpts.json.destination.contentType,
           mime.contentType(destination.name)
@@ -351,15 +351,15 @@ describe('Bucket', function() {
       bucket.combine(['1', '2'], destination);
     });
 
-    it('should make correct API request', function(done) {
+    it('should make correct API request', done => {
       const sources = [bucket.file('1.txt'), bucket.file('2.txt')];
       const destination = bucket.file('destination.txt');
 
-      destination.request = function(reqOpts) {
+      destination.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, '/compose');
         assert.deepEqual(reqOpts.json, {
-          destination: {contentType: mime.contentType(destination.name)},
-          sourceObjects: [{name: sources[0].name}, {name: sources[1].name}],
+          destination: { contentType: mime.contentType(destination.name) },
+          sourceObjects: [{ name: sources[0].name }, { name: sources[1].name }],
         });
 
         done();
@@ -368,11 +368,11 @@ describe('Bucket', function() {
       bucket.combine(sources, destination);
     });
 
-    it('should encode the destination file name', function(done) {
+    it('should encode the destination file name', done => {
       const sources = [bucket.file('1.txt'), bucket.file('2.txt')];
       const destination = bucket.file('needs encoding.jpg');
 
-      destination.request = function(reqOpts) {
+      destination.request = reqOpts => {
         assert.strictEqual(reqOpts.uri.indexOf(destination), -1);
         done();
       };
@@ -380,17 +380,17 @@ describe('Bucket', function() {
       bucket.combine(sources, destination);
     });
 
-    it('should send a source generation value if available', function(done) {
+    it('should send a source generation value if available', done => {
       const sources = [bucket.file('1.txt'), bucket.file('2.txt')];
-      sources[0].metadata = {generation: 1};
-      sources[1].metadata = {generation: 2};
+      sources[0].metadata = { generation: 1 };
+      sources[1].metadata = { generation: 2 };
 
       const destination = bucket.file('destination.txt');
 
-      destination.request = function(reqOpts) {
+      destination.request = reqOpts => {
         assert.deepEqual(reqOpts.json.sourceObjects, [
-          {name: sources[0].name, generation: sources[0].metadata.generation},
-          {name: sources[1].name, generation: sources[1].metadata.generation},
+          { name: sources[0].name, generation: sources[0].metadata.generation },
+          { name: sources[1].name, generation: sources[1].metadata.generation },
         ]);
 
         done();
@@ -399,7 +399,7 @@ describe('Bucket', function() {
       bucket.combine(sources, destination);
     });
 
-    it('should accept userProject option', function(done) {
+    it('should accept userProject option', done => {
       const options = {
         userProject: 'user-project-id',
       };
@@ -407,7 +407,7 @@ describe('Bucket', function() {
       const sources = [bucket.file('1.txt'), bucket.file('2.txt')];
       const destination = bucket.file('destination.txt');
 
-      destination.request = function(reqOpts) {
+      destination.request = reqOpts => {
         assert.strictEqual(reqOpts.qs, options);
         done();
       };
@@ -415,75 +415,75 @@ describe('Bucket', function() {
       bucket.combine(sources, destination, options, assert.ifError);
     });
 
-    it('should execute the callback', function(done) {
+    it('should execute the callback', done => {
       const sources = [bucket.file('1.txt'), bucket.file('2.txt')];
       const destination = bucket.file('destination.txt');
 
-      destination.request = function(reqOpts, callback) {
+      destination.request = (reqOpts, callback) => {
         callback();
       };
 
       bucket.combine(sources, destination, done);
     });
 
-    it('should execute the callback with an error', function(done) {
+    it('should execute the callback with an error', done => {
       const sources = [bucket.file('1.txt'), bucket.file('2.txt')];
       const destination = bucket.file('destination.txt');
 
       const error = new Error('Error.');
 
-      destination.request = function(reqOpts, callback) {
+      destination.request = (reqOpts, callback) => {
         callback(error);
       };
 
-      bucket.combine(sources, destination, function(err) {
+      bucket.combine(sources, destination, err => {
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should execute the callback with apiResponse', function(done) {
+    it('should execute the callback with apiResponse', done => {
       const sources = [bucket.file('1.txt'), bucket.file('2.txt')];
       const destination = bucket.file('destination.txt');
-      const resp = {success: true};
+      const resp = { success: true };
 
-      destination.request = function(reqOpts, callback) {
+      destination.request = (reqOpts, callback) => {
         callback(null, resp);
       };
 
-      bucket.combine(sources, destination, function(err, obj, apiResponse) {
+      bucket.combine(sources, destination, (err, obj, apiResponse) => {
         assert.strictEqual(resp, apiResponse);
         done();
       });
     });
   });
 
-  describe('createChannel', function() {
+  describe('createChannel', () => {
     const ID = 'id';
     const CONFIG = {
       address: 'https://...',
     };
 
-    it('should throw if an ID is not provided', function() {
-      assert.throws(function() {
+    it('should throw if an ID is not provided', () => {
+      assert.throws(() => {
         bucket.createChannel();
       }, /An ID is required to create a channel\./);
     });
 
-    it('should throw if an address is not provided', function() {
-      assert.throws(function() {
+    it('should throw if an address is not provided', () => {
+      assert.throws(() => {
         bucket.createChannel(ID, {});
       }, /An address is required to create a channel\./);
     });
 
-    it('should make the correct request', function(done) {
+    it('should make the correct request', done => {
       const config = extend({}, CONFIG, {
         a: 'b',
         c: 'd',
       });
       const originalConfig = extend({}, config);
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/o/watch');
 
@@ -500,12 +500,12 @@ describe('Bucket', function() {
       bucket.createChannel(ID, config, assert.ifError);
     });
 
-    it('should accept userProject option', function(done) {
+    it('should accept userProject option', done => {
       const options = {
         userProject: 'user-project-id',
       };
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.qs, options);
         done();
       };
@@ -513,18 +513,18 @@ describe('Bucket', function() {
       bucket.createChannel(ID, CONFIG, options, assert.ifError);
     });
 
-    describe('error', function() {
+    describe('error', () => {
       const error = new Error('Error.');
       const apiResponse = {};
 
-      beforeEach(function() {
-        bucket.request = function(reqOpts, callback) {
+      beforeEach(() => {
+        bucket.request = (reqOpts, callback) => {
           callback(error, apiResponse);
         };
       });
 
-      it('should execute callback with error & API response', function(done) {
-        bucket.createChannel(ID, CONFIG, function(err, channel, apiResponse_) {
+      it('should execute callback with error & API response', done => {
+        bucket.createChannel(ID, CONFIG, (err, channel, apiResponse_) => {
           assert.strictEqual(err, error);
           assert.strictEqual(channel, null);
           assert.strictEqual(apiResponse_, apiResponse);
@@ -534,28 +534,28 @@ describe('Bucket', function() {
       });
     });
 
-    describe('success', function() {
+    describe('success', () => {
       const apiResponse = {
         resourceId: 'resource-id',
       };
 
-      beforeEach(function() {
-        bucket.request = function(reqOpts, callback) {
+      beforeEach(() => {
+        bucket.request = (reqOpts, callback) => {
           callback(null, apiResponse);
         };
       });
 
-      it('should exec a callback with Channel & API response', function(done) {
+      it('should exec a callback with Channel & API response', done => {
         const channel = {};
 
-        bucket.storage.channel = function(id, resourceId) {
+        bucket.storage.channel = (id, resourceId) => {
           assert.strictEqual(id, ID);
           assert.strictEqual(resourceId, apiResponse.resourceId);
 
           return channel;
         };
 
-        bucket.createChannel(ID, CONFIG, function(err, channel_, apiResponse_) {
+        bucket.createChannel(ID, CONFIG, (err, channel_, apiResponse_) => {
           assert.ifError(err);
 
           assert.strictEqual(channel_, channel);
@@ -569,7 +569,7 @@ describe('Bucket', function() {
     });
   });
 
-  describe('createNotification', function() {
+  describe('createNotification', () => {
     const PUBSUB_SERVICE_PATH = '//pubsub.googleapis.com/';
     const TOPIC = 'my-topic';
     const FULL_TOPIC_NAME =
@@ -579,23 +579,23 @@ describe('Bucket', function() {
       this.name = 'projects/grape-spaceship-123/topics/' + name;
     }
 
-    beforeEach(function() {
+    beforeEach(() => {
       fakeUtil.isCustomType = util.isCustomType;
     });
 
-    it('should throw an error if a valid topic is not provided', function() {
-      assert.throws(function() {
+    it('should throw an error if a valid topic is not provided', () => {
+      assert.throws(() => {
         bucket.createNotification();
       }, /A valid topic name is required\./);
     });
 
-    it('should make the correct request', function(done) {
+    it('should make the correct request', done => {
       const topic = 'projects/my-project/topics/my-topic';
-      const options = {payloadFormat: 'NONE'};
+      const options = { payloadFormat: 'NONE' };
       const expectedTopic = PUBSUB_SERVICE_PATH + topic;
-      const expectedJson = extend({topic: expectedTopic}, snakeize(options));
+      const expectedJson = extend({ topic: expectedTopic }, snakeize(options));
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/notificationConfigs');
         assert.deepEqual(reqOpts.json, expectedJson);
@@ -606,8 +606,8 @@ describe('Bucket', function() {
       bucket.createNotification(topic, options, assert.ifError);
     });
 
-    it('should accept incomplete topic names', function(done) {
-      bucket.request = function(reqOpts) {
+    it('should accept incomplete topic names', done => {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.json.topic, FULL_TOPIC_NAME);
         done();
       };
@@ -615,17 +615,17 @@ describe('Bucket', function() {
       bucket.createNotification(TOPIC, {}, assert.ifError);
     });
 
-    it('should accept a topic object', function(done) {
+    it('should accept a topic object', done => {
       const fakeTopic = new FakeTopic('my-topic');
       const expectedTopicName = PUBSUB_SERVICE_PATH + fakeTopic.name;
 
-      fakeUtil.isCustomType = function(topic, type) {
+      fakeUtil.isCustomType = (topic, type) => {
         assert.strictEqual(topic, fakeTopic);
         assert.strictEqual(type, 'pubsub/topic');
         return true;
       };
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.json.topic, expectedTopicName);
         done();
       };
@@ -633,8 +633,8 @@ describe('Bucket', function() {
       bucket.createNotification(fakeTopic, {}, assert.ifError);
     });
 
-    it('should set a default payload format', function(done) {
-      bucket.request = function(reqOpts) {
+    it('should set a default payload format', done => {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.json.payload_format, 'JSON_API_V1');
         done();
       };
@@ -642,13 +642,13 @@ describe('Bucket', function() {
       bucket.createNotification(TOPIC, {}, assert.ifError);
     });
 
-    it('should optionally accept options', function(done) {
+    it('should optionally accept options', done => {
       const expectedJson = {
         topic: FULL_TOPIC_NAME,
         payload_format: 'JSON_API_V1',
       };
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.deepEqual(reqOpts.json, expectedJson);
         done();
       };
@@ -656,12 +656,12 @@ describe('Bucket', function() {
       bucket.createNotification(TOPIC, assert.ifError);
     });
 
-    it('should accept a userProject', function(done) {
+    it('should accept a userProject', done => {
       const options = {
         userProject: 'grape-spaceship-123',
       };
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -669,15 +669,15 @@ describe('Bucket', function() {
       bucket.createNotification(TOPIC, options, assert.ifError);
     });
 
-    it('should return errors to the callback', function(done) {
+    it('should return errors to the callback', done => {
       const error = new Error('err');
       const response = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(error, response);
       };
 
-      bucket.createNotification(TOPIC, function(err, notification, resp) {
+      bucket.createNotification(TOPIC, (err, notification, resp) => {
         assert.strictEqual(err, error);
         assert.strictEqual(notification, null);
         assert.strictEqual(resp, response);
@@ -685,21 +685,21 @@ describe('Bucket', function() {
       });
     });
 
-    it('should return a notification object', function(done) {
+    it('should return a notification object', done => {
       const fakeId = '123';
-      const response = {id: fakeId};
+      const response = { id: fakeId };
       const fakeNotification = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(null, response);
       };
 
-      bucket.notification = function(id) {
+      bucket.notification = id => {
         assert.strictEqual(id, fakeId);
         return fakeNotification;
       };
 
-      bucket.createNotification(TOPIC, function(err, notification, resp) {
+      bucket.createNotification(TOPIC, (err, notification, resp) => {
         assert.ifError(err);
         assert.strictEqual(notification, fakeNotification);
         assert.strictEqual(notification.metadata, response);
@@ -709,9 +709,9 @@ describe('Bucket', function() {
     });
   });
 
-  describe('delete', function() {
-    it('should make the correct request', function(done) {
-      bucket.request = function(reqOpts, callback) {
+  describe('delete', () => {
+    it('should make the correct request', done => {
+      bucket.request = (reqOpts, callback) => {
         assert.strictEqual(reqOpts.method, 'DELETE');
         assert.strictEqual(reqOpts.uri, '');
         assert.deepEqual(reqOpts.qs, {});
@@ -721,10 +721,10 @@ describe('Bucket', function() {
       bucket.delete(done);
     });
 
-    it('should accept options', function(done) {
+    it('should accept options', done => {
       const options = {};
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.qs, options);
         done();
       };
@@ -732,8 +732,8 @@ describe('Bucket', function() {
       bucket.delete(options, assert.ifError);
     });
 
-    it('should not require a callback', function(done) {
-      bucket.request = function(reqOpts, callback) {
+    it('should not require a callback', done => {
+      bucket.request = (reqOpts, callback) => {
         assert.doesNotThrow(callback);
         done();
       };
@@ -742,9 +742,9 @@ describe('Bucket', function() {
     });
   });
 
-  describe('deleteFiles', function() {
-    it('should accept only a callback', function(done) {
-      bucket.getFiles = function(query, callback) {
+  describe('deleteFiles', () => {
+    it('should accept only a callback', done => {
+      bucket.getFiles = (query, callback) => {
         assert.deepEqual(query, {});
         callback(null, []);
       };
@@ -752,10 +752,10 @@ describe('Bucket', function() {
       bucket.deleteFiles(done);
     });
 
-    it('should get files from the bucket', function(done) {
-      const query = {a: 'b', c: 'd'};
+    it('should get files from the bucket', done => {
+      const query = { a: 'b', c: 'd' };
 
-      bucket.getFiles = function(query_) {
+      bucket.getFiles = query_ => {
         assert.deepEqual(query_, query);
         done();
       };
@@ -763,89 +763,89 @@ describe('Bucket', function() {
       bucket.deleteFiles(query, assert.ifError);
     });
 
-    it('should process 10 files at a time', function(done) {
-      eachLimitOverride = function(arr, limit) {
+    it('should process 10 files at a time', done => {
+      eachLimitOverride = (arr, limit) => {
         assert.equal(limit, 10);
         done();
       };
 
-      bucket.getFiles = function(query, callback) {
+      bucket.getFiles = (query, callback) => {
         callback(null, []);
       };
 
       bucket.deleteFiles({}, assert.ifError);
     });
 
-    it('should delete the files', function(done) {
+    it('should delete the files', done => {
       const query = {};
       let timesCalled = 0;
 
       const files = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('delete', function(query_, callback) {
+        propAssign('delete', (query_, callback) => {
           timesCalled++;
           assert.strictEqual(query_, query);
           callback();
         })
       );
 
-      bucket.getFiles = function(query_, callback) {
+      bucket.getFiles = (query_, callback) => {
         assert.strictEqual(query_, query);
         callback(null, files);
       };
 
-      bucket.deleteFiles(query, function(err) {
+      bucket.deleteFiles(query, err => {
         assert.ifError(err);
         assert.equal(timesCalled, files.length);
         done();
       });
     });
 
-    it('should execute callback with error from getting files', function(done) {
+    it('should execute callback with error from getting files', done => {
       const error = new Error('Error.');
 
-      bucket.getFiles = function(query, callback) {
+      bucket.getFiles = (query, callback) => {
         callback(error);
       };
 
-      bucket.deleteFiles({}, function(err) {
+      bucket.deleteFiles({}, err => {
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should execute callback with error from deleting file', function(done) {
+    it('should execute callback with error from deleting file', done => {
       const error = new Error('Error.');
 
       const files = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('delete', function(query, callback) {
+        propAssign('delete', (query, callback) => {
           callback(error);
         })
       );
 
-      bucket.getFiles = function(query, callback) {
+      bucket.getFiles = (query, callback) => {
         callback(null, files);
       };
 
-      bucket.deleteFiles({}, function(err) {
+      bucket.deleteFiles({}, err => {
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should execute callback with queued errors', function(done) {
+    it('should execute callback with queued errors', done => {
       const error = new Error('Error.');
 
       const files = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('delete', function(query, callback) {
+        propAssign('delete', (query, callback) => {
           callback(error);
         })
       );
 
-      bucket.getFiles = function(query, callback) {
+      bucket.getFiles = (query, callback) => {
         callback(null, files);
       };
 
-      bucket.deleteFiles({force: true}, function(errs) {
+      bucket.deleteFiles({ force: true }, errs => {
         assert.strictEqual(errs[0], error);
         assert.strictEqual(errs[1], error);
         done();
@@ -853,40 +853,40 @@ describe('Bucket', function() {
     });
   });
 
-  describe('deleteLabels', function() {
-    describe('all labels', function() {
-      it('should get all of the label names', function(done) {
-        bucket.getLabels = function() {
+  describe('deleteLabels', () => {
+    describe('all labels', () => {
+      it('should get all of the label names', done => {
+        bucket.getLabels = () => {
           done();
         };
 
         bucket.deleteLabels(assert.ifError);
       });
 
-      it('should return an error from getLabels()', function(done) {
+      it('should return an error from getLabels()', done => {
         const error = new Error('Error.');
 
-        bucket.getLabels = function(callback) {
+        bucket.getLabels = callback => {
           callback(error);
         };
 
-        bucket.deleteLabels(function(err) {
+        bucket.deleteLabels(err => {
           assert.strictEqual(err, error);
           done();
         });
       });
 
-      it('should call setLabels with all label names', function(done) {
+      it('should call setLabels with all label names', done => {
         const labels = {
           labelone: 'labelonevalue',
           labeltwo: 'labeltwovalue',
         };
 
-        bucket.getLabels = function(callback) {
+        bucket.getLabels = callback => {
           callback(null, labels);
         };
 
-        bucket.setLabels = function(labels, callback) {
+        bucket.setLabels = (labels, callback) => {
           assert.deepStrictEqual(labels, {
             labelone: null,
             labeltwo: null,
@@ -898,11 +898,11 @@ describe('Bucket', function() {
       });
     });
 
-    describe('single label', function() {
+    describe('single label', () => {
       const LABEL = 'labelname';
 
-      it('should call setLabels with a single label', function(done) {
-        bucket.setLabels = function(labels, callback) {
+      it('should call setLabels with a single label', done => {
+        bucket.setLabels = (labels, callback) => {
           assert.deepStrictEqual(labels, {
             [LABEL]: null,
           });
@@ -913,11 +913,11 @@ describe('Bucket', function() {
       });
     });
 
-    describe('multiple labels', function() {
+    describe('multiple labels', () => {
       const LABELS = ['labelonename', 'labeltwoname'];
 
-      it('should call setLabels with multiple labels', function(done) {
-        bucket.setLabels = function(labels, callback) {
+      it('should call setLabels with multiple labels', done => {
+        bucket.setLabels = (labels, callback) => {
           assert.deepStrictEqual(labels, {
             labelonename: null,
             labeltwoname: null,
@@ -930,9 +930,9 @@ describe('Bucket', function() {
     });
   });
 
-  describe('disableRequesterPays', function() {
-    it('should call setMetadata correctly', function(done) {
-      bucket.setMetadata = function(metadata, callback) {
+  describe('disableRequesterPays', () => {
+    it('should call setMetadata correctly', done => {
+      bucket.setMetadata = (metadata, callback) => {
         assert.deepStrictEqual(metadata, {
           billing: {
             requesterPays: false,
@@ -944,8 +944,8 @@ describe('Bucket', function() {
       bucket.disableRequesterPays(done);
     });
 
-    it('should not require a callback', function(done) {
-      bucket.setMetadata = function(metadata, callback) {
+    it('should not require a callback', done => {
+      bucket.setMetadata = (metadata, callback) => {
         assert.doesNotThrow(callback);
         done();
       };
@@ -954,9 +954,9 @@ describe('Bucket', function() {
     });
   });
 
-  describe('enableRequesterPays', function() {
-    it('should call setMetadata correctly', function(done) {
-      bucket.setMetadata = function(metadata, callback) {
+  describe('enableRequesterPays', () => {
+    it('should call setMetadata correctly', done => {
+      bucket.setMetadata = (metadata, callback) => {
         assert.deepStrictEqual(metadata, {
           billing: {
             requesterPays: true,
@@ -968,8 +968,8 @@ describe('Bucket', function() {
       bucket.enableRequesterPays(done);
     });
 
-    it('should not require a callback', function(done) {
-      bucket.setMetadata = function(metadata, callback) {
+    it('should not require a callback', done => {
+      bucket.setMetadata = (metadata, callback) => {
         assert.doesNotThrow(callback);
         done();
       };
@@ -978,19 +978,19 @@ describe('Bucket', function() {
     });
   });
 
-  describe('exists', function() {
-    it('should call get', function(done) {
-      bucket.get = function() {
+  describe('exists', () => {
+    it('should call get', done => {
+      bucket.get = () => {
         done();
       };
 
       bucket.exists(assert.ifError);
     });
 
-    it('should accept and pass options to get', function(done) {
+    it('should accept and pass options to get', done => {
       const options = {};
 
-      bucket.get = function(options_) {
+      bucket.get = options_ => {
         assert.strictEqual(options_, options);
         done();
       };
@@ -998,38 +998,38 @@ describe('Bucket', function() {
       bucket.exists(options, assert.ifError);
     });
 
-    it('should execute callback with false if 404', function(done) {
-      bucket.get = function(options, callback) {
-        callback({code: 404});
+    it('should execute callback with false if 404', done => {
+      bucket.get = (options, callback) => {
+        callback({ code: 404 });
       };
 
-      bucket.exists(function(err, exists) {
+      bucket.exists((err, exists) => {
         assert.ifError(err);
         assert.strictEqual(exists, false);
         done();
       });
     });
 
-    it('should execute callback with error if not 404', function(done) {
-      const error = {code: 500};
+    it('should execute callback with error if not 404', done => {
+      const error = { code: 500 };
 
-      bucket.get = function(options, callback) {
+      bucket.get = (options, callback) => {
         callback(error);
       };
 
-      bucket.exists(function(err, exists) {
+      bucket.exists((err, exists) => {
         assert.strictEqual(err, error);
         assert.strictEqual(exists, undefined);
         done();
       });
     });
 
-    it('should execute callback with true if no error', function(done) {
-      bucket.get = function(options, callback) {
+    it('should execute callback with true if no error', done => {
+      bucket.get = (options, callback) => {
         callback();
       };
 
-      bucket.exists(function(err, exists) {
+      bucket.exists((err, exists) => {
         assert.ifError(err);
         assert.strictEqual(exists, true);
         done();
@@ -1037,51 +1037,51 @@ describe('Bucket', function() {
     });
   });
 
-  describe('file', function() {
+  describe('file', () => {
     const FILE_NAME = 'remote-file-name.jpg';
     let file;
-    const options = {a: 'b', c: 'd'};
+    const options = { a: 'b', c: 'd' };
 
-    beforeEach(function() {
+    beforeEach(() => {
       file = bucket.file(FILE_NAME, options);
     });
 
-    it('should throw if no name is provided', function() {
-      assert.throws(function() {
+    it('should throw if no name is provided', () => {
+      assert.throws(() => {
         bucket.file();
       }, /A file name must be specified\./);
     });
 
-    it('should return a File object', function() {
+    it('should return a File object', () => {
       assert(file instanceof FakeFile);
     });
 
-    it('should pass bucket to File object', function() {
+    it('should pass bucket to File object', () => {
       assert.deepEqual(file.calledWith_[0], bucket);
     });
 
-    it('should pass filename to File object', function() {
+    it('should pass filename to File object', () => {
       assert.equal(file.calledWith_[1], FILE_NAME);
     });
 
-    it('should pass configuration object to File', function() {
+    it('should pass configuration object to File', () => {
       assert.deepEqual(file.calledWith_[2], options);
     });
   });
 
-  describe('get', function() {
-    it('should get the metadata', function(done) {
-      bucket.getMetadata = function() {
+  describe('get', () => {
+    it('should get the metadata', done => {
+      bucket.getMetadata = () => {
         done();
       };
 
       bucket.get(assert.ifError);
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const options = {};
 
-      bucket.getMetadata = function(options_) {
+      bucket.getMetadata = options_ => {
         assert.strictEqual(options_, options);
         done();
       };
@@ -1089,15 +1089,15 @@ describe('Bucket', function() {
       bucket.get(options, assert.ifError);
     });
 
-    it('should execute callback with error & metadata', function(done) {
+    it('should execute callback with error & metadata', done => {
       const error = new Error('Error.');
       const metadata = {};
 
-      bucket.getMetadata = function(options, callback) {
+      bucket.getMetadata = (options, callback) => {
         callback(error, metadata);
       };
 
-      bucket.get(function(err, instance, metadata_) {
+      bucket.get((err, instance, metadata_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(instance, null);
         assert.strictEqual(metadata_, metadata);
@@ -1106,14 +1106,14 @@ describe('Bucket', function() {
       });
     });
 
-    it('should execute callback with instance & metadata', function(done) {
+    it('should execute callback with instance & metadata', done => {
       const metadata = {};
 
-      bucket.getMetadata = function(options, callback) {
+      bucket.getMetadata = (options, callback) => {
         callback(null, metadata);
       };
 
-      bucket.get(function(err, instance, metadata_) {
+      bucket.get((err, instance, metadata_) => {
         assert.ifError(err);
 
         assert.strictEqual(instance, bucket);
@@ -1123,28 +1123,28 @@ describe('Bucket', function() {
       });
     });
 
-    describe('autoCreate', function() {
+    describe('autoCreate', () => {
       let AUTO_CREATE_CONFIG;
 
-      const ERROR = {code: 404};
+      const ERROR = { code: 404 };
       const METADATA = {};
 
-      beforeEach(function() {
+      beforeEach(() => {
         AUTO_CREATE_CONFIG = {
           autoCreate: true,
         };
 
-        bucket.getMetadata = function(options, callback) {
+        bucket.getMetadata = (options, callback) => {
           callback(ERROR, METADATA);
         };
       });
 
-      it('should pass config to create if it was provided', function(done) {
+      it('should pass config to create if it was provided', done => {
         const config = extend({}, AUTO_CREATE_CONFIG, {
           maxResults: 5,
         });
 
-        bucket.create = function(config_) {
+        bucket.create = config_ => {
           assert.strictEqual(config_, config);
           done();
         };
@@ -1152,21 +1152,21 @@ describe('Bucket', function() {
         bucket.get(config, assert.ifError);
       });
 
-      it('should pass only a callback to create if no config', function(done) {
-        bucket.create = function(callback) {
+      it('should pass only a callback to create if no config', done => {
+        bucket.create = callback => {
           callback(); // done()
         };
 
         bucket.get(AUTO_CREATE_CONFIG, done);
       });
 
-      describe('error', function() {
-        it('should execute callback with error & API response', function(done) {
+      describe('error', () => {
+        it('should execute callback with error & API response', done => {
           const error = new Error('Error.');
           const apiResponse = {};
 
-          bucket.create = function(callback) {
-            bucket.get = function(config, callback) {
+          bucket.create = callback => {
+            bucket.get = (config, callback) => {
               assert.deepEqual(config, {});
               callback(); // done()
             };
@@ -1174,7 +1174,7 @@ describe('Bucket', function() {
             callback(error, null, apiResponse);
           };
 
-          bucket.get(AUTO_CREATE_CONFIG, function(err, instance, resp) {
+          bucket.get(AUTO_CREATE_CONFIG, (err, instance, resp) => {
             assert.strictEqual(err, error);
             assert.strictEqual(instance, null);
             assert.strictEqual(resp, apiResponse);
@@ -1182,13 +1182,13 @@ describe('Bucket', function() {
           });
         });
 
-        it('should refresh the metadata after a 409', function(done) {
+        it('should refresh the metadata after a 409', done => {
           const error = {
             code: 409,
           };
 
-          bucket.create = function(callback) {
-            bucket.get = function(config, callback) {
+          bucket.create = callback => {
+            bucket.get = (config, callback) => {
               assert.deepEqual(config, {});
               callback(); // done()
             };
@@ -1202,9 +1202,9 @@ describe('Bucket', function() {
     });
   });
 
-  describe('getFiles', function() {
-    it('should get files without a query', function(done) {
-      bucket.request = function(reqOpts) {
+  describe('getFiles', () => {
+    it('should get files without a query', done => {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, '/o');
         assert.deepEqual(reqOpts.qs, {});
         done();
@@ -1213,61 +1213,61 @@ describe('Bucket', function() {
       bucket.getFiles(util.noop);
     });
 
-    it('should get files with a query', function(done) {
+    it('should get files with a query', done => {
       const token = 'next-page-token';
-      bucket.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {maxResults: 5, pageToken: token});
+      bucket.request = reqOpts => {
+        assert.deepEqual(reqOpts.qs, { maxResults: 5, pageToken: token });
         done();
       };
-      bucket.getFiles({maxResults: 5, pageToken: token}, util.noop);
+      bucket.getFiles({ maxResults: 5, pageToken: token }, util.noop);
     });
 
-    it('should allow setting a directory', function(done) {
+    it('should allow setting a directory', done => {
       const directory = 'directory-name';
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.prefix, `${directory}/`);
         assert.strictEqual(reqOpts.qs.directory, undefined);
         done();
       };
-      bucket.getFiles({directory}, assert.ifError);
+      bucket.getFiles({ directory }, assert.ifError);
     });
 
-    it('should strip excess slashes from a directory', function(done) {
+    it('should strip excess slashes from a directory', done => {
       const directory = 'directory-name///';
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.prefix, `directory-name/`);
         done();
       };
-      bucket.getFiles({directory}, assert.ifError);
+      bucket.getFiles({ directory }, assert.ifError);
     });
 
-    it('should return nextQuery if more results exist', function() {
+    it('should return nextQuery if more results exist', () => {
       const token = 'next-page-token';
-      bucket.request = function(reqOpts, callback) {
-        callback(null, {nextPageToken: token, items: []});
+      bucket.request = (reqOpts, callback) => {
+        callback(null, { nextPageToken: token, items: [] });
       };
-      bucket.getFiles({maxResults: 5}, function(err, results, nextQuery) {
+      bucket.getFiles({ maxResults: 5 }, (err, results, nextQuery) => {
         assert.equal(nextQuery.pageToken, token);
         assert.strictEqual(nextQuery.maxResults, 5);
       });
     });
 
-    it('should return null nextQuery if there are no more results', function() {
-      bucket.request = function(reqOpts, callback) {
-        callback(null, {items: []});
+    it('should return null nextQuery if there are no more results', () => {
+      bucket.request = (reqOpts, callback) => {
+        callback(null, { items: [] });
       };
-      bucket.getFiles({maxResults: 5}, function(err, results, nextQuery) {
+      bucket.getFiles({ maxResults: 5 }, (err, results, nextQuery) => {
         assert.strictEqual(nextQuery, null);
       });
     });
 
-    it('should return File objects', function(done) {
-      bucket.request = function(reqOpts, callback) {
+    it('should return File objects', done => {
+      bucket.request = (reqOpts, callback) => {
         callback(null, {
-          items: [{name: 'fake-file-name', generation: 1}],
+          items: [{ name: 'fake-file-name', generation: 1 }],
         });
       };
-      bucket.getFiles(function(err, files) {
+      bucket.getFiles((err, files) => {
         assert.ifError(err);
         assert(files[0] instanceof FakeFile);
         assert.equal(typeof files[0].calledWith_[2].generation, 'undefined');
@@ -1275,14 +1275,14 @@ describe('Bucket', function() {
       });
     });
 
-    it('should return versioned Files if queried for versions', function(done) {
-      bucket.request = function(reqOpts, callback) {
+    it('should return versioned Files if queried for versions', done => {
+      bucket.request = (reqOpts, callback) => {
         callback(null, {
-          items: [{name: 'fake-file-name', generation: 1}],
+          items: [{ name: 'fake-file-name', generation: 1 }],
         });
       };
 
-      bucket.getFiles({versions: true}, function(err, files) {
+      bucket.getFiles({ versions: true }, (err, files) => {
         assert.ifError(err);
         assert(files[0] instanceof FakeFile);
         assert.equal(files[0].calledWith_[2].generation, 1);
@@ -1290,42 +1290,42 @@ describe('Bucket', function() {
       });
     });
 
-    it('should set kmsKeyName on file', function(done) {
-      let kmsKeyName = 'kms-key-name';
+    it('should set kmsKeyName on file', done => {
+      const kmsKeyName = 'kms-key-name';
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(null, {
-          items: [{name: 'fake-file-name', kmsKeyName}],
+          items: [{ name: 'fake-file-name', kmsKeyName }],
         });
       };
 
-      bucket.getFiles({versions: true}, function(err, files) {
+      bucket.getFiles({ versions: true }, (err, files) => {
         assert.ifError(err);
         assert.strictEqual(files[0].calledWith_[2].kmsKeyName, kmsKeyName);
         done();
       });
     });
 
-    it('should return apiResponse in callback', function(done) {
-      const resp = {items: [{name: 'fake-file-name'}]};
-      bucket.request = function(reqOpts, callback) {
+    it('should return apiResponse in callback', done => {
+      const resp = { items: [{ name: 'fake-file-name' }] };
+      bucket.request = (reqOpts, callback) => {
         callback(null, resp);
       };
-      bucket.getFiles(function(err, files, nextQuery, apiResponse) {
+      bucket.getFiles((err, files, nextQuery, apiResponse) => {
         assert.deepEqual(resp, apiResponse);
         done();
       });
     });
 
-    it('should execute callback with error & API response', function(done) {
+    it('should execute callback with error & API response', done => {
       const error = new Error('Error.');
       const apiResponse = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(error, apiResponse);
       };
 
-      bucket.getFiles(function(err, files, nextQuery, apiResponse_) {
+      bucket.getFiles((err, files, nextQuery, apiResponse_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(files, null);
         assert.strictEqual(nextQuery, null);
@@ -1335,7 +1335,7 @@ describe('Bucket', function() {
       });
     });
 
-    it('should populate returned File object with metadata', function(done) {
+    it('should populate returned File object with metadata', done => {
       const fileMetadata = {
         name: 'filename',
         contentType: 'x-zebra',
@@ -1343,10 +1343,10 @@ describe('Bucket', function() {
           my: 'custom metadata',
         },
       };
-      bucket.request = function(reqOpts, callback) {
-        callback(null, {items: [fileMetadata]});
+      bucket.request = (reqOpts, callback) => {
+        callback(null, { items: [fileMetadata] });
       };
-      bucket.getFiles(function(err, files) {
+      bucket.getFiles((err, files) => {
         assert.ifError(err);
         assert.deepEqual(files[0].metadata, fileMetadata);
         done();
@@ -1354,19 +1354,19 @@ describe('Bucket', function() {
     });
   });
 
-  describe('getLabels', function() {
-    it('should refresh metadata', function(done) {
-      bucket.getMetadata = function() {
+  describe('getLabels', () => {
+    it('should refresh metadata', done => {
+      bucket.getMetadata = () => {
         done();
       };
 
       bucket.getLabels(assert.ifError);
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const options = {};
 
-      bucket.getMetadata = function(options_) {
+      bucket.getMetadata = options_ => {
         assert.strictEqual(options_, options);
         done();
       };
@@ -1374,45 +1374,45 @@ describe('Bucket', function() {
       bucket.getLabels(options, assert.ifError);
     });
 
-    it('should return error from getMetadata', function(done) {
+    it('should return error from getMetadata', done => {
       const error = new Error('Error.');
 
-      bucket.getMetadata = function(options, callback) {
+      bucket.getMetadata = (options, callback) => {
         callback(error);
       };
 
-      bucket.getLabels(function(err) {
+      bucket.getLabels(err => {
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should return labels metadata property', function(done) {
+    it('should return labels metadata property', done => {
       const metadata = {
         labels: {
           label: 'labelvalue',
         },
       };
 
-      bucket.getMetadata = function(options, callback) {
+      bucket.getMetadata = (options, callback) => {
         callback(null, metadata);
       };
 
-      bucket.getLabels(function(err, labels) {
+      bucket.getLabels((err, labels) => {
         assert.ifError(err);
         assert.strictEqual(labels, metadata.labels);
         done();
       });
     });
 
-    it('should return empty object if no labels exist', function(done) {
+    it('should return empty object if no labels exist', done => {
       const metadata = {};
 
-      bucket.getMetadata = function(options, callback) {
+      bucket.getMetadata = (options, callback) => {
         callback(null, metadata);
       };
 
-      bucket.getLabels(function(err, labels) {
+      bucket.getLabels((err, labels) => {
         assert.ifError(err);
         assert.deepStrictEqual(labels, {});
         done();
@@ -1420,9 +1420,9 @@ describe('Bucket', function() {
     });
   });
 
-  describe('getMetadata', function() {
-    it('should make the correct request', function(done) {
-      bucket.request = function(reqOpts) {
+  describe('getMetadata', () => {
+    it('should make the correct request', done => {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, '');
         assert.deepEqual(reqOpts.qs, {});
         done();
@@ -1431,10 +1431,10 @@ describe('Bucket', function() {
       bucket.getMetadata(assert.ifError);
     });
 
-    it('should accept options', function(done) {
+    it('should accept options', done => {
       const options = {};
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.qs, options);
         done();
       };
@@ -1442,15 +1442,15 @@ describe('Bucket', function() {
       bucket.getMetadata(options, assert.ifError);
     });
 
-    it('should execute callback with error & apiResponse', function(done) {
+    it('should execute callback with error & apiResponse', done => {
       const error = new Error('Error.');
       const apiResponse = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(error, apiResponse);
       };
 
-      bucket.getMetadata(function(err, metadata, apiResponse_) {
+      bucket.getMetadata((err, metadata, apiResponse_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(metadata, null);
         assert.strictEqual(apiResponse_, apiResponse);
@@ -1458,28 +1458,28 @@ describe('Bucket', function() {
       });
     });
 
-    it('should update metadata', function(done) {
+    it('should update metadata', done => {
       const apiResponse = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(null, apiResponse);
       };
 
-      bucket.getMetadata(function(err) {
+      bucket.getMetadata(err => {
         assert.ifError(err);
         assert.strictEqual(bucket.metadata, apiResponse);
         done();
       });
     });
 
-    it('should execute callback with metadata & API response', function(done) {
+    it('should execute callback with metadata & API response', done => {
       const apiResponse = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(null, apiResponse);
       };
 
-      bucket.getMetadata(function(err, metadata, apiResponse_) {
+      bucket.getMetadata((err, metadata, apiResponse_) => {
         assert.ifError(err);
         assert.strictEqual(metadata, apiResponse);
         assert.strictEqual(apiResponse_, apiResponse);
@@ -1488,11 +1488,11 @@ describe('Bucket', function() {
     });
   });
 
-  describe('getNotifications', function() {
-    it('should make the correct request', function(done) {
+  describe('getNotifications', () => {
+    it('should make the correct request', done => {
       const options = {};
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, '/notificationConfigs');
         assert.strictEqual(reqOpts.qs, options);
         done();
@@ -1501,8 +1501,8 @@ describe('Bucket', function() {
       bucket.getNotifications(options, assert.ifError);
     });
 
-    it('should optionally accept options', function(done) {
-      bucket.request = function(reqOpts) {
+    it('should optionally accept options', done => {
+      bucket.request = reqOpts => {
         assert.deepEqual(reqOpts.qs, {});
         done();
       };
@@ -1510,15 +1510,15 @@ describe('Bucket', function() {
       bucket.getNotifications(assert.ifError);
     });
 
-    it('should return any errors to the callback', function(done) {
+    it('should return any errors to the callback', done => {
       const error = new Error('err');
       const response = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(error, response);
       };
 
-      bucket.getNotifications(function(err, notifications, resp) {
+      bucket.getNotifications((err, notifications, resp) => {
         assert.strictEqual(err, error);
         assert.strictEqual(notifications, null);
         assert.strictEqual(resp, response);
@@ -1526,27 +1526,27 @@ describe('Bucket', function() {
       });
     });
 
-    it('should return a list of notification objects', function(done) {
-      const fakeItems = [{id: '1'}, {id: '2'}, {id: '3'}];
-      const response = {items: fakeItems};
+    it('should return a list of notification objects', done => {
+      const fakeItems = [{ id: '1' }, { id: '2' }, { id: '3' }];
+      const response = { items: fakeItems };
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(null, response);
       };
 
       let callCount = 0;
       const fakeNotifications = [{}, {}, {}];
 
-      bucket.notification = function(id) {
+      bucket.notification = id => {
         const expectedId = fakeItems[callCount].id;
         assert.strictEqual(id, expectedId);
         return fakeNotifications[callCount++];
       };
 
-      bucket.getNotifications(function(err, notifications, resp) {
+      bucket.getNotifications((err, notifications, resp) => {
         assert.ifError(err);
 
-        notifications.forEach(function(notification, i) {
+        notifications.forEach((notification, i) => {
           assert.strictEqual(notification, fakeNotifications[i]);
           assert.strictEqual(notification.metadata, fakeItems[i]);
         });
@@ -1557,27 +1557,27 @@ describe('Bucket', function() {
     });
   });
 
-  describe('makePrivate', function() {
-    it('should set predefinedAcl & privatize files', function(done) {
+  describe('makePrivate', () => {
+    it('should set predefinedAcl & privatize files', done => {
       let didSetPredefinedAcl = false;
       let didMakeFilesPrivate = false;
 
-      bucket.setMetadata = function(metadata, options, callback) {
-        assert.deepEqual(metadata, {acl: null});
-        assert.deepEqual(options, {predefinedAcl: 'projectPrivate'});
+      bucket.setMetadata = (metadata, options, callback) => {
+        assert.deepEqual(metadata, { acl: null });
+        assert.deepEqual(options, { predefinedAcl: 'projectPrivate' });
 
         didSetPredefinedAcl = true;
         callback();
       };
 
-      bucket.makeAllFilesPublicPrivate_ = function(opts, callback) {
+      bucket.makeAllFilesPublicPrivate_ = (opts, callback) => {
         assert.strictEqual(opts.private, true);
         assert.strictEqual(opts.force, true);
         didMakeFilesPrivate = true;
         callback();
       };
 
-      bucket.makePrivate({includeFiles: true, force: true}, function(err) {
+      bucket.makePrivate({ includeFiles: true, force: true }, err => {
         assert.ifError(err);
         assert(didSetPredefinedAcl);
         assert(didMakeFilesPrivate);
@@ -1585,12 +1585,12 @@ describe('Bucket', function() {
       });
     });
 
-    it('should accept userProject', function(done) {
+    it('should accept userProject', done => {
       const options = {
         userProject: 'user-project-id',
       };
 
-      bucket.setMetadata = function(metadata, options_) {
+      bucket.setMetadata = (metadata, options_) => {
         assert.strictEqual(options_.userProject, options.userProject);
         done();
       };
@@ -1598,59 +1598,59 @@ describe('Bucket', function() {
       bucket.makePrivate(options, assert.ifError);
     });
 
-    it('should not make files private by default', function(done) {
-      bucket.request = function(reqOpts, callback) {
+    it('should not make files private by default', done => {
+      bucket.request = (reqOpts, callback) => {
         callback();
       };
 
-      bucket.makeAllFilesPublicPrivate_ = function() {
+      bucket.makeAllFilesPublicPrivate_ = () => {
         throw new Error('Please, no. I do not want to be called.');
       };
 
       bucket.makePrivate(done);
     });
 
-    it('should execute callback with error', function(done) {
+    it('should execute callback with error', done => {
       const error = new Error('Error.');
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(error);
       };
 
-      bucket.makePrivate(function(err) {
+      bucket.makePrivate(err => {
         assert.equal(err, error);
         done();
       });
     });
   });
 
-  describe('makePublic', function() {
-    beforeEach(function() {
-      bucket.request = function(reqOpts, callback) {
+  describe('makePublic', () => {
+    beforeEach(() => {
+      bucket.request = (reqOpts, callback) => {
         callback();
       };
     });
 
-    it('should set ACL, default ACL, and publicize files', function(done) {
+    it('should set ACL, default ACL, and publicize files', done => {
       let didSetAcl = false;
       let didSetDefaultAcl = false;
       let didMakeFilesPublic = false;
 
-      bucket.acl.add = function(opts, callback) {
+      bucket.acl.add = (opts, callback) => {
         assert.equal(opts.entity, 'allUsers');
         assert.equal(opts.role, 'READER');
         didSetAcl = true;
         callback();
       };
 
-      bucket.acl.default.add = function(opts, callback) {
+      bucket.acl.default.add = (opts, callback) => {
         assert.equal(opts.entity, 'allUsers');
         assert.equal(opts.role, 'READER');
         didSetDefaultAcl = true;
         callback();
       };
 
-      bucket.makeAllFilesPublicPrivate_ = function(opts, callback) {
+      bucket.makeAllFilesPublicPrivate_ = (opts, callback) => {
         assert.strictEqual(opts.public, true);
         assert.strictEqual(opts.force, true);
         didMakeFilesPublic = true;
@@ -1661,8 +1661,7 @@ describe('Bucket', function() {
         {
           includeFiles: true,
           force: true,
-        },
-        function(err) {
+        }, err => {
           assert.ifError(err);
           assert(didSetAcl);
           assert(didSetDefaultAcl);
@@ -1672,44 +1671,44 @@ describe('Bucket', function() {
       );
     });
 
-    it('should not make files public by default', function(done) {
-      bucket.acl.add = function(opts, callback) {
+    it('should not make files public by default', done => {
+      bucket.acl.add = (opts, callback) => {
         callback();
       };
 
-      bucket.acl.default.add = function(opts, callback) {
+      bucket.acl.default.add = (opts, callback) => {
         callback();
       };
 
-      bucket.makeAllFilesPublicPrivate_ = function() {
+      bucket.makeAllFilesPublicPrivate_ = () => {
         throw new Error('Please, no. I do not want to be called.');
       };
 
       bucket.makePublic(done);
     });
 
-    it('should execute callback with error', function(done) {
+    it('should execute callback with error', done => {
       const error = new Error('Error.');
 
-      bucket.acl.add = function(opts, callback) {
+      bucket.acl.add = (opts, callback) => {
         callback(error);
       };
 
-      bucket.makePublic(function(err) {
+      bucket.makePublic(err => {
         assert.equal(err, error);
         done();
       });
     });
   });
 
-  describe('notification', function() {
-    it('should throw an error if an id is not provided', function() {
-      assert.throws(function() {
+  describe('notification', () => {
+    it('should throw an error if an id is not provided', () => {
+      assert.throws(() => {
         bucket.notification();
       }, /You must supply a notification ID\./);
     });
 
-    it('should return a Notification object', function() {
+    it('should return a Notification object', () => {
       const fakeId = '123';
       const notification = bucket.notification(fakeId);
 
@@ -1719,15 +1718,15 @@ describe('Bucket', function() {
     });
   });
 
-  describe('request', function() {
+  describe('request', () => {
     const USER_PROJECT = 'grape-spaceship-123';
 
-    beforeEach(function() {
+    beforeEach(() => {
       bucket.userProject = USER_PROJECT;
     });
 
-    it('should set the userProject if qs is undefined', function(done) {
-      FakeServiceObject.prototype.request = function(reqOpts) {
+    it('should set the userProject if qs is undefined', done => {
+      FakeServiceObject.prototype.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
         done();
       };
@@ -1735,14 +1734,14 @@ describe('Bucket', function() {
       bucket.request({}, assert.ifError);
     });
 
-    it('should set the userProject if field is undefined', function(done) {
+    it('should set the userProject if field is undefined', done => {
       const options = {
         qs: {
           foo: 'bar',
         },
       };
 
-      FakeServiceObject.prototype.request = function(reqOpts) {
+      FakeServiceObject.prototype.request = reqOpts => {
         assert.strictEqual(reqOpts.qs, options.qs);
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
         done();
@@ -1751,7 +1750,7 @@ describe('Bucket', function() {
       bucket.request(options, assert.ifError);
     });
 
-    it('should not overwrite the userProject', function(done) {
+    it('should not overwrite the userProject', done => {
       const fakeUserProject = 'not-grape-spaceship-123';
       const options = {
         qs: {
@@ -1759,7 +1758,7 @@ describe('Bucket', function() {
         },
       };
 
-      FakeServiceObject.prototype.request = function(reqOpts) {
+      FakeServiceObject.prototype.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, fakeUserProject);
         done();
       };
@@ -1767,10 +1766,10 @@ describe('Bucket', function() {
       bucket.request(options, assert.ifError);
     });
 
-    it('should call ServiceObject#request correctly', function(done) {
+    it('should call ServiceObject#request correctly', done => {
       const options = {};
 
-      FakeServiceObject.prototype.request = function(reqOpts, callback) {
+      FakeServiceObject.prototype.request = (reqOpts, callback) => {
         assert.strictEqual(this, bucket);
         assert.strictEqual(reqOpts, options);
         callback(); // done fn
@@ -1780,11 +1779,11 @@ describe('Bucket', function() {
     });
   });
 
-  describe('setLabels', function() {
-    it('should correctly call setMetadata', function(done) {
+  describe('setLabels', () => {
+    it('should correctly call setMetadata', done => {
       const labels = {};
 
-      bucket.setMetadata = function(metadata, options, callback) {
+      bucket.setMetadata = (metadata, options, callback) => {
         assert.strictEqual(metadata.labels, labels);
         callback(); // done()
       };
@@ -1792,11 +1791,11 @@ describe('Bucket', function() {
       bucket.setLabels(labels, done);
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const labels = {};
       const options = {};
 
-      bucket.setMetadata = function(metadata, options_) {
+      bucket.setMetadata = (metadata, options_) => {
         assert.strictEqual(options_, options);
         done();
       };
@@ -1805,11 +1804,11 @@ describe('Bucket', function() {
     });
   });
 
-  describe('setMetadata', function() {
-    it('should make the correct request', function(done) {
+  describe('setMetadata', () => {
+    it('should make the correct request', done => {
       const metadata = {};
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.method, 'PATCH');
         assert.strictEqual(reqOpts.uri, '');
         assert.strictEqual(reqOpts.json, metadata);
@@ -1820,8 +1819,8 @@ describe('Bucket', function() {
       bucket.setMetadata(metadata, assert.ifError);
     });
 
-    it('should not require a callback', function(done) {
-      bucket.request = function(reqOpts, callback) {
+    it('should not require a callback', done => {
+      bucket.request = (reqOpts, callback) => {
         assert.doesNotThrow(callback);
         done();
       };
@@ -1829,10 +1828,10 @@ describe('Bucket', function() {
       bucket.setMetadata({});
     });
 
-    it('should accept options', function(done) {
+    it('should accept options', done => {
       const options = {};
 
-      bucket.request = function(reqOpts) {
+      bucket.request = reqOpts => {
         assert.strictEqual(reqOpts.qs, options);
         done();
       };
@@ -1840,43 +1839,43 @@ describe('Bucket', function() {
       bucket.setMetadata({}, options, assert.ifError);
     });
 
-    it('should execute callback with error & apiResponse', function(done) {
+    it('should execute callback with error & apiResponse', done => {
       const error = new Error('Error.');
       const apiResponse = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(error, apiResponse);
       };
 
-      bucket.setMetadata({}, function(err, apiResponse_) {
+      bucket.setMetadata({}, (err, apiResponse_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(apiResponse_, apiResponse);
         done();
       });
     });
 
-    it('should update metadata', function(done) {
+    it('should update metadata', done => {
       const apiResponse = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(null, apiResponse);
       };
 
-      bucket.setMetadata({}, function(err) {
+      bucket.setMetadata({}, err => {
         assert.ifError(err);
         assert.strictEqual(bucket.metadata, apiResponse);
         done();
       });
     });
 
-    it('should execute callback with metadata & API response', function(done) {
+    it('should execute callback with metadata & API response', done => {
       const apiResponse = {};
 
-      bucket.request = function(reqOpts, callback) {
+      bucket.request = (reqOpts, callback) => {
         callback(null, apiResponse);
       };
 
-      bucket.setMetadata({}, function(err, apiResponse_) {
+      bucket.setMetadata({}, (err, apiResponse_) => {
         assert.ifError(err);
         assert.strictEqual(apiResponse_, apiResponse);
         done();
@@ -1884,13 +1883,13 @@ describe('Bucket', function() {
     });
   });
 
-  describe('setStorageClass', function() {
+  describe('setStorageClass', () => {
     const STORAGE_CLASS = 'NEW_STORAGE_CLASS';
     const OPTIONS = {};
     const CALLBACK = util.noop;
 
-    it('should convert camelCase to snake_case', function(done) {
-      bucket.setMetadata = function(metadata) {
+    it('should convert camelCase to snake_case', done => {
+      bucket.setMetadata = metadata => {
         assert.strictEqual(metadata.storageClass, 'CAMEL_CASE');
         done();
       };
@@ -1898,8 +1897,8 @@ describe('Bucket', function() {
       bucket.setStorageClass('camelCase', OPTIONS, CALLBACK);
     });
 
-    it('should convert hyphenate to snake_case', function(done) {
-      bucket.setMetadata = function(metadata) {
+    it('should convert hyphenate to snake_case', done => {
+      bucket.setMetadata = metadata => {
         assert.strictEqual(metadata.storageClass, 'HYPHENATED_CLASS');
         done();
       };
@@ -1907,9 +1906,9 @@ describe('Bucket', function() {
       bucket.setStorageClass('hyphenated-class', OPTIONS, CALLBACK);
     });
 
-    it('should call setMetdata correctly', function(done) {
-      bucket.setMetadata = function(metadata, options, callback) {
-        assert.deepStrictEqual(metadata, {storageClass: STORAGE_CLASS});
+    it('should call setMetdata correctly', done => {
+      bucket.setMetadata = (metadata, options, callback) => {
+        assert.deepStrictEqual(metadata, { storageClass: STORAGE_CLASS });
         assert.strictEqual(options, OPTIONS);
         assert.strictEqual(callback, CALLBACK);
         done();
@@ -1919,8 +1918,8 @@ describe('Bucket', function() {
     });
   });
 
-  describe('setUserProject', function() {
-    it('should set the userProject property', function() {
+  describe('setUserProject', () => {
+    it('should set the userProject property', () => {
       const userProject = 'grape-spaceship-123';
 
       bucket.setUserProject(userProject);
@@ -1928,7 +1927,7 @@ describe('Bucket', function() {
     });
   });
 
-  describe('upload', function() {
+  describe('upload', () => {
     const basename = 'testfile.json';
     const filepath = path.join(__dirname, '../../test/testdata/' + basename);
     const textFilepath = path.join(__dirname, '../../test/testdata/textfile.txt');
@@ -1940,35 +1939,35 @@ describe('Bucket', function() {
       },
     };
 
-    beforeEach(function() {
+    beforeEach(() => {
       requestOverride = util.noop;
-      requestOverride.get = function() {
+      requestOverride.get = () => {
         const requestStream = through();
 
-        setImmediate(function() {
+        setImmediate(() => {
           requestStream.end();
         });
 
         return requestStream;
       };
-      requestOverride.head = function(uri, callback) {
-        callback(null, {headers: {}});
+      requestOverride.head = (uri, callback) => {
+        callback(null, { headers: {} });
       };
 
-      bucket.file = function(name, metadata) {
+      bucket.file = (name, metadata) => {
         return new FakeFile(bucket, name, metadata);
       };
     });
 
-    it('should return early in snippet sandbox', function() {
+    it('should return early in snippet sandbox', () => {
       (global as any).GCLOUD_SANDBOX_ENV = true;
       const returnValue = bucket.upload(filepath, assert.ifError);
       delete (global as any).GCLOUD_SANDBOX_ENV;
       assert.strictEqual(returnValue, undefined);
     });
 
-    it('should accept a path & cb', function(done) {
-      bucket.upload(filepath, function(err, file) {
+    it('should accept a path & cb', done => {
+      bucket.upload(filepath, (err, file) => {
         assert.ifError(err);
         assert.equal(file.bucket.name, bucket.name);
         assert.equal(file.name, basename);
@@ -1976,8 +1975,8 @@ describe('Bucket', function() {
       });
     });
 
-    it('should accept a url path & cb', function(done) {
-      bucket.upload(urlPath, function(err, file) {
+    it('should accept a url path & cb', done => {
+      bucket.upload(urlPath, (err, file) => {
         assert.ifError(err);
         assert.equal(file.bucket.name, bucket.name);
         assert.equal(file.name, path.basename(urlPath));
@@ -1985,8 +1984,8 @@ describe('Bucket', function() {
       });
     });
 
-    it('should accept a url, custom request options & cb', function(done) {
-      requestOverride.get = function(options) {
+    it('should accept a url, custom request options & cb', done => {
+      requestOverride.get = options => {
         assert.deepEqual(options, {
           url: urlPath,
           followAllRedirects: true,
@@ -2004,13 +2003,13 @@ describe('Bucket', function() {
       bucket.upload(urlPath, options, assert.ifError);
     });
 
-    it('should accept a path, metadata, & cb', function(done) {
+    it('should accept a path, metadata, & cb', done => {
       const options = {
         metadata,
         encryptionKey: 'key',
         kmsKeyName: 'kms-key-name',
       };
-      bucket.upload(filepath, options, function(err, file) {
+      bucket.upload(filepath, options, (err, file) => {
         assert.ifError(err);
         assert.equal(file.bucket.name, bucket.name);
         assert.deepEqual(file.metadata, metadata);
@@ -2020,14 +2019,14 @@ describe('Bucket', function() {
       });
     });
 
-    it('should accept a path, a string dest, & cb', function(done) {
+    it('should accept a path, a string dest, & cb', done => {
       const newFileName = 'new-file-name.png';
       const options = {
         destination: newFileName,
         encryptionKey: 'key',
         kmsKeyName: 'kms-key-name',
       };
-      bucket.upload(filepath, options, function(err, file) {
+      bucket.upload(filepath, options, (err, file) => {
         assert.ifError(err);
         assert.equal(file.bucket.name, bucket.name);
         assert.equal(file.name, newFileName);
@@ -2037,7 +2036,7 @@ describe('Bucket', function() {
       });
     });
 
-    it('should accept a path, a string dest, metadata, & cb', function(done) {
+    it('should accept a path, a string dest, metadata, & cb', done => {
       const newFileName = 'new-file-name.png';
       const options = {
         destination: newFileName,
@@ -2045,7 +2044,7 @@ describe('Bucket', function() {
         encryptionKey: 'key',
         kmsKeyName: 'kms-key-name',
       };
-      bucket.upload(filepath, options, function(err, file) {
+      bucket.upload(filepath, options, (err, file) => {
         assert.ifError(err);
         assert.equal(file.bucket.name, bucket.name);
         assert.equal(file.name, newFileName);
@@ -2056,26 +2055,26 @@ describe('Bucket', function() {
       });
     });
 
-    it('should accept a path, a File dest, & cb', function(done) {
+    it('should accept a path, a File dest, & cb', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      fakeFile.isSameFile = function() {
+      fakeFile.isSameFile = () => {
         return true;
       };
-      const options = {destination: fakeFile};
-      bucket.upload(filepath, options, function(err, file) {
+      const options = { destination: fakeFile };
+      bucket.upload(filepath, options, (err, file) => {
         assert.ifError(err);
         assert(file.isSameFile());
         done();
       });
     });
 
-    it('should accept a path, a File dest, metadata, & cb', function(done) {
+    it('should accept a path, a File dest, metadata, & cb', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      fakeFile.isSameFile = function() {
+      fakeFile.isSameFile = () => {
         return true;
       };
-      const options = {destination: fakeFile, metadata};
-      bucket.upload(filepath, options, function(err, file) {
+      const options = { destination: fakeFile, metadata };
+      bucket.upload(filepath, options, (err, file) => {
         assert.ifError(err);
         assert(file.isSameFile());
         assert.deepEqual(file.metadata, metadata);
@@ -2083,33 +2082,33 @@ describe('Bucket', function() {
       });
     });
 
-    it('should execute callback with error if file not found', function(done) {
-      bucket.upload('./not-real-file.json', function(err) {
+    it('should execute callback with error if file not found', done => {
+      bucket.upload('./not-real-file.json', err => {
         assert.strictEqual(err.code, 'ENOENT');
         done();
       });
     });
 
-    it('should execute callback with error if url not found', function(done) {
+    it('should execute callback with error if url not found', done => {
       const error = new Error('Error.');
 
-      requestOverride.head = function(url, callback) {
+      requestOverride.head = (url, callback) => {
         callback(error);
       };
 
-      bucket.upload('http://not-real-url', function(err) {
+      bucket.upload('http://not-real-url', err => {
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should guess at the content type', function(done) {
+    it('should guess at the content type', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      const options = {destination: fakeFile};
-      fakeFile.createWriteStream = function(options) {
+      const options = { destination: fakeFile };
+      fakeFile.createWriteStream = options => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           const expectedContentType = 'application/json; charset=utf-8';
           assert.equal(options.metadata.contentType, expectedContentType);
           done();
@@ -2119,13 +2118,13 @@ describe('Bucket', function() {
       bucket.upload(filepath, options, assert.ifError);
     });
 
-    it('should guess at the charset', function(done) {
+    it('should guess at the charset', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      const options = {destination: fakeFile};
-      fakeFile.createWriteStream = function(options) {
+      const options = { destination: fakeFile };
+      fakeFile.createWriteStream = options => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           const expectedContentType = 'text/plain; charset=utf-8';
           assert.equal(options.metadata.contentType, expectedContentType);
           done();
@@ -2135,13 +2134,13 @@ describe('Bucket', function() {
       bucket.upload(textFilepath, options, assert.ifError);
     });
 
-    it('should force a resumable upload', function(done) {
+    it('should force a resumable upload', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      const options = {destination: fakeFile, resumable: true};
-      fakeFile.createWriteStream = function(options_) {
+      const options = { destination: fakeFile, resumable: true };
+      fakeFile.createWriteStream = options_ => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           assert.strictEqual(options_.resumable, options.resumable);
           done();
         });
@@ -2150,13 +2149,13 @@ describe('Bucket', function() {
       bucket.upload(filepath, options, assert.ifError);
     });
 
-    it('should force a resumable upload with url', function(done) {
+    it('should force a resumable upload with url', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      const options = {destination: fakeFile, resumable: true};
-      fakeFile.createWriteStream = function(options_) {
+      const options = { destination: fakeFile, resumable: true };
+      fakeFile.createWriteStream = options_ => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           assert.strictEqual(options_.resumable, options.resumable);
           done();
         });
@@ -2165,8 +2164,8 @@ describe('Bucket', function() {
       bucket.upload(urlPath, options, assert.ifError);
     });
 
-    it('should set resumable to true from contentLength', function(done) {
-      requestOverride.head = function(url, callback) {
+    it('should set resumable to true from contentLength', done => {
+      requestOverride.head = (url, callback) => {
         callback(null, {
           headers: {
             'content-length': 5000001,
@@ -2175,21 +2174,21 @@ describe('Bucket', function() {
       };
 
       const fakeFile = new FakeFile(bucket, 'file-name');
-      fakeFile.createWriteStream = function(options) {
+      fakeFile.createWriteStream = options => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           assert.strictEqual(options.resumable, true);
           done();
         });
         return ws;
       };
 
-      bucket.upload(urlPath, {destination: fakeFile}, assert.ifError);
+      bucket.upload(urlPath, { destination: fakeFile }, assert.ifError);
     });
 
-    it('should set resumable to false from contentLength', function(done) {
-      requestOverride.head = function(url, callback) {
+    it('should set resumable to false from contentLength', done => {
+      requestOverride.head = (url, callback) => {
         callback(null, {
           headers: {
             'content-length': 1001,
@@ -2198,27 +2197,27 @@ describe('Bucket', function() {
       };
 
       const fakeFile = new FakeFile(bucket, 'file-name');
-      fakeFile.createWriteStream = function(options) {
+      fakeFile.createWriteStream = options => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           assert.strictEqual(options.resumable, false);
           done();
         });
         return ws;
       };
 
-      bucket.upload(urlPath, {destination: fakeFile}, assert.ifError);
+      bucket.upload(urlPath, { destination: fakeFile }, assert.ifError);
     });
 
-    it('should allow overriding content type', function(done) {
+    it('should allow overriding content type', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      const metadata = {contentType: 'made-up-content-type'};
-      const options = {destination: fakeFile, metadata};
-      fakeFile.createWriteStream = function(options) {
+      const metadata = { contentType: 'made-up-content-type' };
+      const options = { destination: fakeFile, metadata };
+      fakeFile.createWriteStream = options => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           assert.equal(options.metadata.contentType, metadata.contentType);
           done();
         });
@@ -2227,17 +2226,17 @@ describe('Bucket', function() {
       bucket.upload(filepath, options, assert.ifError);
     });
 
-    it('should pass provided options to createWriteStream', function(done) {
+    it('should pass provided options to createWriteStream', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
       const options = {
         destination: fakeFile,
         a: 'b',
         c: 'd',
       };
-      fakeFile.createWriteStream = function(options_) {
+      fakeFile.createWriteStream = options_ => {
         const ws = new stream.Writable();
         (ws as any).write = util.noop;
-        setImmediate(function() {
+        setImmediate(() => {
           assert.strictEqual(options_.a, options.a);
           assert.strictEqual(options_.c, options.c);
           done();
@@ -2247,38 +2246,38 @@ describe('Bucket', function() {
       bucket.upload(filepath, options, assert.ifError);
     });
 
-    it('should execute callback on error', function(done) {
+    it('should execute callback on error', done => {
       const error = new Error('Error.');
       const fakeFile = new FakeFile(bucket, 'file-name');
-      const options = {destination: fakeFile};
-      fakeFile.createWriteStream = function() {
+      const options = { destination: fakeFile };
+      fakeFile.createWriteStream = () => {
         const ws = through();
-        setImmediate(function() {
+        setImmediate(() => {
           ws.destroy(error);
         });
         return ws;
       };
-      bucket.upload(filepath, options, function(err) {
+      bucket.upload(filepath, options, err => {
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should return file and metadata', function(done) {
+    it('should return file and metadata', done => {
       const fakeFile = new FakeFile(bucket, 'file-name');
-      const options = {destination: fakeFile};
+      const options = { destination: fakeFile };
       const metadata = {};
 
-      fakeFile.createWriteStream = function() {
+      fakeFile.createWriteStream = () => {
         const ws = through();
-        setImmediate(function() {
+        setImmediate(() => {
           fakeFile.metadata = metadata;
           ws.end();
         });
         return ws;
       };
 
-      bucket.upload(filepath, options, function(err, file, apiResponse) {
+      bucket.upload(filepath, options, (err, file, apiResponse) => {
         assert.ifError(err);
         assert.strictEqual(file, fakeFile);
         assert.strictEqual(apiResponse, metadata);
@@ -2287,11 +2286,11 @@ describe('Bucket', function() {
     });
   });
 
-  describe('makeAllFilesPublicPrivate_', function() {
-    it('should get all files from the bucket', function(done) {
+  describe('makeAllFilesPublicPrivate_', () => {
+    it('should get all files from the bucket', done => {
       const options = {};
 
-      bucket.getFiles = function(options_) {
+      bucket.getFiles = options_ => {
         assert.strictEqual(options_, options);
         done();
       };
@@ -2299,106 +2298,106 @@ describe('Bucket', function() {
       bucket.makeAllFilesPublicPrivate_(options, assert.ifError);
     });
 
-    it('should process 10 files at a time', function(done) {
-      eachLimitOverride = function(arr, limit) {
+    it('should process 10 files at a time', done => {
+      eachLimitOverride = (arr, limit) => {
         assert.equal(limit, 10);
         done();
       };
 
-      bucket.getFiles = function(options, callback) {
+      bucket.getFiles = (options, callback) => {
         callback(null, []);
       };
 
       bucket.makeAllFilesPublicPrivate_({}, assert.ifError);
     });
 
-    it('should make files public', function(done) {
+    it('should make files public', done => {
       let timesCalled = 0;
 
       const files = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('makePublic', function(callback) {
+        propAssign('makePublic', callback => {
           timesCalled++;
           callback();
         })
       );
 
-      bucket.getFiles = function(options, callback) {
+      bucket.getFiles = (options, callback) => {
         callback(null, files);
       };
 
-      bucket.makeAllFilesPublicPrivate_({public: true}, function(err) {
+      bucket.makeAllFilesPublicPrivate_({ public: true }, err => {
         assert.ifError(err);
         assert.equal(timesCalled, files.length);
         done();
       });
     });
 
-    it('should make files private', function(done) {
+    it('should make files private', done => {
       const options = {
         private: true,
       };
       let timesCalled = 0;
 
       const files = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('makePrivate', function(options_, callback) {
+        propAssign('makePrivate', (options_, callback) => {
           timesCalled++;
           callback();
         })
       );
 
-      bucket.getFiles = function(options_, callback) {
+      bucket.getFiles = (options_, callback) => {
         callback(null, files);
       };
 
-      bucket.makeAllFilesPublicPrivate_(options, function(err) {
+      bucket.makeAllFilesPublicPrivate_(options, err => {
         assert.ifError(err);
         assert.equal(timesCalled, files.length);
         done();
       });
     });
 
-    it('should execute callback with error from getting files', function(done) {
+    it('should execute callback with error from getting files', done => {
       const error = new Error('Error.');
 
-      bucket.getFiles = function(options, callback) {
+      bucket.getFiles = (options, callback) => {
         callback(error);
       };
 
-      bucket.makeAllFilesPublicPrivate_({}, function(err) {
+      bucket.makeAllFilesPublicPrivate_({}, err => {
         assert.equal(err, error);
         done();
       });
     });
 
-    it('should execute callback with error from changing file', function(done) {
+    it('should execute callback with error from changing file', done => {
       const error = new Error('Error.');
 
       const files = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('makePublic', function(callback) {
+        propAssign('makePublic', callback => {
           callback(error);
         })
       );
 
-      bucket.getFiles = function(options, callback) {
+      bucket.getFiles = (options, callback) => {
         callback(null, files);
       };
 
-      bucket.makeAllFilesPublicPrivate_({public: true}, function(err) {
+      bucket.makeAllFilesPublicPrivate_({ public: true }, err => {
         assert.equal(err, error);
         done();
       });
     });
 
-    it('should execute callback with queued errors', function(done) {
+    it('should execute callback with queued errors', done => {
       const error = new Error('Error.');
 
       const files = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('makePublic', function(callback) {
+        propAssign('makePublic', callback => {
           callback(error);
         })
       );
 
-      bucket.getFiles = function(options, callback) {
+      bucket.getFiles = (options, callback) => {
         callback(null, files);
       };
 
@@ -2406,30 +2405,29 @@ describe('Bucket', function() {
         {
           public: true,
           force: true,
-        },
-        function(errs) {
+        }, errs => {
           assert.deepEqual(errs, [error, error]);
           done();
         }
       );
     });
 
-    it('should execute callback with files changed', function(done) {
+    it('should execute callback with files changed', done => {
       const error = new Error('Error.');
 
       const successFiles = [bucket.file('1'), bucket.file('2')].map(
-        propAssign('makePublic', function(callback) {
+        propAssign('makePublic', callback => {
           callback();
         })
       );
 
       const errorFiles = [bucket.file('3'), bucket.file('4')].map(
-        propAssign('makePublic', function(callback) {
+        propAssign('makePublic', callback => {
           callback(error);
         })
       );
 
-      bucket.getFiles = function(options, callback) {
+      bucket.getFiles = (options, callback) => {
         callback(null, successFiles.concat(errorFiles));
       };
 
@@ -2438,7 +2436,7 @@ describe('Bucket', function() {
           public: true,
           force: true,
         },
-        function(errs, files) {
+        (errs, files) => {
           assert.deepEqual(errs, [error, error]);
           assert.deepEqual(files, successFiles);
           done();

--- a/test/channel.ts
+++ b/test/channel.ts
@@ -24,7 +24,7 @@ import assert from 'assert';
 import extend from 'extend';
 import nodeutil from 'util';
 import proxyquire from 'proxyquire';
-import {ServiceObject, util} from '@google-cloud/common';
+import { ServiceObject, util } from '@google-cloud/common';
 
 let promisified = false;
 const fakeUtil = extend({}, util, {
@@ -42,7 +42,7 @@ function FakeServiceObject() {
 
 nodeutil.inherits(FakeServiceObject, ServiceObject);
 
-describe('Channel', function() {
+describe('Channel', () => {
   const STORAGE = {};
   const ID = 'channel-id';
   const RESOURCE_ID = 'resource-id';
@@ -50,7 +50,7 @@ describe('Channel', function() {
   let Channel;
   let channel;
 
-  before(function() {
+  before(() => {
     Channel = proxyquire('../src/channel.js', {
       '@google-cloud/common': {
         ServiceObject: FakeServiceObject,
@@ -59,12 +59,12 @@ describe('Channel', function() {
     }).Channel;
   });
 
-  beforeEach(function() {
+  beforeEach(() => {
     channel = new Channel(STORAGE, ID, RESOURCE_ID);
   });
 
-  describe('initialization', function() {
-    it('should inherit from ServiceObject', function() {
+  describe('initialization', () => {
+    it('should inherit from ServiceObject', () => {
       assert(channel instanceof ServiceObject);
 
       const calledWith = channel.calledWith_[0];
@@ -75,11 +75,11 @@ describe('Channel', function() {
       assert.deepEqual(calledWith.methods, {});
     });
 
-    it('should promisify all the things', function() {
+    it('should promisify all the things', () => {
       assert(promisified);
     });
 
-    it('should set the default metadata', function() {
+    it('should set the default metadata', () => {
       assert.deepEqual(channel.metadata, {
         id: ID,
         resourceId: RESOURCE_ID,
@@ -87,9 +87,9 @@ describe('Channel', function() {
     });
   });
 
-  describe('stop', function() {
-    it('should make the correct request', function(done) {
-      channel.request = function(reqOpts) {
+  describe('stop', () => {
+    it('should make the correct request', done => {
+      channel.request = reqOpts => {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/stop');
         assert.strictEqual(reqOpts.json, channel.metadata);
@@ -100,23 +100,23 @@ describe('Channel', function() {
       channel.stop(assert.ifError);
     });
 
-    it('should execute callback with error & API response', function(done) {
+    it('should execute callback with error & API response', done => {
       const error = {};
       const apiResponse = {};
 
-      channel.request = function(reqOpts, callback) {
+      channel.request = (reqOpts, callback) => {
         callback(error, apiResponse);
       };
 
-      channel.stop(function(err, apiResponse_) {
+      channel.stop((err, apiResponse_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(apiResponse_, apiResponse);
         done();
       });
     });
 
-    it('should not require a callback', function(done) {
-      channel.request = function(reqOpts, callback) {
+    it('should not require a callback', done => {
+      channel.request = (reqOpts, callback) => {
         assert.doesNotThrow(callback);
         done();
       };

--- a/test/file.ts
+++ b/test/file.ts
@@ -32,7 +32,7 @@ import url from 'url';
 import { ServiceObject, util } from '@google-cloud/common';
 import zlib from 'zlib';
 
-const {Bucket} = require('../src/bucket.js');
+const { Bucket } = require('../src/bucket.js');
 
 let promisified = false;
 let makeWritableStreamOverride;
@@ -66,7 +66,7 @@ let requestOverride;
 function fakeRequest() {
   return (requestOverride || requestCached).apply(null, arguments);
 }
-(fakeRequest as any).defaults = function(defaultConfiguration) {
+(fakeRequest as any).defaults = defaultConfiguration => {
   // Ignore the default values, so we don't have to test for them in every API
   // call.
   REQUEST_DEFAULT_CONF = defaultConfiguration;
@@ -92,7 +92,7 @@ function fakeResumableUpload() {
     return resumableUploadOverride || resumableUpload;
   };
 }
-(fakeResumableUpload as any).createURI = function() {
+(fakeResumableUpload as any).createURI = () => {
   let createURI = resumableUpload.createURI;
 
   if (resumableUploadOverride && resumableUploadOverride.createURI) {
@@ -101,7 +101,7 @@ function fakeResumableUpload() {
 
   return createURI.apply(null, arguments);
 };
-(fakeResumableUpload as any).upload = function() {
+(fakeResumableUpload as any).upload = () => {
   let upload = resumableUpload.upload;
   if (resumableUploadOverride && resumableUploadOverride.upload) {
     upload = resumableUploadOverride.upload;
@@ -127,7 +127,7 @@ Object.defineProperty(fakeXdgBasedir, 'config', {
   },
 });
 
-describe('File', function() {
+describe('File', () => {
   let File;
   let file;
 
@@ -137,7 +137,7 @@ describe('File', function() {
   let STORAGE;
   let BUCKET;
 
-  before(function() {
+  before(() => {
     File = proxyquire('../src/file.js', {
       '@google-cloud/common': {
         ServiceObject: FakeServiceObject,
@@ -155,7 +155,7 @@ describe('File', function() {
     duplexify = require('duplexify');
   });
 
-  beforeEach(function() {
+  beforeEach(() => {
     extend(true, fakeFs, fsCached);
     extend(true, fakeOs, osCached);
     xdgConfigOverride = null;
@@ -189,47 +189,47 @@ describe('File', function() {
     resumableUploadOverride = null;
   });
 
-  describe('initialization', function() {
-    it('should promisify all the things', function() {
+  describe('initialization', () => {
+    it('should promisify all the things', () => {
       assert(promisified);
     });
 
-    it('should assign file name', function() {
+    it('should assign file name', () => {
       assert.equal(file.name, FILE_NAME);
     });
 
-    it('should assign the bucket instance', function() {
+    it('should assign the bucket instance', () => {
       assert.strictEqual(file.bucket, BUCKET);
     });
 
-    it('should assign the storage instance', function() {
+    it('should assign the storage instance', () => {
       assert.strictEqual(file.storage, BUCKET.storage);
     });
 
-    it('should strip a single leading slash', function() {
+    it('should strip a single leading slash', () => {
       const file = new File(BUCKET, '/name');
       assert.strictEqual(file.name, 'name');
     });
 
-    it('should assign KMS key name', function() {
+    it('should assign KMS key name', () => {
       const kmsKeyName = 'kms-key-name';
-      const file = new File(BUCKET, '/name', {kmsKeyName});
+      const file = new File(BUCKET, '/name', { kmsKeyName });
       assert.strictEqual(file.kmsKeyName, kmsKeyName);
     });
 
-    it('should accept specifying a generation', function() {
-      const file = new File(BUCKET, 'name', {generation: 2});
+    it('should accept specifying a generation', () => {
+      const file = new File(BUCKET, 'name', { generation: 2 });
       assert.equal(file.generation, 2);
     });
 
-    it('should build a requestQueryObject from generation', function() {
-      const file = new File(BUCKET, 'name', {generation: 2});
+    it('should build a requestQueryObject from generation', () => {
+      const file = new File(BUCKET, 'name', { generation: 2 });
       assert.deepStrictEqual(file.requestQueryObject, {
         generation: 2,
       });
     });
 
-    it('should inherit from ServiceObject', function() {
+    it('should inherit from ServiceObject', () => {
       assert(file instanceof ServiceObject);
 
       const calledWith = file.calledWith_[0];
@@ -239,30 +239,30 @@ describe('File', function() {
       assert.strictEqual(calledWith.id, encodeURIComponent(FILE_NAME));
     });
 
-    it('should use stripped leading slash name in ServiceObject', function() {
+    it('should use stripped leading slash name in ServiceObject', () => {
       const file = new File(BUCKET, '/name');
       const calledWith = file.calledWith_[0];
 
       assert.strictEqual(calledWith.id, 'name');
     });
 
-    it('should set a custom encryption key', function(done) {
+    it('should set a custom encryption key', done => {
       const key = 'key';
 
       const setEncryptionKey = File.prototype.setEncryptionKey;
-      File.prototype.setEncryptionKey = function(key_) {
+      File.prototype.setEncryptionKey = key_ => {
         File.prototype.setEncryptionKey = setEncryptionKey;
         assert.strictEqual(key_, key);
         done();
       };
 
-      new File(BUCKET, FILE_NAME, {encryptionKey: key});
+      new File(BUCKET, FILE_NAME, { encryptionKey: key });
     });
 
-    describe('userProject', function() {
+    describe('userProject', () => {
       const USER_PROJECT = 'grapce-spaceship-123';
 
-      it('should localize the Bucket#userProject', function() {
+      it('should localize the Bucket#userProject', () => {
         const bucket = new Bucket(STORAGE, 'bucket-name', {
           userProject: USER_PROJECT,
         });
@@ -271,7 +271,7 @@ describe('File', function() {
         assert.strictEqual(file.userProject, USER_PROJECT);
       });
 
-      it('should accept a userProject option', function() {
+      it('should accept a userProject option', () => {
         const file = new File(BUCKET, '/name', {
           userProject: USER_PROJECT,
         });
@@ -281,21 +281,21 @@ describe('File', function() {
     });
   });
 
-  describe('copy', function() {
-    it('should throw if no destination is provided', function() {
-      assert.throws(function() {
+  describe('copy', () => {
+    it('should throw if no destination is provided', () => {
+      assert.throws(() => {
         file.copy();
       }, /Destination file should have a name\./);
     });
 
-    it('should URI encode file names', function(done) {
+    it('should URI encode file names', done => {
       const newFile = new File(BUCKET, 'nested/file.jpg');
 
       const expectedPath = `/rewriteTo/b/${
         file.bucket.name
-      }/o/${encodeURIComponent(newFile.name)}`;
+        }/o/${encodeURIComponent(newFile.name)}`;
 
-      directoryFile.request = function(reqOpts) {
+      directoryFile.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, expectedPath);
         done();
       };
@@ -303,17 +303,17 @@ describe('File', function() {
       directoryFile.copy(newFile);
     });
 
-    it('should execute callback with error & API response', function(done) {
+    it('should execute callback with error & API response', done => {
       const error = new Error('Error.');
       const apiResponse = {};
 
       const newFile = new File(BUCKET, 'new-file');
 
-      file.request = function(reqOpts, callback) {
+      file.request = (reqOpts, callback) => {
         callback(error, apiResponse);
       };
 
-      file.copy(newFile, function(err, file, apiResponse_) {
+      file.copy(newFile, (err, file, apiResponse_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(file, null);
         assert.strictEqual(apiResponse_, apiResponse);
@@ -322,11 +322,11 @@ describe('File', function() {
       });
     });
 
-    it('should send query.sourceGeneration if File has one', function(done) {
-      const versionedFile = new File(BUCKET, 'name', {generation: 1});
+    it('should send query.sourceGeneration if File has one', done => {
+      const versionedFile = new File(BUCKET, 'name', { generation: 1 });
       const newFile = new File(BUCKET, 'new-file');
 
-      versionedFile.request = function(reqOpts) {
+      versionedFile.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.sourceGeneration, 1);
         done();
       };
@@ -334,13 +334,13 @@ describe('File', function() {
       versionedFile.copy(newFile, assert.ifError);
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const newFile = new File(BUCKET, 'name');
       const options = {
         option: true,
       };
 
-      file.request = function(reqOpts) {
+      file.request = reqOpts => {
         assert.deepStrictEqual(reqOpts.json, options);
         done();
       };
@@ -348,14 +348,14 @@ describe('File', function() {
       file.copy(newFile, options, assert.ifError);
     });
 
-    it('should pass through userProject', function(done) {
+    it('should pass through userProject', done => {
       const options = {
         userProject: 'user-project',
       };
       const originalOptions = extend({}, options);
       const newFile = new File(BUCKET, 'new-file');
 
-      file.request = function(reqOpts) {
+      file.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         assert.strictEqual(reqOpts.json.userProject, undefined);
         assert.deepStrictEqual(options, originalOptions);
@@ -365,14 +365,14 @@ describe('File', function() {
       file.copy(newFile, options, assert.ifError);
     });
 
-    it('should set correct headers when file is encrypted', function(done) {
+    it('should set correct headers when file is encrypted', done => {
       file.encryptionKey = {};
       file.encryptionKeyBase64 = 'base64';
       file.encryptionKeyHash = 'hash';
 
       const newFile = new File(BUCKET, 'new-file');
 
-      file.request = function(reqOpts) {
+      file.request = reqOpts => {
         assert.deepStrictEqual(reqOpts.headers, {
           'x-goog-copy-source-encryption-algorithm': 'AES256',
           'x-goog-copy-source-encryption-key': file.encryptionKeyBase64,
@@ -384,11 +384,11 @@ describe('File', function() {
       file.copy(newFile, assert.ifError);
     });
 
-    it('should set encryption key on the new File instance', function(done) {
+    it('should set encryption key on the new File instance', done => {
       const newFile = new File(BUCKET, 'new-file');
       newFile.encryptionKey = 'encryptionKey';
 
-      file.setEncryptionKey = function(encryptionKey) {
+      file.setEncryptionKey = encryptionKey => {
         assert.strictEqual(encryptionKey, newFile.encryptionKey);
         done();
       };
@@ -396,11 +396,11 @@ describe('File', function() {
       file.copy(newFile, assert.ifError);
     });
 
-    it('should set destination KMS key name', function(done) {
+    it('should set destination KMS key name', done => {
       const newFile = new File(BUCKET, 'new-file');
       newFile.kmsKeyName = 'kms-key-name';
 
-      file.request = function(reqOpts) {
+      file.request = reqOpts => {
         assert.strictEqual(
           reqOpts.qs.destinationKmsKeyName,
           newFile.kmsKeyName
@@ -412,11 +412,11 @@ describe('File', function() {
       file.copy(newFile, assert.ifError);
     });
 
-    it('should set destination KMS key name from option', function(done) {
+    it('should set destination KMS key name from option', done => {
       const newFile = new File(BUCKET, 'new-file');
       const destinationKmsKeyName = 'destination-kms-key-name';
 
-      file.request = function(reqOpts) {
+      file.request = reqOpts => {
         assert.strictEqual(
           reqOpts.qs.destinationKmsKeyName,
           destinationKmsKeyName
@@ -425,15 +425,15 @@ describe('File', function() {
         done();
       };
 
-      file.copy(newFile, {destinationKmsKeyName}, assert.ifError);
+      file.copy(newFile, { destinationKmsKeyName }, assert.ifError);
     });
 
-    it('should favor the option over the File KMS name', function(done) {
+    it('should favor the option over the File KMS name', done => {
       const newFile = new File(BUCKET, 'new-file');
       newFile.kmsKeyName = 'incorrect-kms-key-name';
       const destinationKmsKeyName = 'correct-kms-key-name';
 
-      file.request = function(reqOpts) {
+      file.request = reqOpts => {
         assert.strictEqual(
           reqOpts.qs.destinationKmsKeyName,
           destinationKmsKeyName
@@ -442,87 +442,87 @@ describe('File', function() {
         done();
       };
 
-      file.copy(newFile, {destinationKmsKeyName}, assert.ifError);
+      file.copy(newFile, { destinationKmsKeyName }, assert.ifError);
     });
 
-    it('should remove custom encryption interceptor if rotating to KMS', function(done) {
+    it('should remove custom encryption interceptor if rotating to KMS', done => {
       const newFile = new File(BUCKET, 'new-file');
       const destinationKmsKeyName = 'correct-kms-key-name';
 
       file.encryptionKeyInterceptor = {};
       file.interceptors = [{}, file.encryptionKeyInterceptor, {}];
 
-      file.request = function() {
+      file.request = () => {
         assert.strictEqual(file.interceptors.length, 2);
         assert(file.interceptors.indexOf(file.encryptionKeyInterceptor) === -1);
         done();
       };
 
-      file.copy(newFile, {destinationKmsKeyName}, assert.ifError);
+      file.copy(newFile, { destinationKmsKeyName }, assert.ifError);
     });
 
-    describe('destination types', function() {
+    describe('destination types', () => {
       function assertPathEquals(file, expectedPath, callback) {
-        file.request = function(reqOpts) {
+        file.request = reqOpts => {
           assert.strictEqual(reqOpts.uri, expectedPath);
           callback();
         };
       }
 
-      it('should allow a string', function(done) {
+      it('should allow a string', done => {
         const newFileName = 'new-file-name.png';
         const expectedPath = `/rewriteTo/b/${
           file.bucket.name
-        }/o/${newFileName}`;
+          }/o/${newFileName}`;
         assertPathEquals(file, expectedPath, done);
         file.copy(newFileName);
       });
 
-      it('should allow a "gs://..." string', function(done) {
+      it('should allow a "gs://..." string', done => {
         const newFileName = 'gs://other-bucket/new-file-name.png';
         const expectedPath = `/rewriteTo/b/other-bucket/o/new-file-name.png`;
         assertPathEquals(file, expectedPath, done);
         file.copy(newFileName);
       });
 
-      it('should allow a Bucket', function(done) {
+      it('should allow a Bucket', done => {
         const expectedPath = `/rewriteTo/b/${BUCKET.name}/o/${file.name}`;
         assertPathEquals(file, expectedPath, done);
         file.copy(BUCKET);
       });
 
-      it('should allow a File', function(done) {
+      it('should allow a File', done => {
         const newFile = new File(BUCKET, 'new-file');
         const expectedPath = `/rewriteTo/b/${BUCKET.name}/o/${newFile.name}`;
         assertPathEquals(file, expectedPath, done);
         file.copy(newFile);
       });
 
-      it('should throw if a destination cannot be parsed', function() {
-        assert.throws(function() {
-          file.copy(function() {});
+      it('should throw if a destination cannot be parsed', () => {
+        assert.throws(() => {
+          file.copy(() => { });
         }, /Destination file should have a name\./);
       });
     });
 
-    describe('not finished copying', function() {
+    describe('not finished copying', () => {
       const apiResponse = {
         rewriteToken: '...',
       };
 
-      beforeEach(function() {
-        file.request = function(reqOpts, callback) {
+      beforeEach(() => {
+        file.request = (reqOpts, callback) => {
           callback(null, apiResponse);
         };
       });
 
-      it('should continue attempting to copy', function(done) {
+      it('should continue attempting to copy', done => {
         const newFile = new File(BUCKET, 'new-file');
 
-        file.request = function(reqOpts, callback) {
-          file.copy = function(newFile_, options, callback) {
+        file.request = (reqOpts, callback) => {
+          file.copy = (newFile_, options, callback) => {
             assert.strictEqual(newFile_, newFile);
-            assert.deepEqual(options, {token: apiResponse.rewriteToken});
+            assert.deepEqual(options, { token: apiResponse.rewriteToken });
             callback(); // done()
           };
 
@@ -532,14 +532,14 @@ describe('File', function() {
         file.copy(newFile, done);
       });
 
-      it('should pass the userProject in subsequent requests', function(done) {
+      it('should pass the userProject in subsequent requests', done => {
         const newFile = new File(BUCKET, 'new-file');
         const fakeOptions = {
           userProject: 'grapce-spaceship-123',
         };
 
-        file.request = function(reqOpts, callback) {
-          file.copy = function(newFile_, options) {
+        file.request = (reqOpts, callback) => {
+          file.copy = (newFile_, options) => {
             assert.notStrictEqual(options, fakeOptions);
             assert.strictEqual(options.userProject, fakeOptions.userProject);
             done();
@@ -551,14 +551,14 @@ describe('File', function() {
         file.copy(newFile, fakeOptions, assert.ifError);
       });
 
-      it('should pass the KMS key name in subsequent requests', function(done) {
+      it('should pass the KMS key name in subsequent requests', done => {
         const newFile = new File(BUCKET, 'new-file');
         const fakeOptions = {
           destinationKmsKeyName: 'kms-key-name',
         };
 
-        file.request = function(reqOpts, callback) {
-          file.copy = function(newFile_, options) {
+        file.request = (reqOpts, callback) => {
+          file.copy = (newFile_, options) => {
             assert.strictEqual(
               options.destinationKmsKeyName,
               fakeOptions.destinationKmsKeyName
@@ -572,38 +572,38 @@ describe('File', function() {
         file.copy(newFile, fakeOptions, assert.ifError);
       });
 
-      it('should make the subsequent correct API request', function(done) {
+      it('should make the subsequent correct API request', done => {
         const newFile = new File(BUCKET, 'new-file');
 
-        file.request = function(reqOpts) {
+        file.request = reqOpts => {
           assert.strictEqual(reqOpts.qs.rewriteToken, apiResponse.rewriteToken);
           done();
         };
 
-        file.copy(newFile, {token: apiResponse.rewriteToken}, assert.ifError);
+        file.copy(newFile, { token: apiResponse.rewriteToken }, assert.ifError);
       });
     });
 
-    describe('returned File object', function() {
-      beforeEach(function() {
-        const resp = {success: true};
-        file.request = function(reqOpts, callback) {
+    describe('returned File object', () => {
+      beforeEach(() => {
+        const resp = { success: true };
+        file.request = (reqOpts, callback) => {
           callback(null, resp);
         };
       });
 
-      it('should re-use file object if one is provided', function(done) {
+      it('should re-use file object if one is provided', done => {
         const newFile = new File(BUCKET, 'new-file');
-        file.copy(newFile, function(err, copiedFile) {
+        file.copy(newFile, (err, copiedFile) => {
           assert.ifError(err);
           assert.deepEqual(copiedFile, newFile);
           done();
         });
       });
 
-      it('should create new file on the same bucket', function(done) {
+      it('should create new file on the same bucket', done => {
         const newFilename = 'new-filename';
-        file.copy(newFilename, function(err, copiedFile) {
+        file.copy(newFilename, (err, copiedFile) => {
           assert.ifError(err);
           assert.equal(copiedFile.bucket.name, BUCKET.name);
           assert.equal(copiedFile.name, newFilename);
@@ -611,8 +611,8 @@ describe('File', function() {
         });
       });
 
-      it('should create new file on the destination bucket', function(done) {
-        file.copy(BUCKET, function(err, copiedFile) {
+      it('should create new file on the destination bucket', done => {
+        file.copy(BUCKET, (err, copiedFile) => {
           assert.ifError(err);
           assert.equal(copiedFile.bucket.name, BUCKET.name);
           assert.equal(copiedFile.name, file.name);
@@ -620,17 +620,17 @@ describe('File', function() {
         });
       });
 
-      it('should pass apiResponse into callback', function(done) {
-        file.copy(BUCKET, function(err, copiedFile, apiResponse) {
+      it('should pass apiResponse into callback', done => {
+        file.copy(BUCKET, (err, copiedFile, apiResponse) => {
           assert.ifError(err);
-          assert.deepEqual({success: true}, apiResponse);
+          assert.deepEqual({ success: true }, apiResponse);
           done();
         });
       });
     });
   });
 
-  describe('createReadStream', function() {
+  describe('createReadStream', () => {
     function getFakeRequest(data?) {
       let requestOptions;
 
@@ -638,7 +638,7 @@ describe('File', function() {
         constructor(_requestOptions?) {
           super();
           requestOptions = _requestOptions;
-          this._read = function () {
+          this._read = () => {
             if (data) {
               this.push(data);
             }
@@ -669,7 +669,7 @@ describe('File', function() {
 
           const self = this;
 
-          setImmediate(function () {
+          setImmediate(() => {
             const stream = new FakeRequest();
             self.emit('response', stream);
           });
@@ -694,7 +694,7 @@ describe('File', function() {
 
           const self = this;
 
-          setImmediate(function () {
+          setImmediate(() => {
             self.emit('error', error);
           });
         }
@@ -709,25 +709,25 @@ describe('File', function() {
       });
     }
 
-    beforeEach(function() {
-      handleRespOverride = function(err, res, body, callback) {
+    beforeEach(() => {
+      handleRespOverride = (err, res, body, callback) => {
         const rawResponseStream = through();
-        (rawResponseStream as any).toJSON = function() {
-          return {headers: {}};
+        (rawResponseStream as any).toJSON = () => {
+          return { headers: {} };
         };
         callback(null, null, rawResponseStream);
-        setImmediate(function() {
+        setImmediate(() => {
           rawResponseStream.end();
         });
       };
 
-      requestOverride = function() {
+      requestOverride = () => {
         return through();
       };
     });
 
-    it('should throw if both a range and validation is given', function() {
-      assert.throws(function() {
+    it('should throw if both a range and validation is given', () => {
+      assert.throws(() => {
         file.createReadStream({
           validation: true,
           start: 3,
@@ -735,21 +735,21 @@ describe('File', function() {
         });
       }, /Cannot use validation with file ranges \(start\/end\)\./);
 
-      assert.throws(function() {
+      assert.throws(() => {
         file.createReadStream({
           validation: true,
           start: 3,
         });
       }, /Cannot use validation with file ranges \(start\/end\)\./);
 
-      assert.throws(function() {
+      assert.throws(() => {
         file.createReadStream({
           validation: true,
           end: 8,
         });
       }, /Cannot use validation with file ranges \(start\/end\)\./);
 
-      assert.doesNotThrow(function() {
+      assert.doesNotThrow(() => {
         file.createReadStream({
           start: 3,
           end: 8,
@@ -757,10 +757,10 @@ describe('File', function() {
       });
     });
 
-    it('should send query.generation if File has one', function(done) {
-      const versionedFile = new File(BUCKET, 'file.txt', {generation: 1});
+    it('should send query.generation if File has one', done => {
+      const versionedFile = new File(BUCKET, 'file.txt', { generation: 1 });
 
-      versionedFile.requestStream = function(rOpts) {
+      versionedFile.requestStream = rOpts => {
         assert.equal(rOpts.qs.generation, 1);
         setImmediate(done);
         return duplexify();
@@ -769,12 +769,12 @@ describe('File', function() {
       versionedFile.createReadStream().resume();
     });
 
-    it('should send query.userProject if provided', function(done) {
+    it('should send query.userProject if provided', done => {
       const options = {
         userProject: 'user-project-id',
       };
 
-      file.requestStream = function(rOpts) {
+      file.requestStream = rOpts => {
         assert.strictEqual(rOpts.qs.userProject, options.userProject);
         setImmediate(done);
         return duplexify();
@@ -783,9 +783,9 @@ describe('File', function() {
       file.createReadStream(options).resume();
     });
 
-    describe('authenticating', function() {
-      it('should create an authenticated request', function(done) {
-        file.requestStream = function(opts) {
+    describe('authenticating', () => {
+      it('should create an authenticated request', done => {
+        file.requestStream = opts => {
           assert.deepEqual(opts, {
             forever: false,
             uri: '',
@@ -796,7 +796,7 @@ describe('File', function() {
               alt: 'media',
             },
           });
-          setImmediate(function() {
+          setImmediate(() => {
             done();
           });
           return duplexify();
@@ -805,14 +805,14 @@ describe('File', function() {
         file.createReadStream().resume();
       });
 
-      describe('errors', function() {
+      describe('errors', () => {
         const ERROR = new Error('Error.');
 
-        beforeEach(function() {
-          file.requestStream = function(opts) {
+        beforeEach(() => {
+          file.requestStream = opts => {
             const stream = requestOverride(opts);
 
-            setImmediate(function() {
+            setImmediate(() => {
               stream.emit('error', ERROR);
             });
 
@@ -820,10 +820,10 @@ describe('File', function() {
           };
         });
 
-        it('should emit an error from authenticating', function(done) {
+        it('should emit an error from authenticating', done => {
           file
             .createReadStream()
-            .once('error', function(err) {
+            .once('error', err => {
               assert.equal(err, ERROR);
               done();
             })
@@ -832,14 +832,14 @@ describe('File', function() {
       });
     });
 
-    describe('requestStream', function() {
-      it('should get readable stream from request', function(done) {
-        const fakeRequest = {a: 'b', c: 'd'};
+    describe('requestStream', () => {
+      it('should get readable stream from request', done => {
+        const fakeRequest = { a: 'b', c: 'd' };
 
         requestOverride = getFakeRequest();
 
-        file.requestStream = function() {
-          setImmediate(function() {
+        file.requestStream = () => {
+          setImmediate(() => {
             assert.deepEqual(requestOverride.getRequestOptions(), fakeRequest);
             done();
           });
@@ -850,30 +850,30 @@ describe('File', function() {
         file.createReadStream().resume();
       });
 
-      it('should emit response event from request', function(done) {
+      it('should emit response event from request', done => {
         file.requestStream = getFakeSuccessfulRequest('body');
 
         file
-          .createReadStream({validation: false})
-          .on('response', function() {
+          .createReadStream({ validation: false })
+          .on('response', () => {
             done();
           })
           .resume();
       });
 
-      it('should let util.handleResp handle the response', function(done) {
-        const response = {a: 'b', c: 'd'};
+      it('should let util.handleResp handle the response', done => {
+        const response = { a: 'b', c: 'd' };
 
-        handleRespOverride = function(err, response_, body) {
+        handleRespOverride = (err, response_, body) => {
           assert.strictEqual(err, null);
           assert.strictEqual(response_, response);
           assert.strictEqual(body, null);
           done();
         };
 
-        file.requestStream = function() {
+        file.requestStream = () => {
           const stream = through();
-          setImmediate(function() {
+          setImmediate(() => {
             stream.emit('response', response);
           });
           return stream;
@@ -882,38 +882,38 @@ describe('File', function() {
         file.createReadStream().resume();
       });
 
-      describe('errors', function() {
+      describe('errors', () => {
         const ERROR = new Error('Error.');
 
-        beforeEach(function() {
+        beforeEach(() => {
           file.requestStream = getFakeFailedRequest(ERROR);
         });
 
-        it('should emit the error', function(done) {
+        it('should emit the error', done => {
           file
             .createReadStream()
-            .once('error', function(err) {
+            .once('error', err => {
               assert.deepEqual(err, ERROR);
               done();
             })
             .resume();
         });
 
-        it('should parse a response stream for a better error', function(done) {
+        it('should parse a response stream for a better error', done => {
           const rawResponsePayload = 'error message from body';
           const rawResponseStream = through();
           const requestStream = through();
 
-          handleRespOverride = function(err, res, body, callback) {
+          handleRespOverride = (err, res, body, callback) => {
             callback(ERROR, null, res);
 
-            setImmediate(function() {
+            setImmediate(() => {
               rawResponseStream.end(rawResponsePayload);
             });
           };
 
-          file.requestStream = function() {
-            setImmediate(function() {
+          file.requestStream = () => {
+            setImmediate(() => {
               requestStream.emit('response', rawResponseStream);
             });
             return requestStream;
@@ -921,7 +921,7 @@ describe('File', function() {
 
           file
             .createReadStream()
-            .once('error', function(err) {
+            .once('error', err => {
               assert.strictEqual(err, ERROR);
               assert.strictEqual(err.message, rawResponsePayload);
               done();
@@ -931,14 +931,14 @@ describe('File', function() {
       });
     });
 
-    describe('compression', function() {
+    describe('compression', () => {
       const DATA = 'test data';
       const GZIPPED_DATA = zlib.gzipSync(DATA);
 
-      beforeEach(function() {
-        handleRespOverride = function(err, res, body, callback) {
+      beforeEach(() => {
+        handleRespOverride = (err, res, body, callback) => {
           const rawResponseStream = through();
-          (rawResponseStream as any).toJSON = function() {
+          (rawResponseStream as any).toJSON = () => {
             return {
               headers: {
                 'content-encoding': 'gzip',
@@ -948,7 +948,7 @@ describe('File', function() {
 
           callback(null, null, rawResponseStream);
 
-          setImmediate(function() {
+          setImmediate(() => {
             rawResponseStream.end(GZIPPED_DATA);
           });
         };
@@ -956,11 +956,11 @@ describe('File', function() {
         file.requestStream = getFakeSuccessfulRequest(GZIPPED_DATA);
       });
 
-      it('should gunzip the response', function(done) {
+      it('should gunzip the response', done => {
         file
           .createReadStream()
           .once('error', done)
-          .on('data', function(data) {
+          .on('data', data => {
             assert.strictEqual(data.toString(), DATA);
             done();
           })
@@ -968,14 +968,14 @@ describe('File', function() {
       });
     });
 
-    describe('validation', function() {
+    describe('validation', () => {
       const data = 'test';
       let fakeValidationStream;
 
-      beforeEach(function() {
+      beforeEach(() => {
         file.metadata.mediaLink = 'http://uri';
 
-        file.getMetadata = function(options, callback) {
+        file.getMetadata = (options, callback) => {
           file.metadata = {
             crc32c: '####wA==',
             md5Hash: 'CY9rzUYh03PK3k6DJie09g==',
@@ -984,20 +984,20 @@ describe('File', function() {
         };
 
         fakeValidationStream = through();
-        fakeValidationStream.test = function() {
+        fakeValidationStream.test = () => {
           return true;
         };
-        hashStreamValidationOverride = function() {
+        hashStreamValidationOverride = () => {
           return fakeValidationStream;
         };
       });
 
-      it('should pass the userProject to getMetadata', function(done) {
+      it('should pass the userProject to getMetadata', done => {
         const fakeOptions = {
           userProject: 'grapce-spaceship-123',
         };
 
-        file.getMetadata = function(options) {
+        file.getMetadata = options => {
           assert.strictEqual(options.userProject, fakeOptions.userProject);
           done();
         };
@@ -1010,9 +1010,9 @@ describe('File', function() {
           .resume();
       });
 
-      it('should destroy stream from failed metadata fetch', function(done) {
+      it('should destroy stream from failed metadata fetch', done => {
         const error = new Error('Error.');
-        file.getMetadata = function(options, callback) {
+        file.getMetadata = (options, callback) => {
           callback(error);
         };
 
@@ -1020,71 +1020,71 @@ describe('File', function() {
 
         file
           .createReadStream()
-          .on('error', function(err) {
+          .on('error', err => {
             assert.strictEqual(err, error);
             done();
           })
           .resume();
       });
 
-      it('should validate with crc32c', function(done) {
+      it('should validate with crc32c', done => {
         file.requestStream = getFakeSuccessfulRequest(data);
 
         file
-          .createReadStream({validation: 'crc32c'})
+          .createReadStream({ validation: 'crc32c' })
           .on('error', done)
           .on('end', done)
           .resume();
       });
 
-      it('should emit an error if crc32c validation fails', function(done) {
+      it('should emit an error if crc32c validation fails', done => {
         file.requestStream = getFakeSuccessfulRequest('bad-data');
 
-        fakeValidationStream.test = function() {
+        fakeValidationStream.test = () => {
           return false;
         };
 
         file
-          .createReadStream({validation: 'crc32c'})
-          .on('error', function(err) {
+          .createReadStream({ validation: 'crc32c' })
+          .on('error', err => {
             assert.strictEqual(err.code, 'CONTENT_DOWNLOAD_MISMATCH');
             done();
           })
           .resume();
       });
 
-      it('should validate with md5', function(done) {
+      it('should validate with md5', done => {
         file.requestStream = getFakeSuccessfulRequest(data);
 
-        fakeValidationStream.test = function() {
+        fakeValidationStream.test = () => {
           return true;
         };
 
         file
-          .createReadStream({validation: 'md5'})
+          .createReadStream({ validation: 'md5' })
           .on('error', done)
           .on('end', done)
           .resume();
       });
 
-      it('should emit an error if md5 validation fails', function(done) {
+      it('should emit an error if md5 validation fails', done => {
         file.requestStream = getFakeSuccessfulRequest('bad-data');
 
-        fakeValidationStream.test = function() {
+        fakeValidationStream.test = () => {
           return false;
         };
 
         file
-          .createReadStream({validation: 'md5'})
-          .on('error', function(err) {
+          .createReadStream({ validation: 'md5' })
+          .on('error', err => {
             assert.strictEqual(err.code, 'CONTENT_DOWNLOAD_MISMATCH');
             done();
           })
           .resume();
       });
 
-      it('should default to crc32c validation', function(done) {
-        file.getMetadata = function(options, callback) {
+      it('should default to crc32c validation', done => {
+        file.getMetadata = (options, callback) => {
           file.metadata = {
             crc32c: file.metadata.crc32c,
           };
@@ -1095,47 +1095,47 @@ describe('File', function() {
 
         file
           .createReadStream()
-          .on('error', function(err) {
+          .on('error', err => {
             assert.strictEqual(err.code, 'CONTENT_DOWNLOAD_MISMATCH');
             done();
           })
           .resume();
       });
 
-      it('should ignore a data mismatch if validation: false', function(done) {
+      it('should ignore a data mismatch if validation: false', done => {
         file.requestStream = getFakeSuccessfulRequest(data);
 
-        fakeValidationStream.test = function() {
+        fakeValidationStream.test = () => {
           return false;
         };
 
         file
-          .createReadStream({validation: false})
+          .createReadStream({ validation: false })
           .resume()
           .on('error', done)
           .on('end', done);
       });
 
-      describe('destroying the through stream', function() {
-        beforeEach(function() {
-          fakeValidationStream.test = function() {
+      describe('destroying the through stream', () => {
+        beforeEach(() => {
+          fakeValidationStream.test = () => {
             return false;
           };
         });
 
-        it('should destroy after failed validation', function(done) {
+        it('should destroy after failed validation', done => {
           file.requestStream = getFakeSuccessfulRequest('bad-data');
 
-          const readStream = file.createReadStream({validation: 'md5'});
-          readStream.destroy = function(err) {
+          const readStream = file.createReadStream({ validation: 'md5' });
+          readStream.destroy = err => {
             assert.strictEqual(err.code, 'CONTENT_DOWNLOAD_MISMATCH');
             done();
           };
           readStream.resume();
         });
 
-        it('should destroy if MD5 is requested but absent', function(done) {
-          file.getMetadata = function(options, callback) {
+        it('should destroy if MD5 is requested but absent', done => {
+          file.getMetadata = (options, callback) => {
             file.metadata = {
               crc32c: file.metadata.crc32c,
             };
@@ -1144,8 +1144,8 @@ describe('File', function() {
 
           file.requestStream = getFakeSuccessfulRequest('bad-data');
 
-          const readStream = file.createReadStream({validation: 'md5'});
-          readStream.destroy = function(err) {
+          const readStream = file.createReadStream({ validation: 'md5' });
+          readStream.destroy = err => {
             assert.strictEqual(err.code, 'MD5_NOT_AVAILABLE');
             done();
           };
@@ -1154,41 +1154,41 @@ describe('File', function() {
       });
     });
 
-    describe('range requests', function() {
-      it('should accept a start range', function(done) {
+    describe('range requests', () => {
+      it('should accept a start range', done => {
         const startOffset = 100;
 
-        file.requestStream = function(opts) {
-          setImmediate(function() {
+        file.requestStream = opts => {
+          setImmediate(() => {
             assert.equal(opts.headers.Range, 'bytes=' + startOffset + '-');
             done();
           });
           return duplexify();
         };
 
-        file.createReadStream({start: startOffset}).resume();
+        file.createReadStream({ start: startOffset }).resume();
       });
 
-      it('should accept an end range and set start to 0', function(done) {
+      it('should accept an end range and set start to 0', done => {
         const endOffset = 100;
 
-        file.requestStream = function(opts) {
-          setImmediate(function() {
+        file.requestStream = opts => {
+          setImmediate(() => {
             assert.equal(opts.headers.Range, 'bytes=0-' + endOffset);
             done();
           });
           return duplexify();
         };
 
-        file.createReadStream({end: endOffset}).resume();
+        file.createReadStream({ end: endOffset }).resume();
       });
 
-      it('should accept both a start and end range', function(done) {
+      it('should accept both a start and end range', done => {
         const startOffset = 100;
         const endOffset = 101;
 
-        file.requestStream = function(opts) {
-          setImmediate(function() {
+        file.requestStream = opts => {
+          setImmediate(() => {
             const expectedRange = 'bytes=' + startOffset + '-' + endOffset;
             assert.equal(opts.headers.Range, expectedRange);
             done();
@@ -1196,15 +1196,15 @@ describe('File', function() {
           return duplexify();
         };
 
-        file.createReadStream({start: startOffset, end: endOffset}).resume();
+        file.createReadStream({ start: startOffset, end: endOffset }).resume();
       });
 
-      it('should accept range start and end as 0', function(done) {
+      it('should accept range start and end as 0', done => {
         const startOffset = 0;
         const endOffset = 0;
 
-        file.requestStream = function(opts) {
-          setImmediate(function() {
+        file.requestStream = opts => {
+          setImmediate(() => {
             const expectedRange = 'bytes=0-0';
             assert.equal(opts.headers.Range, expectedRange);
             done();
@@ -1212,37 +1212,37 @@ describe('File', function() {
           return duplexify();
         };
 
-        file.createReadStream({start: startOffset, end: endOffset}).resume();
+        file.createReadStream({ start: startOffset, end: endOffset }).resume();
       });
 
-      it('should end the through stream', function(done) {
+      it('should end the through stream', done => {
         file.requestStream = getFakeSuccessfulRequest('body');
 
-        const readStream = file.createReadStream({start: 100});
+        const readStream = file.createReadStream({ start: 100 });
         readStream.end = done;
         readStream.resume();
       });
     });
 
-    describe('tail requests', function() {
-      it('should make a request for the tail bytes', function(done) {
+    describe('tail requests', () => {
+      it('should make a request for the tail bytes', done => {
         const endOffset = -10;
 
-        file.requestStream = function(opts) {
-          setImmediate(function() {
+        file.requestStream = opts => {
+          setImmediate(() => {
             assert.equal(opts.headers.Range, 'bytes=' + endOffset);
             done();
           });
           return duplexify();
         };
 
-        file.createReadStream({end: endOffset}).resume();
+        file.createReadStream({ end: endOffset }).resume();
       });
     });
   });
 
-  describe('createResumableUpload', function() {
-    it('should not require options', function(done) {
+  describe('createResumableUpload', () => {
+    it('should not require options', done => {
       resumableUploadOverride = {
         createURI(opts, callback) {
           assert.strictEqual(opts.metadata, undefined);
@@ -1253,7 +1253,7 @@ describe('File', function() {
       file.createResumableUpload(done);
     });
 
-    it('should create a resumable upload URI', function(done) {
+    it('should create a resumable upload URI', done => {
       const options = {
         metadata: {
           contentType: 'application/json',
@@ -1295,32 +1295,32 @@ describe('File', function() {
     });
   });
 
-  describe('createWriteStream', function() {
-    const METADATA = {a: 'b', c: 'd'};
+  describe('createWriteStream', () => {
+    const METADATA = { a: 'b', c: 'd' };
 
-    beforeEach(function() {
-      (fakeFs as any).access = function(dir, check, callback) {
+    beforeEach(() => {
+      (fakeFs as any).access = (dir, check, callback) => {
         // Assume that the required config directory is writable.
         callback();
       };
     });
 
-    it('should return a stream', function() {
+    it('should return a stream', () => {
       assert(file.createWriteStream() instanceof stream);
     });
 
-    it('should emit errors', function(done) {
+    it('should emit errors', done => {
       const error = new Error('Error.');
       const uploadStream = new stream.PassThrough();
 
-      file.startResumableUpload_ = function(dup) {
+      file.startResumableUpload_ = dup => {
         dup.setWritable(uploadStream);
         uploadStream.emit('error', error);
       };
 
       const writable = file.createWriteStream();
 
-      writable.on('error', function(err) {
+      writable.on('error', err => {
         assert.strictEqual(err, error);
         done();
       });
@@ -1328,7 +1328,7 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should start a simple upload if specified', function(done) {
+    it('should start a simple upload if specified', done => {
       const options = {
         metadata: METADATA,
         resumable: false,
@@ -1336,7 +1336,7 @@ describe('File', function() {
       };
       const writable = file.createWriteStream(options);
 
-      file.startSimpleUpload_ = function(stream, options_) {
+      file.startSimpleUpload_ = (stream, options_) => {
         assert.deepEqual(options_, options);
         done();
       };
@@ -1344,7 +1344,7 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should start a resumable upload if specified', function(done) {
+    it('should start a resumable upload if specified', done => {
       const options = {
         metadata: METADATA,
         resumable: true,
@@ -1352,7 +1352,7 @@ describe('File', function() {
       };
       const writable = file.createWriteStream(options);
 
-      file.startResumableUpload_ = function(stream, options_) {
+      file.startResumableUpload_ = (stream, options_) => {
         assert.deepEqual(options_, options);
         done();
       };
@@ -1360,46 +1360,46 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should check if xdg-basedir is writable', function(done) {
+    it('should check if xdg-basedir is writable', done => {
       const fakeDir = 'fake-xdg-dir';
 
       xdgConfigOverride = fakeDir;
 
-      (fakeFs as any).access = function(dir) {
+      (fakeFs as any).access = dir => {
         assert.strictEqual(dir, fakeDir);
         done();
       };
 
-      file.createWriteStream({resumable: true}).write('data');
+      file.createWriteStream({ resumable: true }).write('data');
     });
 
-    it('should fall back to checking tmpdir', function(done) {
+    it('should fall back to checking tmpdir', done => {
       const fakeDir = 'fake-tmp-dir';
 
       xdgConfigOverride = false;
 
-      fakeOs.tmpdir = function() {
+      fakeOs.tmpdir = () => {
         return fakeDir;
       };
 
-      (fakeFs as any).access = function(dir) {
+      (fakeFs as any).access = dir => {
         assert.strictEqual(dir, fakeDir);
         done();
       };
 
-      file.createWriteStream({resumable: true}).write('data');
+      file.createWriteStream({ resumable: true }).write('data');
     });
 
-    it('should fail if resumable requested but not writable', function(done) {
+    it('should fail if resumable requested but not writable', done => {
       const error = new Error('Error.');
 
-      (fakeFs as any).access = function(dir, check, callback) {
+      (fakeFs as any).access = (dir, check, callback) => {
         callback(error);
       };
 
-      const writable = file.createWriteStream({resumable: true});
+      const writable = file.createWriteStream({ resumable: true });
 
-      writable.on('error', function(err) {
+      writable.on('error', err => {
         assert.notStrictEqual(err, error);
 
         assert.strictEqual(err.name, 'ResumableUploadError');
@@ -1421,30 +1421,30 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should fall back to simple if not writable', function(done) {
+    it('should fall back to simple if not writable', done => {
       const options = {
         metadata: METADATA,
         customValue: true,
       };
 
-      file.startSimpleUpload_ = function(stream, options_) {
+      file.startSimpleUpload_ = (stream, options_) => {
         assert.deepEqual(options_, options);
         done();
       };
 
-      (fakeFs as any).access = function(dir, check, callback) {
+      (fakeFs as any).access = (dir, check, callback) => {
         callback(new Error('Error.'));
       };
 
       file.createWriteStream(options).write('data');
     });
 
-    it('should default to a resumable upload', function(done) {
+    it('should default to a resumable upload', done => {
       const writable = file.createWriteStream({
         metadata: METADATA,
       });
 
-      file.startResumableUpload_ = function(stream, options) {
+      file.startResumableUpload_ = (stream, options) => {
         assert.deepEqual(options.metadata, METADATA);
         done();
       };
@@ -1452,11 +1452,11 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should alias contentType to metadata object', function(done) {
+    it('should alias contentType to metadata object', done => {
       const contentType = 'text/html';
-      const writable = file.createWriteStream({contentType});
+      const writable = file.createWriteStream({ contentType });
 
-      file.startResumableUpload_ = function(stream, options) {
+      file.startResumableUpload_ = (stream, options) => {
         assert.strictEqual(options.metadata.contentType, contentType);
         done();
       };
@@ -1464,10 +1464,10 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should detect contentType with contentType:auto', function(done) {
-      const writable = file.createWriteStream({contentType: 'auto'});
+    it('should detect contentType with contentType:auto', done => {
+      const writable = file.createWriteStream({ contentType: 'auto' });
 
-      file.startResumableUpload_ = function(stream, options) {
+      file.startResumableUpload_ = (stream, options) => {
         assert.strictEqual(options.metadata.contentType, 'image/png');
         done();
       };
@@ -1475,10 +1475,10 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should set encoding with gzip:true', function(done) {
-      const writable = file.createWriteStream({gzip: true});
+    it('should set encoding with gzip:true', done => {
+      const writable = file.createWriteStream({ gzip: true });
 
-      file.startResumableUpload_ = function(stream, options) {
+      file.startResumableUpload_ = (stream, options) => {
         assert.strictEqual(options.metadata.contentEncoding, 'gzip');
         done();
       };
@@ -1486,13 +1486,13 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should set encoding with gzip:auto & compressible', function(done) {
+    it('should set encoding with gzip:auto & compressible', done => {
       const writable = file.createWriteStream({
         gzip: 'auto',
         contentType: 'text/html', // (compressible)
       });
 
-      file.startResumableUpload_ = function(stream, options) {
+      file.startResumableUpload_ = (stream, options) => {
         assert.strictEqual(options.metadata.contentEncoding, 'gzip');
         done();
       };
@@ -1500,10 +1500,10 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should not set encoding with gzip:auto & non-compressible', function(done) {
-      const writable = file.createWriteStream({gzip: 'auto'});
+    it('should not set encoding with gzip:auto & non-compressible', done => {
+      const writable = file.createWriteStream({ gzip: 'auto' });
 
-      file.startResumableUpload_ = function(stream, options) {
+      file.startResumableUpload_ = (stream, options) => {
         assert.strictEqual(options.metadata.contentEncoding, undefined);
         done();
       };
@@ -1511,15 +1511,15 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should re-emit response event', function(done) {
+    it('should re-emit response event', done => {
       const writable = file.createWriteStream();
       const resp = {};
 
-      file.startResumableUpload_ = function(stream) {
+      file.startResumableUpload_ = stream => {
         stream.emit('response', resp);
       };
 
-      writable.on('response', function(resp_) {
+      writable.on('response', resp_ => {
         assert.strictEqual(resp_, resp);
         done();
       });
@@ -1527,10 +1527,10 @@ describe('File', function() {
       writable.write('data');
     });
 
-    it('should cork data on prefinish', function(done) {
-      const writable = file.createWriteStream({resumable: false});
+    it('should cork data on prefinish', done => {
+      const writable = file.createWriteStream({ resumable: false });
 
-      file.startSimpleUpload_ = function(stream) {
+      file.startSimpleUpload_ = stream => {
         assert.strictEqual(writable._corked, 0);
         stream.emit('prefinish');
         assert.strictEqual(writable._corked, 1);
@@ -1540,19 +1540,19 @@ describe('File', function() {
       writable.end('data');
     });
 
-    describe('validation', function() {
+    describe('validation', () => {
       const data = 'test';
 
       const fakeMetadata = {
-        crc32c: {crc32c: '####wA=='},
-        md5: {md5Hash: 'CY9rzUYh03PK3k6DJie09g=='},
+        crc32c: { crc32c: '####wA==' },
+        md5: { md5Hash: 'CY9rzUYh03PK3k6DJie09g==' },
       };
 
-      it('should uncork after successful write', function(done) {
-        const writable = file.createWriteStream({validation: 'crc32c'});
+      it('should uncork after successful write', done => {
+        const writable = file.createWriteStream({ validation: 'crc32c' });
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
             assert.strictEqual(writable._corked, 1);
 
             file.metadata = fakeMetadata.crc32c;
@@ -1568,11 +1568,11 @@ describe('File', function() {
         writable.on('error', done);
       });
 
-      it('should validate with crc32c', function(done) {
-        const writable = file.createWriteStream({validation: 'crc32c'});
+      it('should validate with crc32c', done => {
+        const writable = file.createWriteStream({ validation: 'crc32c' });
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
             file.metadata = fakeMetadata.crc32c;
             stream.emit('complete');
           });
@@ -1583,34 +1583,34 @@ describe('File', function() {
         writable.on('error', done).on('finish', done);
       });
 
-      it('should emit an error if crc32c validation fails', function(done) {
-        const writable = file.createWriteStream({validation: 'crc32c'});
+      it('should emit an error if crc32c validation fails', done => {
+        const writable = file.createWriteStream({ validation: 'crc32c' });
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
             file.metadata = fakeMetadata.crc32c;
             stream.emit('complete');
           });
         };
 
-        file.delete = function(cb) {
+        file.delete = cb => {
           cb();
         };
 
         writable.write('bad-data');
         writable.end();
 
-        writable.on('error', function(err) {
+        writable.on('error', err => {
           assert.equal(err.code, 'FILE_NO_UPLOAD');
           done();
         });
       });
 
-      it('should validate with md5', function(done) {
-        const writable = file.createWriteStream({validation: 'md5'});
+      it('should validate with md5', done => {
+        const writable = file.createWriteStream({ validation: 'md5' });
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
             file.metadata = fakeMetadata.md5;
             stream.emit('complete');
           });
@@ -1622,58 +1622,58 @@ describe('File', function() {
         writable.on('error', done).on('finish', done);
       });
 
-      it('should emit an error if md5 validation fails', function(done) {
-        const writable = file.createWriteStream({validation: 'md5'});
+      it('should emit an error if md5 validation fails', done => {
+        const writable = file.createWriteStream({ validation: 'md5' });
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
             file.metadata = fakeMetadata.md5;
             stream.emit('complete');
           });
         };
 
-        file.delete = function(cb) {
+        file.delete = cb => {
           cb();
         };
 
         writable.write('bad-data');
         writable.end();
 
-        writable.on('error', function(err) {
+        writable.on('error', err => {
           assert.equal(err.code, 'FILE_NO_UPLOAD');
           done();
         });
       });
 
-      it('should default to md5 validation', function(done) {
+      it('should default to md5 validation', done => {
         const writable = file.createWriteStream();
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
-            file.metadata = {md5Hash: 'bad-hash'};
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
+            file.metadata = { md5Hash: 'bad-hash' };
             stream.emit('complete');
           });
         };
 
-        file.delete = function(cb) {
+        file.delete = cb => {
           cb();
         };
 
         writable.write(data);
         writable.end();
 
-        writable.on('error', function(err) {
+        writable.on('error', err => {
           assert.equal(err.code, 'FILE_NO_UPLOAD');
           done();
         });
       });
 
-      it('should ignore a data mismatch if validation: false', function(done) {
-        const writable = file.createWriteStream({validation: false});
+      it('should ignore a data mismatch if validation: false', done => {
+        const writable = file.createWriteStream({ validation: false });
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
-            file.metadata = {md5Hash: 'bad-hash'};
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
+            file.metadata = { md5Hash: 'bad-hash' };
             stream.emit('complete');
           });
         };
@@ -1685,17 +1685,17 @@ describe('File', function() {
         writable.on('finish', done);
       });
 
-      it('should delete the file if validation fails', function(done) {
+      it('should delete the file if validation fails', done => {
         const writable = file.createWriteStream();
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
-            file.metadata = {md5Hash: 'bad-hash'};
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
+            file.metadata = { md5Hash: 'bad-hash' };
             stream.emit('complete');
           });
         };
 
-        file.delete = function() {
+        file.delete = () => {
           done();
         };
 
@@ -1703,49 +1703,49 @@ describe('File', function() {
         writable.end();
       });
 
-      it('should emit an error if MD5 is requested but absent', function(done) {
-        const writable = file.createWriteStream({validation: 'md5'});
+      it('should emit an error if MD5 is requested but absent', done => {
+        const writable = file.createWriteStream({ validation: 'md5' });
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
-            file.metadata = {crc32c: 'not-md5'};
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
+            file.metadata = { crc32c: 'not-md5' };
             stream.emit('complete');
           });
         };
 
-        file.delete = function(cb) {
+        file.delete = cb => {
           cb();
         };
 
         writable.write(data);
         writable.end();
 
-        writable.on('error', function(err) {
+        writable.on('error', err => {
           assert.equal(err.code, 'MD5_NOT_AVAILABLE');
           done();
         });
       });
 
-      it('should emit a different error if delete fails', function(done) {
+      it('should emit a different error if delete fails', done => {
         const writable = file.createWriteStream();
 
-        file.startResumableUpload_ = function(stream) {
-          setImmediate(function() {
-            file.metadata = {md5Hash: 'bad-hash'};
+        file.startResumableUpload_ = stream => {
+          setImmediate(() => {
+            file.metadata = { md5Hash: 'bad-hash' };
             stream.emit('complete');
           });
         };
 
         const deleteErrorMessage = 'Delete error message.';
         const deleteError = new Error(deleteErrorMessage);
-        file.delete = function(cb) {
+        file.delete = cb => {
           cb(deleteError);
         };
 
         writable.write(data);
         writable.end();
 
-        writable.on('error', function(err) {
+        writable.on('error', err => {
           assert.equal(err.code, 'FILE_NO_UPLOAD_DELETE');
           assert(err.message.indexOf(deleteErrorMessage) > -1);
           done();
@@ -1754,9 +1754,9 @@ describe('File', function() {
     });
   });
 
-  describe('delete', function() {
-    it('should make the correct request', function(done) {
-      file.parent.delete = function(options, callback) {
+  describe('delete', () => {
+    it('should make the correct request', done => {
+      file.parent.delete = (options, callback) => {
         assert.strictEqual(this, file);
         assert.deepEqual(options, {});
         callback(); // done()
@@ -1765,13 +1765,13 @@ describe('File', function() {
       file.delete(done);
     });
 
-    it('should accept options', function(done) {
+    it('should accept options', done => {
       const options = {
         a: 'b',
         c: 'd',
       };
 
-      file.parent.delete = function(options_) {
+      file.parent.delete = options_ => {
         assert.deepStrictEqual(options_, options);
         done();
       };
@@ -1779,7 +1779,7 @@ describe('File', function() {
       file.delete(options, assert.ifError);
     });
 
-    it('should use requestQueryObject', function(done) {
+    it('should use requestQueryObject', done => {
       const options = {
         a: 'b',
         c: 'd',
@@ -1795,7 +1795,7 @@ describe('File', function() {
         generation: 2,
       };
 
-      file.parent.delete = function(options) {
+      file.parent.delete = options => {
         assert.deepStrictEqual(options, expectedOptions);
         done();
       };
@@ -1804,42 +1804,42 @@ describe('File', function() {
     });
   });
 
-  describe('download', function() {
+  describe('download', () => {
     let fileReadStream;
 
-    beforeEach(function() {
+    beforeEach(() => {
       fileReadStream = new stream.Readable();
       fileReadStream._read = util.noop;
 
-      fileReadStream.on('end', function() {
+      fileReadStream.on('end', () => {
         fileReadStream.emit('complete');
       });
 
-      file.createReadStream = function() {
+      file.createReadStream = () => {
         return fileReadStream;
       };
     });
 
-    it('should accept just a callback', function(done) {
-      fileReadStream._read = function() {
+    it('should accept just a callback', done => {
+      fileReadStream._read = () => {
         done();
       };
 
       file.download(assert.ifError);
     });
 
-    it('should accept an options object and callback', function(done) {
-      fileReadStream._read = function() {
+    it('should accept an options object and callback', done => {
+      fileReadStream._read = () => {
         done();
       };
 
       file.download({}, assert.ifError);
     });
 
-    it('should pass the provided options to createReadStream', function(done) {
-      const readOptions = {start: 100, end: 200};
+    it('should pass the provided options to createReadStream', done => {
+      const readOptions = { start: 100, end: 200 };
 
-      file.createReadStream = function(options) {
+      file.createReadStream = options => {
         assert.deepEqual(options, readOptions);
         done();
         return fileReadStream;
@@ -1848,27 +1848,27 @@ describe('File', function() {
       file.download(readOptions, assert.ifError);
     });
 
-    it('should only execute callback once', function(done) {
-      fileReadStream._read = function() {
+    it('should only execute callback once', done => {
+      fileReadStream._read = () => {
         this.emit('error', new Error('Error.'));
         this.emit('error', new Error('Error.'));
       };
 
-      file.download(function() {
+      file.download(() => {
         done();
       });
     });
 
-    describe('into memory', function() {
-      it('should buffer a file into memory if no destination', function(done) {
+    describe('into memory', () => {
+      it('should buffer a file into memory if no destination', done => {
         const fileContents = 'abcdefghijklmnopqrstuvwxyz';
 
-        fileReadStream._read = function() {
+        fileReadStream._read = () => {
           this.push(fileContents);
           this.push(null);
         };
 
-        file.download(function(err, remoteFileContents) {
+        file.download((err, remoteFileContents) => {
           assert.ifError(err);
 
           assert.equal(fileContents, remoteFileContents);
@@ -1876,37 +1876,37 @@ describe('File', function() {
         });
       });
 
-      it('should execute callback with error', function(done) {
+      it('should execute callback with error', done => {
         const error = new Error('Error.');
 
-        fileReadStream._read = function() {
+        fileReadStream._read = () => {
           this.emit('error', error);
         };
 
-        file.download(function(err) {
+        file.download(err => {
           assert.equal(err, error);
           done();
         });
       });
     });
 
-    describe('with destination', function() {
-      it('should write the file to a destination if provided', function(done) {
+    describe('with destination', () => {
+      it('should write the file to a destination if provided', done => {
         tmp.setGracefulCleanup();
         tmp.file(function _tempFileCreated(err, tmpFilePath) {
           assert.ifError(err);
 
           const fileContents = 'abcdefghijklmnopqrstuvwxyz';
 
-          fileReadStream._read = function() {
+          fileReadStream._read = () => {
             this.push(fileContents);
             this.push(null);
           };
 
-          file.download({destination: tmpFilePath}, function(err) {
+          file.download({ destination: tmpFilePath }, err => {
             assert.ifError(err);
 
-            fs.readFile(tmpFilePath, function(err, tmpFileContents) {
+            fs.readFile(tmpFilePath, (err, tmpFileContents) => {
               assert.ifError(err);
 
               assert.equal(fileContents, tmpFileContents);
@@ -1916,18 +1916,18 @@ describe('File', function() {
         });
       });
 
-      it('should execute callback with error', function(done) {
+      it('should execute callback with error', done => {
         tmp.setGracefulCleanup();
         tmp.file(function _tempFileCreated(err, tmpFilePath) {
           assert.ifError(err);
 
           const error = new Error('Error.');
 
-          fileReadStream._read = function() {
+          fileReadStream._read = () => {
             this.emit('error', error);
           };
 
-          file.download({destination: tmpFilePath}, function(err) {
+          file.download({ destination: tmpFilePath }, err => {
             assert.equal(err, error);
             done();
           });
@@ -1936,11 +1936,11 @@ describe('File', function() {
     });
   });
 
-  describe('exists', function() {
-    it('should call parent exists function', function(done) {
+  describe('exists', () => {
+    it('should call parent exists function', done => {
       const options = {};
 
-      file.parent.exists = function(options_, callback) {
+      file.parent.exists = (options_, callback) => {
         assert.strictEqual(options_, options);
         callback(); // done()
       };
@@ -1949,11 +1949,11 @@ describe('File', function() {
     });
   });
 
-  describe('get', function() {
-    it('should call parent get function', function(done) {
+  describe('get', () => {
+    it('should call parent get function', done => {
       const options = {};
 
-      file.parent.get = function(options_, callback) {
+      file.parent.get = (options_, callback) => {
         assert.strictEqual(options_, options);
         callback(); // done()
       };
@@ -1962,9 +1962,9 @@ describe('File', function() {
     });
   });
 
-  describe('getMetadata', function() {
-    it('should make the correct request', function(done) {
-      file.parent.getMetadata = function(options, callback) {
+  describe('getMetadata', () => {
+    it('should make the correct request', done => {
+      file.parent.getMetadata = (options, callback) => {
         assert.strictEqual(this, file);
         assert.deepEqual(options, {});
         callback(); // done()
@@ -1973,13 +1973,13 @@ describe('File', function() {
       file.getMetadata(done);
     });
 
-    it('should accept options', function(done) {
+    it('should accept options', done => {
       const options = {
         a: 'b',
         c: 'd',
       };
 
-      file.parent.getMetadata = function(options_) {
+      file.parent.getMetadata = options_ => {
         assert.deepStrictEqual(options_, options);
         done();
       };
@@ -1987,7 +1987,7 @@ describe('File', function() {
       file.getMetadata(options, assert.ifError);
     });
 
-    it('should use requestQueryObject', function(done) {
+    it('should use requestQueryObject', done => {
       const options = {
         a: 'b',
         c: 'd',
@@ -2003,7 +2003,7 @@ describe('File', function() {
         generation: 2,
       };
 
-      file.parent.getMetadata = function(options) {
+      file.parent.getMetadata = options => {
         assert.deepStrictEqual(options, expectedOptions);
         done();
       };
@@ -2012,12 +2012,12 @@ describe('File', function() {
     });
   });
 
-  describe('getSignedPolicy', function() {
+  describe('getSignedPolicy', () => {
     const CONFIG = {
       expires: Date.now() + 2000,
     };
 
-    beforeEach(function() {
+    beforeEach(() => {
       BUCKET.storage.authClient = {
         sign: () => {
           return Promise.resolve('signature');
@@ -2025,14 +2025,14 @@ describe('File', function() {
       };
     });
 
-    it('should create a signed policy', function(done) {
-      BUCKET.storage.authClient.sign = function(blobToSign) {
+    it('should create a signed policy', done => {
+      BUCKET.storage.authClient.sign = blobToSign => {
         const policy = Buffer.from(blobToSign, 'base64').toString();
         assert.strictEqual(typeof JSON.parse(policy), 'object');
         return Promise.resolve('signature');
       };
 
-      file.getSignedPolicy(CONFIG, function(err, signedPolicy) {
+      file.getSignedPolicy(CONFIG, (err, signedPolicy) => {
         assert.ifError(err);
         assert.equal(typeof signedPolicy.string, 'string');
         assert.equal(typeof signedPolicy.base64, 'string');
@@ -2041,32 +2041,32 @@ describe('File', function() {
       });
     });
 
-    it('should not modify the configuration object', function(done) {
+    it('should not modify the configuration object', done => {
       const originalConfig = extend({}, CONFIG);
 
-      file.getSignedPolicy(CONFIG, function(err) {
+      file.getSignedPolicy(CONFIG, err => {
         assert.ifError(err);
         assert.deepEqual(CONFIG, originalConfig);
         done();
       });
     });
 
-    it('should return an error if signBlob errors', function(done) {
+    it('should return an error if signBlob errors', done => {
       const error = new Error('Error.');
 
       BUCKET.storage.authClient.sign = () => {
         return Promise.reject(error);
       };
 
-      file.getSignedPolicy(CONFIG, function(err) {
+      file.getSignedPolicy(CONFIG, err => {
         assert.strictEqual(err.name, 'SigningError');
         assert.strictEqual(err.message, error.message);
         done();
       });
     });
 
-    it('should add key equality condition', function(done) {
-      file.getSignedPolicy(CONFIG, function(err, signedPolicy) {
+    it('should add key equality condition', done => {
+      file.getSignedPolicy(CONFIG, (err, signedPolicy) => {
         const conditionString = '["eq","$key","' + file.name + '"]';
         assert.ifError(err);
         assert(signedPolicy.string.indexOf(conditionString) > -1);
@@ -2074,13 +2074,13 @@ describe('File', function() {
       });
     });
 
-    it('should add ACL condtion', function(done) {
+    it('should add ACL condtion', done => {
       file.getSignedPolicy(
         {
           expires: Date.now() + 2000,
           acl: '<acl>',
         },
-        function(err, signedPolicy) {
+        (err, signedPolicy) => {
           const conditionString = '{"acl":"<acl>"}';
           assert.ifError(err);
           assert(signedPolicy.string.indexOf(conditionString) > -1);
@@ -2089,7 +2089,7 @@ describe('File', function() {
       );
     });
 
-    it('should add success redirect', function(done) {
+    it('should add success redirect', done => {
       const redirectUrl = 'http://redirect';
 
       file.getSignedPolicy(
@@ -2097,12 +2097,12 @@ describe('File', function() {
           expires: Date.now() + 2000,
           successRedirect: redirectUrl,
         },
-        function(err, signedPolicy) {
+        (err, signedPolicy) => {
           assert.ifError(err);
 
           const policy = JSON.parse(signedPolicy.string);
           assert(
-            policy.conditions.some(function(condition) {
+            policy.conditions.some(condition => {
               return condition.success_action_redirect === redirectUrl;
             })
           );
@@ -2112,7 +2112,7 @@ describe('File', function() {
       );
     });
 
-    it('should add success status', function(done) {
+    it('should add success status', done => {
       const successStatus = '200';
 
       file.getSignedPolicy(
@@ -2120,12 +2120,12 @@ describe('File', function() {
           expires: Date.now() + 2000,
           successStatus,
         },
-        function(err, signedPolicy) {
+        (err, signedPolicy) => {
           assert.ifError(err);
 
           const policy = JSON.parse(signedPolicy.string);
           assert(
-            policy.conditions.some(function(condition) {
+            policy.conditions.some(condition => {
               return condition.success_action_status === successStatus;
             })
           );
@@ -2135,15 +2135,15 @@ describe('File', function() {
       );
     });
 
-    describe('expires', function() {
-      it('should accept Date objects', function(done) {
+    describe('expires', () => {
+      it('should accept Date objects', done => {
         const expires = new Date(Date.now() + 1000 * 60);
 
         file.getSignedPolicy(
           {
             expires,
           },
-          function(err, policy) {
+          (err, policy) => {
             assert.ifError(err);
             const expires_ = JSON.parse(policy.string).expiration;
             assert.strictEqual(expires_, expires.toISOString());
@@ -2152,14 +2152,14 @@ describe('File', function() {
         );
       });
 
-      it('should accept numbers', function(done) {
+      it('should accept numbers', done => {
         const expires = Date.now() + 1000 * 60;
 
         file.getSignedPolicy(
           {
             expires,
           },
-          function(err, policy) {
+          (err, policy) => {
             assert.ifError(err);
             const expires_ = JSON.parse(policy.string).expiration;
             assert.strictEqual(expires_, new Date(expires).toISOString());
@@ -2168,14 +2168,14 @@ describe('File', function() {
         );
       });
 
-      it('should accept strings', function(done) {
+      it('should accept strings', done => {
         const expires = '12-12-2099';
 
         file.getSignedPolicy(
           {
             expires,
           },
-          function(err, policy) {
+          (err, policy) => {
             assert.ifError(err);
             const expires_ = JSON.parse(policy.string).expiration;
             assert.strictEqual(expires_, new Date(expires).toISOString());
@@ -2184,28 +2184,28 @@ describe('File', function() {
         );
       });
 
-      it('should throw if a date from the past is given', function() {
+      it('should throw if a date from the past is given', () => {
         const expires = Date.now() - 5;
 
-        assert.throws(function() {
+        assert.throws(() => {
           file.getSignedPolicy(
             {
               expires,
             },
-            function() {}
+            () => { }
           );
         }, /An expiration date cannot be in the past\./);
       });
     });
 
-    describe('equality condition', function() {
-      it('should add equality conditions (array of arrays)', function(done) {
+    describe('equality condition', () => {
+      it('should add equality conditions (array of arrays)', done => {
         file.getSignedPolicy(
           {
             expires: Date.now() + 2000,
             equals: [['$<field>', '<value>']],
           },
-          function(err, signedPolicy) {
+          (err, signedPolicy) => {
             const conditionString = '["eq","$<field>","<value>"]';
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
@@ -2214,13 +2214,13 @@ describe('File', function() {
         );
       });
 
-      it('should add equality condition (array)', function(done) {
+      it('should add equality condition (array)', done => {
         file.getSignedPolicy(
           {
             expires: Date.now() + 2000,
             equals: ['$<field>', '<value>'],
           },
-          function(err, signedPolicy) {
+          (err, signedPolicy) => {
             const conditionString = '["eq","$<field>","<value>"]';
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
@@ -2229,39 +2229,39 @@ describe('File', function() {
         );
       });
 
-      it('should throw if equal condition is not an array', function() {
-        assert.throws(function() {
+      it('should throw if equal condition is not an array', () => {
+        assert.throws(() => {
           file.getSignedPolicy(
             {
               expires: Date.now() + 2000,
               equals: [{}],
             },
-            function() {}
+            () => { }
           );
         }, /Equals condition must be an array of 2 elements\./);
       });
 
-      it('should throw if equal condition length is not 2', function() {
-        assert.throws(function() {
+      it('should throw if equal condition length is not 2', () => {
+        assert.throws(() => {
           file.getSignedPolicy(
             {
               expires: Date.now() + 2000,
               equals: [['1', '2', '3']],
             },
-            function() {}
+            () => { }
           );
         }, /Equals condition must be an array of 2 elements\./);
       });
     });
 
-    describe('prefix conditions', function() {
-      it('should add prefix conditions (array of arrays)', function(done) {
+    describe('prefix conditions', () => {
+      it('should add prefix conditions (array of arrays)', done => {
         file.getSignedPolicy(
           {
             expires: Date.now() + 2000,
             startsWith: [['$<field>', '<value>']],
           },
-          function(err, signedPolicy) {
+          (err, signedPolicy) => {
             const conditionString = '["starts-with","$<field>","<value>"]';
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
@@ -2270,13 +2270,13 @@ describe('File', function() {
         );
       });
 
-      it('should add prefix condition (array)', function(done) {
+      it('should add prefix condition (array)', done => {
         file.getSignedPolicy(
           {
             expires: Date.now() + 2000,
             startsWith: ['$<field>', '<value>'],
           },
-          function(err, signedPolicy) {
+          (err, signedPolicy) => {
             const conditionString = '["starts-with","$<field>","<value>"]';
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
@@ -2285,39 +2285,39 @@ describe('File', function() {
         );
       });
 
-      it('should throw if prexif condition is not an array', function() {
-        assert.throws(function() {
+      it('should throw if prexif condition is not an array', () => {
+        assert.throws(() => {
           file.getSignedPolicy(
             {
               expires: Date.now() + 2000,
               startsWith: [{}],
             },
-            function() {}
+            () => { }
           );
         }, /StartsWith condition must be an array of 2 elements\./);
       });
 
-      it('should throw if prefix condition length is not 2', function() {
-        assert.throws(function() {
+      it('should throw if prefix condition length is not 2', () => {
+        assert.throws(() => {
           file.getSignedPolicy(
             {
               expires: Date.now() + 2000,
               startsWith: [['1', '2', '3']],
             },
-            function() {}
+            () => { }
           );
         }, /StartsWith condition must be an array of 2 elements\./);
       });
     });
 
-    describe('content length', function() {
-      it('should add content length condition', function(done) {
+    describe('content length', () => {
+      it('should add content length condition', done => {
         file.getSignedPolicy(
           {
             expires: Date.now() + 2000,
-            contentLengthRange: {min: 0, max: 1},
+            contentLengthRange: { min: 0, max: 1 },
           },
-          function(err, signedPolicy) {
+          (err, signedPolicy) => {
             const conditionString = '["content-length-range",0,1]';
             assert.ifError(err);
             assert(signedPolicy.string.indexOf(conditionString) > -1);
@@ -2326,39 +2326,39 @@ describe('File', function() {
         );
       });
 
-      it('should throw if content length has no min', function() {
-        assert.throws(function() {
+      it('should throw if content length has no min', () => {
+        assert.throws(() => {
           file.getSignedPolicy(
             {
               expires: Date.now() + 2000,
-              contentLengthRange: [{max: 1}],
+              contentLengthRange: [{ max: 1 }],
             },
-            function() {}
+            () => { }
           );
         }, /ContentLengthRange must have numeric min & max fields\./);
       });
 
-      it('should throw if content length has no max', function() {
-        assert.throws(function() {
+      it('should throw if content length has no max', () => {
+        assert.throws(() => {
           file.getSignedPolicy(
             {
               expires: Date.now() + 2000,
-              contentLengthRange: [{min: 0}],
+              contentLengthRange: [{ min: 0 }],
             },
-            function() {}
+            () => { }
           );
         }, /ContentLengthRange must have numeric min & max fields\./);
       });
     });
   });
 
-  describe('getSignedUrl', function() {
+  describe('getSignedUrl', () => {
     const CONFIG = {
       action: 'read',
       expires: Date.now() + 2000,
     };
 
-    beforeEach(function() {
+    beforeEach(() => {
       BUCKET.storage.authClient = {
         getCredentials() {
           return Promise.resolve({
@@ -2371,8 +2371,8 @@ describe('File', function() {
       };
     });
 
-    it('should create a signed url', function(done) {
-      BUCKET.storage.authClient.sign = function(blobToSign) {
+    it('should create a signed url', done => {
+      BUCKET.storage.authClient.sign = blobToSign => {
         assert.deepStrictEqual(
           blobToSign,
           [
@@ -2386,7 +2386,7 @@ describe('File', function() {
         return Promise.resolve('signature');
       };
 
-      file.getSignedUrl(CONFIG, function(err, signedUrl) {
+      file.getSignedUrl(CONFIG, (err, signedUrl) => {
         assert.ifError(err);
         assert.equal(typeof signedUrl, 'string');
         const expires = Math.round(CONFIG.expires / 1000);
@@ -2400,22 +2400,22 @@ describe('File', function() {
       });
     });
 
-    it('should not modify the configuration object', function(done) {
+    it('should not modify the configuration object', done => {
       const originalConfig = extend({}, CONFIG);
 
-      file.getSignedUrl(CONFIG, function(err) {
+      file.getSignedUrl(CONFIG, err => {
         assert.ifError(err);
         assert.deepEqual(CONFIG, originalConfig);
         done();
       });
     });
 
-    it('should set correct settings if resumable', function(done) {
+    it('should set correct settings if resumable', done => {
       const config = extend({}, CONFIG, {
         action: 'resumable',
       });
 
-      BUCKET.storage.authClient.sign = function(blobToSign) {
+      BUCKET.storage.authClient.sign = blobToSign => {
         assert.strictEqual(blobToSign.indexOf('POST'), 0);
         assert(blobToSign.indexOf('x-goog-resumable:start') > -1);
         done();
@@ -2424,28 +2424,28 @@ describe('File', function() {
       file.getSignedUrl(config, assert.ifError);
     });
 
-    it('should return an error if signBlob errors', function(done) {
+    it('should return an error if signBlob errors', done => {
       const error = new Error('Error.');
 
-      BUCKET.storage.authClient.sign = function() {
+      BUCKET.storage.authClient.sign = () => {
         return Promise.reject(error);
       };
 
-      file.getSignedUrl(CONFIG, function(err) {
+      file.getSignedUrl(CONFIG, err => {
         assert.strictEqual(err.name, 'SigningError');
         assert.strictEqual(err.message, error.message);
         done();
       });
     });
 
-    it('should URI encode file names', function(done) {
-      directoryFile.getSignedUrl(CONFIG, function(err, signedUrl) {
+    it('should URI encode file names', done => {
+      directoryFile.getSignedUrl(CONFIG, (err, signedUrl) => {
         assert(signedUrl.indexOf(encodeURIComponent(directoryFile.name)) > -1);
         done();
       });
     });
 
-    it('should add response-content-type parameter', function(done) {
+    it('should add response-content-type parameter', done => {
       const type = 'application/json';
 
       directoryFile.getSignedUrl(
@@ -2454,29 +2454,29 @@ describe('File', function() {
           expires: Date.now() + 2000,
           responseType: type,
         },
-        function(err, signedUrl) {
+        (err, signedUrl) => {
           assert(signedUrl.indexOf(encodeURIComponent(type)) > -1);
           done();
         }
       );
     });
 
-    it('should add generation parameter', function(done) {
+    it('should add generation parameter', done => {
       const generation = 10003320000;
-      const file = new File(BUCKET, 'name', {generation});
+      const file = new File(BUCKET, 'name', { generation });
 
-      file.getSignedUrl(CONFIG, function(err, signedUrl) {
+      file.getSignedUrl(CONFIG, (err, signedUrl) => {
         assert(signedUrl.indexOf(encodeURIComponent(generation.toString())) > -1);
         done();
       });
     });
 
-    describe('cname', function() {
-      it('should use a provided cname', function(done) {
+    describe('cname', () => {
+      it('should use a provided cname', done => {
         const host = 'http://www.example.com';
-        const configWithCname = extend({cname: host}, CONFIG);
+        const configWithCname = extend({ cname: host }, CONFIG);
 
-        file.getSignedUrl(configWithCname, function(err, signedUrl) {
+        file.getSignedUrl(configWithCname, (err, signedUrl) => {
           assert.ifError(err);
 
           const expires = Math.round(CONFIG.expires / 1000);
@@ -2491,7 +2491,7 @@ describe('File', function() {
         });
       });
 
-      it('should remove trailing slashes from cname', function(done) {
+      it('should remove trailing slashes from cname', done => {
         const host = 'http://www.example.com//';
 
         file.getSignedUrl(
@@ -2500,7 +2500,7 @@ describe('File', function() {
             cname: host,
             expires: Date.now() + 2000,
           },
-          function(err, signedUrl) {
+          (err, signedUrl) => {
             assert.ifError(err);
             assert.strictEqual(signedUrl.indexOf(host), -1);
             assert.strictEqual(signedUrl.indexOf(host.substr(0, -1)), 0);
@@ -2510,8 +2510,8 @@ describe('File', function() {
       });
     });
 
-    describe('promptSaveAs', function() {
-      it('should add response-content-disposition', function(done) {
+    describe('promptSaveAs', () => {
+      it('should add response-content-disposition', done => {
         const disposition = 'attachment; filename="fname.ext"';
         directoryFile.getSignedUrl(
           {
@@ -2519,7 +2519,7 @@ describe('File', function() {
             expires: Date.now() + 2000,
             promptSaveAs: 'fname.ext',
           },
-          function(err, signedUrl) {
+          (err, signedUrl) => {
             assert(signedUrl.indexOf(encodeURIComponent(disposition)) > -1);
             done();
           }
@@ -2527,8 +2527,8 @@ describe('File', function() {
       });
     });
 
-    describe('responseDisposition', function() {
-      it('should add response-content-disposition', function(done) {
+    describe('responseDisposition', () => {
+      it('should add response-content-disposition', done => {
         const disposition = 'attachment; filename="fname.ext"';
         directoryFile.getSignedUrl(
           {
@@ -2536,14 +2536,14 @@ describe('File', function() {
             expires: Date.now() + 2000,
             responseDisposition: disposition,
           },
-          function(err, signedUrl) {
+          (err, signedUrl) => {
             assert(signedUrl.indexOf(encodeURIComponent(disposition)) > -1);
             done();
           }
         );
       });
 
-      it('should ignore promptSaveAs if set', function(done) {
+      it('should ignore promptSaveAs if set', done => {
         const disposition = 'attachment; filename="fname.ext"';
         const saveAs = 'fname2.ext';
         directoryFile.getSignedUrl(
@@ -2553,7 +2553,7 @@ describe('File', function() {
             promptSaveAs: saveAs,
             responseDisposition: disposition,
           },
-          function(err, signedUrl) {
+          (err, signedUrl) => {
             assert(signedUrl.indexOf(encodeURIComponent(disposition)) > -1);
             assert(signedUrl.indexOf(encodeURIComponent(saveAs)) === -1);
             done();
@@ -2562,8 +2562,8 @@ describe('File', function() {
       });
     });
 
-    describe('expires', function() {
-      it('should accept Date objects', function(done) {
+    describe('expires', () => {
+      it('should accept Date objects', done => {
         const expires = new Date(Date.now() + 1000 * 60);
         const expectedExpires = Math.round(expires.valueOf() / 1000);
 
@@ -2572,7 +2572,7 @@ describe('File', function() {
             action: 'read',
             expires,
           },
-          function(err, signedUrl) {
+          (err, signedUrl) => {
             assert.ifError(err);
             const expires_ = url.parse(signedUrl, true).query.Expires;
             assert.equal(expires_, expectedExpires);
@@ -2581,7 +2581,7 @@ describe('File', function() {
         );
       });
 
-      it('should accept numbers', function(done) {
+      it('should accept numbers', done => {
         const expires = Date.now() + 1000 * 60;
         const expectedExpires = Math.round(new Date(expires).valueOf() / 1000);
 
@@ -2590,7 +2590,7 @@ describe('File', function() {
             action: 'read',
             expires,
           },
-          function(err, signedUrl) {
+          (err, signedUrl) => {
             assert.ifError(err);
             const expires_ = url.parse(signedUrl, true).query.Expires;
             assert.equal(expires_, expectedExpires);
@@ -2599,7 +2599,7 @@ describe('File', function() {
         );
       });
 
-      it('should accept strings', function(done) {
+      it('should accept strings', done => {
         const expires = '12-12-2099';
         const expectedExpires = Math.round(new Date(expires).valueOf() / 1000);
 
@@ -2608,7 +2608,7 @@ describe('File', function() {
             action: 'read',
             expires,
           },
-          function(err, signedUrl) {
+          (err, signedUrl) => {
             assert.ifError(err);
             const expires_ = url.parse(signedUrl, true).query.Expires;
             assert.equal(expires_, expectedExpires);
@@ -2617,29 +2617,29 @@ describe('File', function() {
         );
       });
 
-      it('should throw if a date from the past is given', function() {
+      it('should throw if a date from the past is given', () => {
         const expires = Date.now() - 5;
 
-        assert.throws(function() {
+        assert.throws(() => {
           file.getSignedUrl(
             {
               action: 'read',
               expires,
             },
-            function() {}
+            () => { }
           );
         }, /An expiration date cannot be in the past\./);
       });
     });
 
-    describe('extensionHeaders', function() {
-      it('should add headers to signature', function(done) {
+    describe('extensionHeaders', () => {
+      it('should add headers to signature', done => {
         const extensionHeaders = {
           'x-goog-acl': 'public-read',
           'x-foo': 'bar',
         };
 
-        BUCKET.storage.authClient.sign = function(blobToSign) {
+        BUCKET.storage.authClient.sign = blobToSign => {
           const headers = 'x-goog-acl:public-read\nx-foo:bar\n';
           assert(blobToSign.indexOf(headers) > -1);
           done();
@@ -2657,15 +2657,15 @@ describe('File', function() {
     });
   });
 
-  describe('makePrivate', function() {
-    it('should execute callback with API response', function(done) {
+  describe('makePrivate', () => {
+    it('should execute callback with API response', done => {
       const apiResponse = {};
 
-      file.setMetadata = function(metadata, query, callback) {
+      file.setMetadata = (metadata, query, callback) => {
         callback(null, apiResponse);
       };
 
-      file.makePrivate(function(err, apiResponse_) {
+      file.makePrivate((err, apiResponse_) => {
         assert.ifError(err);
         assert.strictEqual(apiResponse_, apiResponse);
 
@@ -2673,15 +2673,15 @@ describe('File', function() {
       });
     });
 
-    it('should execute callback with error & API response', function(done) {
+    it('should execute callback with error & API response', done => {
       const error = new Error('Error.');
       const apiResponse = {};
 
-      file.setMetadata = function(metadata, query, callback) {
+      file.setMetadata = (metadata, query, callback) => {
         callback(error, apiResponse);
       };
 
-      file.makePrivate(function(err, apiResponse_) {
+      file.makePrivate((err, apiResponse_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(apiResponse_, apiResponse);
 
@@ -2689,31 +2689,31 @@ describe('File', function() {
       });
     });
 
-    it('should make the file private to project by default', function(done) {
-      file.setMetadata = function(metadata, query) {
-        assert.deepStrictEqual(metadata, {acl: null});
-        assert.deepEqual(query, {predefinedAcl: 'projectPrivate'});
+    it('should make the file private to project by default', done => {
+      file.setMetadata = (metadata, query) => {
+        assert.deepStrictEqual(metadata, { acl: null });
+        assert.deepEqual(query, { predefinedAcl: 'projectPrivate' });
         done();
       };
 
       file.makePrivate(util.noop);
     });
 
-    it('should make the file private to user if strict = true', function(done) {
-      file.setMetadata = function(metadata, query) {
-        assert.deepEqual(query, {predefinedAcl: 'private'});
+    it('should make the file private to user if strict = true', done => {
+      file.setMetadata = (metadata, query) => {
+        assert.deepEqual(query, { predefinedAcl: 'private' });
         done();
       };
 
-      file.makePrivate({strict: true}, util.noop);
+      file.makePrivate({ strict: true }, util.noop);
     });
 
-    it('should accept userProject', function(done) {
+    it('should accept userProject', done => {
       const options = {
         userProject: 'user-project-id',
       };
 
-      file.setMetadata = function(metadata, query) {
+      file.setMetadata = (metadata, query) => {
         assert.strictEqual(query.userProject, options.userProject);
         done();
       };
@@ -2722,18 +2722,18 @@ describe('File', function() {
     });
   });
 
-  describe('makePublic', function() {
-    it('should execute callback', function(done) {
-      file.acl.add = function(options, callback) {
+  describe('makePublic', () => {
+    it('should execute callback', done => {
+      file.acl.add = (options, callback) => {
         callback();
       };
 
       file.makePublic(done);
     });
 
-    it('should make the file public', function(done) {
-      file.acl.add = function(options) {
-        assert.deepEqual(options, {entity: 'allUsers', role: 'READER'});
+    it('should make the file public', done => {
+      file.acl.add = options => {
+        assert.deepEqual(options, { entity: 'allUsers', role: 'READER' });
         done();
       };
 
@@ -2741,37 +2741,37 @@ describe('File', function() {
     });
   });
 
-  describe('move', function() {
-    describe('copy to destination', function() {
+  describe('move', () => {
+    describe('copy to destination', () => {
       function assertCopyFile(file, expectedDestination, callback) {
-        file.copy = function(destination) {
+        file.copy = destination => {
           assert.strictEqual(destination, expectedDestination);
           callback();
         };
       }
 
-      it('should call copy with string', function(done) {
+      it('should call copy with string', done => {
         const newFileName = 'new-file-name.png';
         assertCopyFile(file, newFileName, done);
         file.move(newFileName);
       });
 
-      it('should call copy with Bucket', function(done) {
+      it('should call copy with Bucket', done => {
         assertCopyFile(file, BUCKET, done);
         file.move(BUCKET);
       });
 
-      it('should call copy with File', function(done) {
+      it('should call copy with File', done => {
         const newFile = new File(BUCKET, 'new-file');
         assertCopyFile(file, newFile, done);
         file.move(newFile);
       });
 
-      it('should accept an options object', function(done) {
+      it('should accept an options object', done => {
         const newFile = new File(BUCKET, 'name');
         const options = {};
 
-        file.copy = function(destination, options_) {
+        file.copy = (destination, options_) => {
           assert.strictEqual(options_, options);
           done();
         };
@@ -2779,52 +2779,52 @@ describe('File', function() {
         file.move(newFile, options, assert.ifError);
       });
 
-      it('should fail if copy fails', function(done) {
+      it('should fail if copy fails', done => {
         const error = new Error('Error.');
-        file.copy = function(destination, options, callback) {
+        file.copy = (destination, options, callback) => {
           callback(error);
         };
-        file.move('new-filename', function(err) {
+        file.move('new-filename', err => {
           assert.equal(err, error);
           done();
         });
       });
     });
 
-    describe('delete original file', function() {
-      it('should delete if copy is successful', function(done) {
-        file.copy = function(destination, options, callback) {
+    describe('delete original file', () => {
+      it('should delete if copy is successful', done => {
+        file.copy = (destination, options, callback) => {
           callback(null);
         };
-        file.delete = function() {
+        file.delete = () => {
           assert.equal(this, file);
           done();
         };
         file.move('new-filename');
       });
 
-      it('should not delete if copy fails', function(done) {
+      it('should not delete if copy fails', done => {
         let deleteCalled = false;
-        file.copy = function(destination, options, callback) {
+        file.copy = (destination, options, callback) => {
           callback(new Error('Error.'));
         };
-        file.delete = function() {
+        file.delete = () => {
           deleteCalled = true;
         };
-        file.move('new-filename', function() {
+        file.move('new-filename', () => {
           assert.equal(deleteCalled, false);
           done();
         });
       });
 
-      it('should pass options to delete', function(done) {
+      it('should pass options to delete', done => {
         const options = {};
 
-        file.copy = function(destination, options, callback) {
+        file.copy = (destination, options, callback) => {
           callback();
         };
 
-        file.delete = function(options_) {
+        file.delete = options_ => {
           assert.strictEqual(options_, options);
           done();
         };
@@ -2832,15 +2832,15 @@ describe('File', function() {
         file.move('new-filename', options, assert.ifError);
       });
 
-      it('should fail if delete fails', function(done) {
+      it('should fail if delete fails', done => {
         const error = new Error('Error.');
-        file.copy = function(destination, options, callback) {
+        file.copy = (destination, options, callback) => {
           callback();
         };
-        file.delete = function(options, callback) {
+        file.delete = (options, callback) => {
           callback(error);
         };
-        file.move('new-filename', function(err) {
+        file.move('new-filename', err => {
           assert.equal(err, error);
           done();
         });
@@ -2848,15 +2848,15 @@ describe('File', function() {
     });
   });
 
-  describe('request', function() {
+  describe('request', () => {
     const USER_PROJECT = 'grape-spaceship-123';
 
-    beforeEach(function() {
+    beforeEach(() => {
       file.userProject = USER_PROJECT;
     });
 
-    it('should set the userProject if qs is undefined', function(done) {
-      FakeServiceObject.prototype.request = function(reqOpts) {
+    it('should set the userProject if qs is undefined', done => {
+      FakeServiceObject.prototype.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
         done();
       };
@@ -2864,14 +2864,14 @@ describe('File', function() {
       file.request({}, assert.ifError);
     });
 
-    it('should set the userProject if field is undefined', function(done) {
+    it('should set the userProject if field is undefined', done => {
       const options = {
         qs: {
           foo: 'bar',
         },
       };
 
-      FakeServiceObject.prototype.request = function(reqOpts) {
+      FakeServiceObject.prototype.request = reqOpts => {
         assert.strictEqual(reqOpts.qs, options.qs);
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
         done();
@@ -2880,7 +2880,7 @@ describe('File', function() {
       file.request(options, assert.ifError);
     });
 
-    it('should not overwrite the userProject', function(done) {
+    it('should not overwrite the userProject', done => {
       const fakeUserProject = 'not-grape-spaceship-123';
       const options = {
         qs: {
@@ -2888,7 +2888,7 @@ describe('File', function() {
         },
       };
 
-      FakeServiceObject.prototype.request = function(reqOpts) {
+      FakeServiceObject.prototype.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, fakeUserProject);
         done();
       };
@@ -2896,10 +2896,10 @@ describe('File', function() {
       file.request(options, assert.ifError);
     });
 
-    it('should call ServiceObject#request correctly', function(done) {
+    it('should call ServiceObject#request correctly', done => {
       const options = {};
 
-      FakeServiceObject.prototype.request = function(reqOpts, callback) {
+      FakeServiceObject.prototype.request = (reqOpts, callback) => {
         assert.strictEqual(this, file);
         assert.strictEqual(reqOpts, options);
         callback(); // done fn
@@ -2909,11 +2909,11 @@ describe('File', function() {
     });
   });
 
-  describe('rotateEncryptionKey', function() {
-    it('should create new File correctly', function(done) {
+  describe('rotateEncryptionKey', () => {
+    it('should create new File correctly', done => {
       const options = {};
 
-      file.bucket.file = function(id, options_) {
+      file.bucket.file = (id, options_) => {
         assert.strictEqual(id, file.id);
         assert.strictEqual(options_, options);
         done();
@@ -2922,10 +2922,10 @@ describe('File', function() {
       file.rotateEncryptionKey(options, assert.ifError);
     });
 
-    it('should default to customer-supplied encryption key', function(done) {
+    it('should default to customer-supplied encryption key', done => {
       const encryptionKey = 'encryption-key';
 
-      file.bucket.file = function(id, options) {
+      file.bucket.file = (id, options) => {
         assert.strictEqual(options.encryptionKey, encryptionKey);
         done();
       };
@@ -2933,10 +2933,10 @@ describe('File', function() {
       file.rotateEncryptionKey(encryptionKey, assert.ifError);
     });
 
-    it('should accept a Buffer for customer-supplied encryption key', function(done) {
+    it('should accept a Buffer for customer-supplied encryption key', done => {
       const encryptionKey = crypto.randomBytes(32);
 
-      file.bucket.file = function(id, options) {
+      file.bucket.file = (id, options) => {
         assert.strictEqual(options.encryptionKey, encryptionKey);
         done();
       };
@@ -2944,14 +2944,14 @@ describe('File', function() {
       file.rotateEncryptionKey(encryptionKey, assert.ifError);
     });
 
-    it('should call copy correctly', function(done) {
+    it('should call copy correctly', done => {
       const newFile = {};
 
-      file.bucket.file = function() {
+      file.bucket.file = () => {
         return newFile;
       };
 
-      file.copy = function(destination, callback) {
+      file.copy = (destination, callback) => {
         assert.strictEqual(destination, newFile);
         callback(); // done()
       };
@@ -2960,13 +2960,13 @@ describe('File', function() {
     });
   });
 
-  describe('save', function() {
+  describe('save', () => {
     const DATA = 'Data!';
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const options = {};
 
-      file.createWriteStream = function(options_) {
+      file.createWriteStream = options_ => {
         assert.strictEqual(options_, options);
         setImmediate(done);
         return new stream.PassThrough();
@@ -2975,8 +2975,8 @@ describe('File', function() {
       file.save(DATA, options, assert.ifError);
     });
 
-    it('should not require options', function(done) {
-      file.createWriteStream = function(options_) {
+    it('should not require options', done => {
+      file.createWriteStream = options_ => {
         assert.deepEqual(options_, {});
         setImmediate(done);
         return new stream.PassThrough();
@@ -2985,11 +2985,11 @@ describe('File', function() {
       file.save(DATA, assert.ifError);
     });
 
-    it('should register the error listener', function(done) {
-      file.createWriteStream = function() {
+    it('should register the error listener', done => {
+      file.createWriteStream = () => {
         const writeStream = new stream.PassThrough();
         writeStream.on('error', done);
-        setImmediate(function() {
+        setImmediate(() => {
           writeStream.emit('error');
         });
         return writeStream;
@@ -2998,8 +2998,8 @@ describe('File', function() {
       file.save(DATA, assert.ifError);
     });
 
-    it('should register the finish listener', function(done) {
-      file.createWriteStream = function() {
+    it('should register the finish listener', done => {
+      file.createWriteStream = () => {
         const writeStream = new stream.PassThrough();
         writeStream.once('finish', done);
         return writeStream;
@@ -3008,10 +3008,10 @@ describe('File', function() {
       file.save(DATA, assert.ifError);
     });
 
-    it('should write the data', function(done) {
-      file.createWriteStream = function() {
+    it('should write the data', done => {
+      file.createWriteStream = () => {
         const writeStream = new stream.PassThrough();
-        writeStream.on('data', function(data) {
+        writeStream.on('data', data => {
           assert.strictEqual(data.toString(), DATA);
           done();
         });
@@ -3022,11 +3022,11 @@ describe('File', function() {
     });
   });
 
-  describe('setMetadata', function() {
-    it('should make the correct request', function(done) {
+  describe('setMetadata', () => {
+    it('should make the correct request', done => {
       const metadata = {};
 
-      file.parent.setMetadata = function(metadata, options, callback) {
+      file.parent.setMetadata = (metadata, options, callback) => {
         assert.strictEqual(this, file);
         assert.deepEqual(options, {});
         callback(); // done()
@@ -3035,13 +3035,13 @@ describe('File', function() {
       file.setMetadata(metadata, done);
     });
 
-    it('should accept options', function(done) {
+    it('should accept options', done => {
       const options = {
         a: 'b',
         c: 'd',
       };
 
-      file.parent.setMetadata = function(metadata, options_) {
+      file.parent.setMetadata = (metadata, options_) => {
         assert.deepStrictEqual(options_, options);
         done();
       };
@@ -3049,7 +3049,7 @@ describe('File', function() {
       file.setMetadata({}, options, assert.ifError);
     });
 
-    it('should use requestQueryObject', function(done) {
+    it('should use requestQueryObject', done => {
       const options = {
         a: 'b',
         c: 'd',
@@ -3065,7 +3065,7 @@ describe('File', function() {
         generation: 2,
       };
 
-      file.parent.setMetadata = function(metadata, options) {
+      file.parent.setMetadata = (metadata, options) => {
         assert.deepStrictEqual(options, expectedOptions);
         done();
       };
@@ -3074,11 +3074,11 @@ describe('File', function() {
     });
   });
 
-  describe('setStorageClass', function() {
+  describe('setStorageClass', () => {
     const STORAGE_CLASS = 'new_storage_class';
 
-    it('should make the correct copy request', function(done) {
-      file.copy = function(newFile, options) {
+    it('should make the correct copy request', done => {
+      file.copy = (newFile, options) => {
         assert.strictEqual(newFile, file);
         assert.deepEqual(options, {
           storageClass: STORAGE_CLASS.toUpperCase(),
@@ -3089,7 +3089,7 @@ describe('File', function() {
       file.setStorageClass(STORAGE_CLASS, assert.ifError);
     });
 
-    it('should accept options', function(done) {
+    it('should accept options', done => {
       const options = {
         a: 'b',
         c: 'd',
@@ -3101,7 +3101,7 @@ describe('File', function() {
         storageClass: STORAGE_CLASS.toUpperCase(),
       };
 
-      file.copy = function(newFile, options) {
+      file.copy = (newFile, options) => {
         assert.deepStrictEqual(options, expectedOptions);
         done();
       };
@@ -3109,8 +3109,8 @@ describe('File', function() {
       file.setStorageClass(STORAGE_CLASS, options, assert.ifError);
     });
 
-    it('should convert camelCase to snake_case', function(done) {
-      file.copy = function(newFile, options) {
+    it('should convert camelCase to snake_case', done => {
+      file.copy = (newFile, options) => {
         assert.strictEqual(options.storageClass, 'CAMEL_CASE');
         done();
       };
@@ -3118,8 +3118,8 @@ describe('File', function() {
       file.setStorageClass('camelCase', assert.ifError);
     });
 
-    it('should convert hyphenate to snake_case', function(done) {
-      file.copy = function(newFile, options) {
+    it('should convert hyphenate to snake_case', done => {
+      file.copy = (newFile, options) => {
         assert.strictEqual(options.storageClass, 'HYPHENATED_CLASS');
         done();
       };
@@ -3127,18 +3127,18 @@ describe('File', function() {
       file.setStorageClass('hyphenated-class', assert.ifError);
     });
 
-    describe('error', function() {
+    describe('error', () => {
       const ERROR = new Error('Error.');
       const API_RESPONSE = {};
 
-      beforeEach(function() {
-        file.copy = function(newFile, options, callback) {
+      beforeEach(() => {
+        file.copy = (newFile, options, callback) => {
           callback(ERROR, null, API_RESPONSE);
         };
       });
 
-      it('should execute callback with error & API response', function(done) {
-        file.setStorageClass(STORAGE_CLASS, function(err, apiResponse) {
+      it('should execute callback with error & API response', done => {
+        file.setStorageClass(STORAGE_CLASS, (err, apiResponse) => {
           assert.strictEqual(err, ERROR);
           assert.strictEqual(apiResponse, API_RESPONSE);
           done();
@@ -3146,7 +3146,7 @@ describe('File', function() {
       });
     });
 
-    describe('success', function() {
+    describe('success', () => {
       const METADATA = {};
 
       const COPIED_FILE = {
@@ -3155,22 +3155,22 @@ describe('File', function() {
 
       const API_RESPONSE = {};
 
-      beforeEach(function() {
-        file.copy = function(newFile, options, callback) {
+      beforeEach(() => {
+        file.copy = (newFile, options, callback) => {
           callback(null, COPIED_FILE, API_RESPONSE);
         };
       });
 
-      it('should update the metadata on the file', function(done) {
-        file.setStorageClass(STORAGE_CLASS, function(err) {
+      it('should update the metadata on the file', done => {
+        file.setStorageClass(STORAGE_CLASS, err => {
           assert.ifError(err);
           assert.strictEqual(file.metadata, METADATA);
           done();
         });
       });
 
-      it('should execute callback with api response', function(done) {
-        file.setStorageClass(STORAGE_CLASS, function(err, apiResponse) {
+      it('should execute callback with api response', done => {
+        file.setStorageClass(STORAGE_CLASS, (err, apiResponse) => {
           assert.ifError(err);
           assert.strictEqual(apiResponse, API_RESPONSE);
           done();
@@ -3179,7 +3179,7 @@ describe('File', function() {
     });
   });
 
-  describe('setEncryptionKey', function() {
+  describe('setEncryptionKey', () => {
     const KEY = crypto.randomBytes(32);
     const KEY_BASE64 = Buffer.from(KEY as any).toString('base64');
     const KEY_HASH = crypto
@@ -3188,27 +3188,27 @@ describe('File', function() {
       .digest('base64');
     let _file;
 
-    beforeEach(function() {
+    beforeEach(() => {
       _file = file.setEncryptionKey(KEY);
     });
 
-    it('should localize the key', function() {
+    it('should localize the key', () => {
       assert.strictEqual(file.encryptionKey, KEY);
     });
 
-    it('should localize the base64 key', function() {
+    it('should localize the base64 key', () => {
       assert.strictEqual(file.encryptionKeyBase64, KEY_BASE64);
     });
 
-    it('should localize the hash', function() {
+    it('should localize the hash', () => {
       assert.strictEqual(file.encryptionKeyHash, KEY_HASH);
     });
 
-    it('should return the file instance', function() {
+    it('should return the file instance', () => {
       assert.strictEqual(_file, file);
     });
 
-    it('should push the correct request interceptor', function(done) {
+    it('should push the correct request interceptor', done => {
       const expectedInterceptor = {
         headers: {
           'x-goog-encryption-algorithm': 'AES256',
@@ -3230,9 +3230,9 @@ describe('File', function() {
     });
   });
 
-  describe('startResumableUpload_', function() {
-    describe('starting', function() {
-      it('should start a resumable upload', function(done) {
+  describe('startResumableUpload_', () => {
+    describe('starting', () => {
+      it('should start a resumable upload', done => {
         const options = {
           metadata: {},
           offset: 1234,
@@ -3274,20 +3274,20 @@ describe('File', function() {
         file.startResumableUpload_(duplexify(), options);
       });
 
-      it('should emit the response', function(done) {
+      it('should emit the response', done => {
         const resp = {};
         const uploadStream = through();
 
         resumableUploadOverride = {
           upload() {
-            setImmediate(function() {
+            setImmediate(() => {
               uploadStream.emit('response', resp);
             });
             return uploadStream;
           },
         };
 
-        uploadStream.on('response', function(resp_) {
+        uploadStream.on('response', resp_ => {
           assert.strictEqual(resp_, resp);
           done();
         });
@@ -3295,16 +3295,16 @@ describe('File', function() {
         file.startResumableUpload_(duplexify());
       });
 
-      it('should set the metadata from the metadata event', function(done) {
+      it('should set the metadata from the metadata event', done => {
         const metadata = {};
         const uploadStream = through();
 
         resumableUploadOverride = {
           upload() {
-            setImmediate(function() {
+            setImmediate(() => {
               uploadStream.emit('metadata', metadata);
 
-              setImmediate(function() {
+              setImmediate(() => {
                 assert.strictEqual(file.metadata, metadata);
                 done();
               });
@@ -3316,7 +3316,7 @@ describe('File', function() {
         file.startResumableUpload_(duplexify());
       });
 
-      it('should emit complete after the stream finishes', function(done) {
+      it('should emit complete after the stream finishes', done => {
         const dup = duplexify();
 
         dup.on('complete', done);
@@ -3324,7 +3324,7 @@ describe('File', function() {
         resumableUploadOverride = {
           upload() {
             const uploadStream = new stream.Transform();
-            setImmediate(function() {
+            setImmediate(() => {
               uploadStream.end();
             });
             return uploadStream;
@@ -3334,11 +3334,11 @@ describe('File', function() {
         file.startResumableUpload_(dup);
       });
 
-      it('should set the writable stream', function(done) {
+      it('should set the writable stream', done => {
         const dup = duplexify();
         const uploadStream = through();
 
-        dup.setWritable = function(stream) {
+        dup.setWritable = stream => {
           assert.strictEqual(stream, uploadStream);
           done();
         };
@@ -3354,16 +3354,16 @@ describe('File', function() {
     });
   });
 
-  describe('startSimpleUpload_', function() {
-    it('should get a writable stream', function(done) {
-      makeWritableStreamOverride = function() {
+  describe('startSimpleUpload_', () => {
+    it('should get a writable stream', done => {
+      makeWritableStreamOverride = () => {
         done();
       };
 
       file.startSimpleUpload_(duplexify());
     });
 
-    it('should pass the required arguments', function(done) {
+    it('should pass the required arguments', done => {
       const options = {
         metadata: {},
         predefinedAcl: 'allUsers',
@@ -3371,7 +3371,7 @@ describe('File', function() {
         public: true,
       };
 
-      makeWritableStreamOverride = function(stream, options_) {
+      makeWritableStreamOverride = (stream, options_) => {
         assert.strictEqual(options_.metadata, options.metadata);
         assert.deepEqual(options_.request, {
           qs: {
@@ -3389,28 +3389,28 @@ describe('File', function() {
       file.startSimpleUpload_(duplexify(), options);
     });
 
-    it('should set predefinedAcl when public: true', function(done) {
-      makeWritableStreamOverride = function(stream, options_) {
+    it('should set predefinedAcl when public: true', done => {
+      makeWritableStreamOverride = (stream, options_) => {
         assert.strictEqual(options_.request.qs.predefinedAcl, 'publicRead');
         done();
       };
 
-      file.startSimpleUpload_(duplexify(), {public: true});
+      file.startSimpleUpload_(duplexify(), { public: true });
     });
 
-    it('should set predefinedAcl when private: true', function(done) {
-      makeWritableStreamOverride = function(stream, options_) {
+    it('should set predefinedAcl when private: true', done => {
+      makeWritableStreamOverride = (stream, options_) => {
         assert.strictEqual(options_.request.qs.predefinedAcl, 'private');
         done();
       };
 
-      file.startSimpleUpload_(duplexify(), {private: true});
+      file.startSimpleUpload_(duplexify(), { private: true });
     });
 
-    it('should send query.ifGenerationMatch if File has one', function(done) {
-      const versionedFile = new File(BUCKET, 'new-file.txt', {generation: 1});
+    it('should send query.ifGenerationMatch if File has one', done => {
+      const versionedFile = new File(BUCKET, 'new-file.txt', { generation: 1 });
 
-      makeWritableStreamOverride = function(stream, options) {
+      makeWritableStreamOverride = (stream, options) => {
         assert.equal(options.request.qs.ifGenerationMatch, 1);
         done();
       };
@@ -3418,10 +3418,10 @@ describe('File', function() {
       versionedFile.startSimpleUpload_(duplexify(), {});
     });
 
-    it('should send query.kmsKeyName if File has one', function(done) {
+    it('should send query.kmsKeyName if File has one', done => {
       file.kmsKeyName = 'kms-key-name';
 
-      makeWritableStreamOverride = function(stream, options) {
+      makeWritableStreamOverride = (stream, options) => {
         assert.strictEqual(options.request.qs.kmsKeyName, file.kmsKeyName);
         done();
       };
@@ -3429,12 +3429,12 @@ describe('File', function() {
       file.startSimpleUpload_(duplexify(), {});
     });
 
-    it('should send userProject if set', function(done) {
+    it('should send userProject if set', done => {
       const options = {
         userProject: 'user-project-id',
       };
 
-      makeWritableStreamOverride = function(stream, options_) {
+      makeWritableStreamOverride = (stream, options_) => {
         assert.equal(options_.request.qs.userProject, options.userProject);
         done();
       };
@@ -3442,22 +3442,22 @@ describe('File', function() {
       file.startSimpleUpload_(duplexify(), options);
     });
 
-    describe('request', function() {
-      describe('error', function() {
+    describe('request', () => {
+      describe('error', () => {
         const error = new Error('Error.');
 
-        beforeEach(function() {
-          file.request = function(reqOpts, callback) {
+        beforeEach(() => {
+          file.request = (reqOpts, callback) => {
             callback(error);
           };
         });
 
-        it('should destroy the stream', function(done) {
+        it('should destroy the stream', done => {
           const stream = duplexify();
 
           file.startSimpleUpload_(stream);
 
-          stream.on('error', function(err) {
+          stream.on('error', err => {
             assert.strictEqual(stream.destroyed, true);
             assert.strictEqual(err, error);
             done();
@@ -3465,17 +3465,17 @@ describe('File', function() {
         });
       });
 
-      describe('success', function() {
+      describe('success', () => {
         const body = {};
         const resp = {};
 
-        beforeEach(function() {
-          file.request = function(reqOpts, callback) {
+        beforeEach(() => {
+          file.request = (reqOpts, callback) => {
             callback(null, body, resp);
           };
         });
 
-        it('should set the metadata', function() {
+        it('should set the metadata', () => {
           const stream = duplexify();
 
           file.startSimpleUpload_(stream);
@@ -3483,10 +3483,10 @@ describe('File', function() {
           assert.strictEqual(file.metadata, body);
         });
 
-        it('should emit the response', function(done) {
+        it('should emit the response', done => {
           const stream = duplexify();
 
-          stream.on('response', function(resp_) {
+          stream.on('response', resp_ => {
             assert.strictEqual(resp_, resp);
             done();
           });
@@ -3494,7 +3494,7 @@ describe('File', function() {
           file.startSimpleUpload_(stream);
         });
 
-        it('should emit complete', function(done) {
+        it('should emit complete', done => {
           const stream = duplexify();
 
           stream.on('complete', done);
@@ -3505,8 +3505,8 @@ describe('File', function() {
     });
   });
 
-  describe('setUserProject', function() {
-    it('should set the userProject property', function() {
+  describe('setUserProject', () => {
+    it('should set the userProject property', () => {
       const userProject = 'grape-spaceship-123';
 
       file.setUserProject(userProject);

--- a/test/iam.ts
+++ b/test/iam.ts
@@ -58,10 +58,12 @@ describe('storage/iam', () => {
     });
 
     it('should localize the request function', done => {
-      BUCKET_INSTANCE.request = callback => {
-        assert.strictEqual(this, BUCKET_INSTANCE);
-        callback(); // done()
-      };
+      extend(BUCKET_INSTANCE, {
+        request(callback) {
+          assert.strictEqual(this, BUCKET_INSTANCE);
+          callback(); // done()
+        },
+      });
 
       const iam = new Iam(BUCKET_INSTANCE);
       iam.request_(done);

--- a/test/iam.ts
+++ b/test/iam.ts
@@ -21,7 +21,7 @@ import extend from 'extend';
 import proxyquire from 'proxyquire';
 import { util } from '@google-cloud/common';
 
-describe('storage/iam', function() {
+describe('storage/iam', () => {
   let Iam;
   let iam;
 
@@ -35,7 +35,7 @@ describe('storage/iam', function() {
     },
   });
 
-  before(function() {
+  before(() => {
     Iam = proxyquire('../src/iam.js', {
       '@google-cloud/common': {
         util: fakeUtil,
@@ -43,7 +43,7 @@ describe('storage/iam', function() {
     }).Iam;
   });
 
-  beforeEach(function() {
+  beforeEach(() => {
     BUCKET_INSTANCE = {
       id: 'bucket-id',
       request: util.noop,
@@ -52,13 +52,13 @@ describe('storage/iam', function() {
     iam = new Iam(BUCKET_INSTANCE);
   });
 
-  describe('initialization', function() {
-    it('should promisify all the things', function() {
+  describe('initialization', () => {
+    it('should promisify all the things', () => {
       assert(promisified);
     });
 
-    it('should localize the request function', function(done) {
-      BUCKET_INSTANCE.request = function(callback) {
+    it('should localize the request function', done => {
+      BUCKET_INSTANCE.request = callback => {
         assert.strictEqual(this, BUCKET_INSTANCE);
         callback(); // done()
       };
@@ -67,14 +67,14 @@ describe('storage/iam', function() {
       iam.request_(done);
     });
 
-    it('should localize the resource ID', function() {
+    it('should localize the resource ID', () => {
       assert.strictEqual(iam.resourceId_, 'buckets/' + BUCKET_INSTANCE.id);
     });
   });
 
-  describe('getPolicy', function() {
-    it('should make the correct api request', function(done) {
-      iam.request_ = function(reqOpts, callback) {
+  describe('getPolicy', () => {
+    it('should make the correct api request', done => {
+      iam.request_ = (reqOpts, callback) => {
         assert.deepEqual(reqOpts, {
           uri: '/iam',
           qs: {},
@@ -86,12 +86,12 @@ describe('storage/iam', function() {
       iam.getPolicy(done);
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const options = {
         userProject: 'grape-spaceship-123',
       };
 
-      iam.request_ = function(reqOpts) {
+      iam.request_ = reqOpts => {
         assert.strictEqual(reqOpts.qs, options);
         done();
       };
@@ -100,19 +100,19 @@ describe('storage/iam', function() {
     });
   });
 
-  describe('setPolicy', function() {
-    it('should throw an error if a policy is not supplied', function() {
-      assert.throws(function() {
+  describe('setPolicy', () => {
+    it('should throw an error if a policy is not supplied', () => {
+      assert.throws(() => {
         iam.setPolicy(util.noop);
       }, /A policy object is required\./);
     });
 
-    it('should make the correct API request', function(done) {
+    it('should make the correct API request', done => {
       const policy = {
         a: 'b',
       };
 
-      iam.request_ = function(reqOpts, callback) {
+      iam.request_ = (reqOpts, callback) => {
         assert.deepEqual(reqOpts, {
           method: 'PUT',
           uri: '/iam',
@@ -131,7 +131,7 @@ describe('storage/iam', function() {
       iam.setPolicy(policy, done);
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const policy = {
         a: 'b',
       };
@@ -140,7 +140,7 @@ describe('storage/iam', function() {
         userProject: 'grape-spaceship-123',
       };
 
-      iam.request_ = function(reqOpts) {
+      iam.request_ = reqOpts => {
         assert.strictEqual(reqOpts.qs, options);
         done();
       };
@@ -149,17 +149,17 @@ describe('storage/iam', function() {
     });
   });
 
-  describe('testPermissions', function() {
-    it('should throw an error if permissions are missing', function() {
-      assert.throws(function() {
+  describe('testPermissions', () => {
+    it('should throw an error if permissions are missing', () => {
+      assert.throws(() => {
         iam.testPermissions(util.noop);
       }, /Permissions are required\./);
     });
 
-    it('should make the correct API request', function(done) {
+    it('should make the correct API request', done => {
       const permissions = 'storage.bucket.list';
 
-      iam.request_ = function(reqOpts) {
+      iam.request_ = reqOpts => {
         assert.deepEqual(reqOpts, {
           uri: '/iam/testPermissions',
           qs: {
@@ -174,16 +174,16 @@ describe('storage/iam', function() {
       iam.testPermissions(permissions, assert.ifError);
     });
 
-    it('should send an error back if the request fails', function(done) {
+    it('should send an error back if the request fails', done => {
       const permissions = ['storage.bucket.list'];
       const error = new Error('Error.');
       const apiResponse = {};
 
-      iam.request_ = function(reqOpts, callback) {
+      iam.request_ = (reqOpts, callback) => {
         callback(error, apiResponse);
       };
 
-      iam.testPermissions(permissions, function(err, permissions, apiResp) {
+      iam.testPermissions(permissions, (err, permissions, apiResp) => {
         assert.strictEqual(err, error);
         assert.strictEqual(permissions, null);
         assert.strictEqual(apiResp, apiResponse);
@@ -191,17 +191,17 @@ describe('storage/iam', function() {
       });
     });
 
-    it('should pass back a hash of permissions the user has', function(done) {
+    it('should pass back a hash of permissions the user has', done => {
       const permissions = ['storage.bucket.list', 'storage.bucket.consume'];
       const apiResponse = {
         permissions: ['storage.bucket.consume'],
       };
 
-      iam.request_ = function(reqOpts, callback) {
+      iam.request_ = (reqOpts, callback) => {
         callback(null, apiResponse);
       };
 
-      iam.testPermissions(permissions, function(err, permissions, apiResp) {
+      iam.testPermissions(permissions, (err, permissions, apiResp) => {
         assert.ifError(err);
         assert.deepEqual(permissions, {
           'storage.bucket.list': false,
@@ -213,7 +213,7 @@ describe('storage/iam', function() {
       });
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const permissions = ['storage.bucket.list'];
       const options = {
         userProject: 'grape-spaceship-123',
@@ -226,7 +226,7 @@ describe('storage/iam', function() {
         options
       );
 
-      iam.request_ = function(reqOpts) {
+      iam.request_ = reqOpts => {
         assert.deepEqual(reqOpts.qs, expectedQuery);
         done();
       };

--- a/test/index.ts
+++ b/test/index.ts
@@ -21,7 +21,7 @@ import assert from 'assert';
 import extend from 'extend';
 import nodeutil from 'util';
 import proxyquire from 'proxyquire';
-import {Service, util} from '@google-cloud/common';
+import { Service, util } from '@google-cloud/common';
 
 function FakeChannel() {
   this.calledWith_ = arguments;
@@ -77,14 +77,14 @@ describe('Storage', () => {
         paginator: fakePaginator,
         util: fakeUtil,
       },
-      './channel.js': {Channel: FakeChannel},
+      './channel.js': { Channel: FakeChannel },
     });
     Bucket = Storage.Bucket;
   });
 
   beforeEach(() => {
     extend(fakeUtil, originalFakeUtil);
-    storage = new Storage({projectId: PROJECT_ID});
+    storage = new Storage({ projectId: PROJECT_ID });
   });
 
   describe('instantiation', () => {
@@ -102,7 +102,7 @@ describe('Storage', () => {
 
     it('should work without new', () => {
       assert.doesNotThrow(() => {
-        Storage({projectId: PROJECT_ID});
+        Storage({ projectId: PROJECT_ID });
       });
     });
 
@@ -164,8 +164,8 @@ describe('Storage', () => {
 
   describe('createBucket', () => {
     const BUCKET_NAME = 'new-bucket-name';
-    const METADATA = {a: 'b', c: {d: 'e'}};
-    const BUCKET = {name: BUCKET_NAME};
+    const METADATA = { a: 'b', c: { d: 'e' } };
+    const BUCKET = { name: BUCKET_NAME };
 
     it('should make correct API request', done => {
       storage.request = (reqOpts, callback) => {
@@ -182,7 +182,7 @@ describe('Storage', () => {
 
     it('should accept a name, metadata, and callback', done => {
       storage.request = (reqOpts, callback) => {
-        assert.deepEqual(reqOpts.json, extend(METADATA, {name: BUCKET_NAME}));
+        assert.deepEqual(reqOpts.json, extend(METADATA, { name: BUCKET_NAME }));
         callback(null, METADATA);
       };
       storage.bucket = name => {
@@ -248,7 +248,7 @@ describe('Storage', () => {
     });
 
     it('should execute callback with apiResponse', done => {
-      const resp = {success: true};
+      const resp = { success: true };
       storage.request = (reqOpts, callback) => {
         callback(null, resp);
       };
@@ -265,7 +265,7 @@ describe('Storage', () => {
           done();
         };
 
-        storage.createBucket(BUCKET_NAME, {coldline: true}, assert.ifError);
+        storage.createBucket(BUCKET_NAME, { coldline: true }, assert.ifError);
       });
 
       it('should expand metadata.dra', done => {
@@ -275,7 +275,7 @@ describe('Storage', () => {
           done();
         };
 
-        storage.createBucket(BUCKET_NAME, {dra: true}, assert.ifError);
+        storage.createBucket(BUCKET_NAME, { dra: true }, assert.ifError);
       });
 
       it('should expand metadata.multiRegional', done => {
@@ -299,7 +299,7 @@ describe('Storage', () => {
           done();
         };
 
-        storage.createBucket(BUCKET_NAME, {nearline: true}, assert.ifError);
+        storage.createBucket(BUCKET_NAME, { nearline: true }, assert.ifError);
       });
 
       it('should expand metadata.regional', done => {
@@ -308,7 +308,7 @@ describe('Storage', () => {
           done();
         };
 
-        storage.createBucket(BUCKET_NAME, {regional: true}, assert.ifError);
+        storage.createBucket(BUCKET_NAME, { regional: true }, assert.ifError);
       });
     });
 
@@ -331,7 +331,7 @@ describe('Storage', () => {
     it('should get buckets without a query', done => {
       storage.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, '/b');
-        assert.deepEqual(reqOpts.qs, {project: storage.projectId});
+        assert.deepEqual(reqOpts.qs, { project: storage.projectId });
         done();
       };
       storage.getBuckets(util.noop);
@@ -347,7 +347,7 @@ describe('Storage', () => {
         });
         done();
       };
-      storage.getBuckets({maxResults: 5, pageToken: token}, util.noop);
+      storage.getBuckets({ maxResults: 5, pageToken: token }, util.noop);
     });
 
     it('should execute callback with error', done => {
@@ -370,9 +370,9 @@ describe('Storage', () => {
     it('should return nextQuery if more results exist', () => {
       const token = 'next-page-token';
       storage.request = (reqOpts, callback) => {
-        callback(null, {nextPageToken: token, items: []});
+        callback(null, { nextPageToken: token, items: [] });
       };
-      storage.getBuckets({maxResults: 5}, (err, results, nextQuery) => {
+      storage.getBuckets({ maxResults: 5 }, (err, results, nextQuery) => {
         assert.equal(nextQuery.pageToken, token);
         assert.strictEqual(nextQuery.maxResults, 5);
       });
@@ -380,16 +380,16 @@ describe('Storage', () => {
 
     it('should return null nextQuery if there are no more results', () => {
       storage.request = (reqOpts, callback) => {
-        callback(null, {items: []});
+        callback(null, { items: [] });
       };
-      storage.getBuckets({maxResults: 5}, (err, results, nextQuery) => {
+      storage.getBuckets({ maxResults: 5 }, (err, results, nextQuery) => {
         assert.strictEqual(nextQuery, null);
       });
     });
 
     it('should return Bucket objects', done => {
       storage.request = (reqOpts, callback) => {
-        callback(null, {items: [{id: 'fake-bucket-name'}]});
+        callback(null, { items: [{ id: 'fake-bucket-name' }] });
       };
       storage.getBuckets((err, buckets) => {
         assert.ifError(err);
@@ -399,7 +399,7 @@ describe('Storage', () => {
     });
 
     it('should return apiResponse', done => {
-      const resp = {items: [{id: 'fake-bucket-name'}]};
+      const resp = { items: [{ id: 'fake-bucket-name' }] };
       storage.request = (reqOpts, callback) => {
         callback(null, resp);
       };
@@ -418,7 +418,7 @@ describe('Storage', () => {
         },
       };
       storage.request = (reqOpts, callback) => {
-        callback(null, {items: [bucketMetadata]});
+        callback(null, { items: [bucketMetadata] });
       };
       storage.getBuckets((err, buckets) => {
         assert.ifError(err);

--- a/test/index.ts
+++ b/test/index.ts
@@ -21,7 +21,7 @@ import assert from 'assert';
 import extend from 'extend';
 import nodeutil from 'util';
 import proxyquire from 'proxyquire';
-import { Service, util } from '@google-cloud/common';
+import {Service, util} from '@google-cloud/common';
 
 function FakeChannel() {
   this.calledWith_ = arguments;
@@ -64,13 +64,13 @@ const fakeUtil = extend({}, util, {
 });
 const originalFakeUtil = extend(true, {}, fakeUtil);
 
-describe('Storage', function() {
+describe('Storage', () => {
   const PROJECT_ID = 'project-id';
   let Storage;
   let storage;
   let Bucket;
 
-  before(function() {
+  before(() => {
     Storage = proxyquire('../src', {
       '@google-cloud/common': {
         Service: FakeService,
@@ -82,31 +82,31 @@ describe('Storage', function() {
     Bucket = Storage.Bucket;
   });
 
-  beforeEach(function() {
+  beforeEach(() => {
     extend(fakeUtil, originalFakeUtil);
     storage = new Storage({projectId: PROJECT_ID});
   });
 
-  describe('instantiation', function() {
-    it('should extend the correct methods', function() {
+  describe('instantiation', () => {
+    it('should extend the correct methods', () => {
       assert(extended); // See `fakePaginator.extend`
     });
 
-    it('should streamify the correct methods', function() {
+    it('should streamify the correct methods', () => {
       assert.strictEqual(storage.getBucketsStream, 'getBuckets');
     });
 
-    it('should promisify all the things', function() {
+    it('should promisify all the things', () => {
       assert(promisified);
     });
 
-    it('should work without new', function() {
-      assert.doesNotThrow(function() {
+    it('should work without new', () => {
+      assert.doesNotThrow(() => {
         Storage({projectId: PROJECT_ID});
       });
     });
 
-    it('should inherit from Service', function() {
+    it('should inherit from Service', () => {
       assert(storage instanceof Service);
 
       const calledWith = storage.calledWith_[0];
@@ -123,21 +123,21 @@ describe('Storage', function() {
     });
   });
 
-  describe('bucket', function() {
-    it('should throw if no name was provided', function() {
-      assert.throws(function() {
+  describe('bucket', () => {
+    it('should throw if no name was provided', () => {
+      assert.throws(() => {
         storage.bucket();
       }, /A bucket name is needed to use Cloud Storage\./);
     });
 
-    it('should accept a string for a name', function() {
+    it('should accept a string for a name', () => {
       const newBucketName = 'new-bucket-name';
       const bucket = storage.bucket(newBucketName);
       assert(bucket instanceof Bucket);
       assert.equal(bucket.name, newBucketName);
     });
 
-    it('should optionally accept options', function() {
+    it('should optionally accept options', () => {
       const options = {
         userProject: 'grape-spaceship-123',
       };
@@ -147,11 +147,11 @@ describe('Storage', function() {
     });
   });
 
-  describe('channel', function() {
+  describe('channel', () => {
     const ID = 'channel-id';
     const RESOURCE_ID = 'resource-id';
 
-    it('should create a Channel object', function() {
+    it('should create a Channel object', () => {
       const channel = storage.channel(ID, RESOURCE_ID);
 
       assert(channel instanceof FakeChannel);
@@ -162,13 +162,13 @@ describe('Storage', function() {
     });
   });
 
-  describe('createBucket', function() {
+  describe('createBucket', () => {
     const BUCKET_NAME = 'new-bucket-name';
     const METADATA = {a: 'b', c: {d: 'e'}};
     const BUCKET = {name: BUCKET_NAME};
 
-    it('should make correct API request', function(done) {
-      storage.request = function(reqOpts, callback) {
+    it('should make correct API request', done => {
+      storage.request = (reqOpts, callback) => {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/b');
         assert.strictEqual(reqOpts.qs.project, storage.projectId);
@@ -180,40 +180,40 @@ describe('Storage', function() {
       storage.createBucket(BUCKET_NAME, done);
     });
 
-    it('should accept a name, metadata, and callback', function(done) {
-      storage.request = function(reqOpts, callback) {
+    it('should accept a name, metadata, and callback', done => {
+      storage.request = (reqOpts, callback) => {
         assert.deepEqual(reqOpts.json, extend(METADATA, {name: BUCKET_NAME}));
         callback(null, METADATA);
       };
-      storage.bucket = function(name) {
+      storage.bucket = name => {
         assert.equal(name, BUCKET_NAME);
         return BUCKET;
       };
-      storage.createBucket(BUCKET_NAME, METADATA, function(err) {
+      storage.createBucket(BUCKET_NAME, METADATA, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('should accept a name and callback only', function(done) {
-      storage.request = function(reqOpts, callback) {
+    it('should accept a name and callback only', done => {
+      storage.request = (reqOpts, callback) => {
         callback();
       };
       storage.createBucket(BUCKET_NAME, done);
     });
 
-    it('should throw if no name is provided', function() {
-      assert.throws(function() {
+    it('should throw if no name is provided', () => {
+      assert.throws(() => {
         storage.createBucket();
       }, /A name is required to create a bucket\./);
     });
 
-    it('should honor the userProject option', function(done) {
+    it('should honor the userProject option', done => {
       const options = {
         userProject: 'grape-spaceship-123',
       };
 
-      storage.request = function(reqOpts) {
+      storage.request = reqOpts => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -221,14 +221,14 @@ describe('Storage', function() {
       storage.createBucket(BUCKET_NAME, options, assert.ifError);
     });
 
-    it('should execute callback with bucket', function(done) {
-      storage.bucket = function() {
+    it('should execute callback with bucket', done => {
+      storage.bucket = () => {
         return BUCKET;
       };
-      storage.request = function(reqOpts, callback) {
+      storage.request = (reqOpts, callback) => {
         callback(null, METADATA);
       };
-      storage.createBucket(BUCKET_NAME, function(err, bucket) {
+      storage.createBucket(BUCKET_NAME, (err, bucket) => {
         assert.ifError(err);
         assert.deepEqual(bucket, BUCKET);
         assert.deepEqual(bucket.metadata, METADATA);
@@ -236,31 +236,31 @@ describe('Storage', function() {
       });
     });
 
-    it('should execute callback on error', function(done) {
+    it('should execute callback on error', done => {
       const error = new Error('Error.');
-      storage.request = function(reqOpts, callback) {
+      storage.request = (reqOpts, callback) => {
         callback(error);
       };
-      storage.createBucket(BUCKET_NAME, function(err) {
+      storage.createBucket(BUCKET_NAME, err => {
         assert.equal(err, error);
         done();
       });
     });
 
-    it('should execute callback with apiResponse', function(done) {
+    it('should execute callback with apiResponse', done => {
       const resp = {success: true};
-      storage.request = function(reqOpts, callback) {
+      storage.request = (reqOpts, callback) => {
         callback(null, resp);
       };
-      storage.createBucket(BUCKET_NAME, function(err, bucket, apiResponse) {
+      storage.createBucket(BUCKET_NAME, (err, bucket, apiResponse) => {
         assert.equal(resp, apiResponse);
         done();
       });
     });
 
-    describe('storage classes', function() {
-      it('should expand metadata.coldline', function(done) {
-        storage.request = function(reqOpts) {
+    describe('storage classes', () => {
+      it('should expand metadata.coldline', done => {
+        storage.request = reqOpts => {
           assert.strictEqual(reqOpts.json.storageClass, 'COLDLINE');
           done();
         };
@@ -268,8 +268,8 @@ describe('Storage', function() {
         storage.createBucket(BUCKET_NAME, {coldline: true}, assert.ifError);
       });
 
-      it('should expand metadata.dra', function(done) {
-        storage.request = function(reqOpts) {
+      it('should expand metadata.dra', done => {
+        storage.request = reqOpts => {
           const body = reqOpts.json;
           assert.strictEqual(body.storageClass, 'DURABLE_REDUCED_AVAILABILITY');
           done();
@@ -278,8 +278,8 @@ describe('Storage', function() {
         storage.createBucket(BUCKET_NAME, {dra: true}, assert.ifError);
       });
 
-      it('should expand metadata.multiRegional', function(done) {
-        storage.request = function(reqOpts) {
+      it('should expand metadata.multiRegional', done => {
+        storage.request = reqOpts => {
           assert.strictEqual(reqOpts.json.storageClass, 'MULTI_REGIONAL');
           done();
         };
@@ -293,8 +293,8 @@ describe('Storage', function() {
         );
       });
 
-      it('should expand metadata.nearline', function(done) {
-        storage.request = function(reqOpts) {
+      it('should expand metadata.nearline', done => {
+        storage.request = reqOpts => {
           assert.strictEqual(reqOpts.json.storageClass, 'NEARLINE');
           done();
         };
@@ -302,8 +302,8 @@ describe('Storage', function() {
         storage.createBucket(BUCKET_NAME, {nearline: true}, assert.ifError);
       });
 
-      it('should expand metadata.regional', function(done) {
-        storage.request = function(reqOpts) {
+      it('should expand metadata.regional', done => {
+        storage.request = reqOpts => {
           assert.strictEqual(reqOpts.json.storageClass, 'REGIONAL');
           done();
         };
@@ -312,12 +312,12 @@ describe('Storage', function() {
       });
     });
 
-    describe('requesterPays', function() {
-      it('should accept requesterPays setting', function(done) {
+    describe('requesterPays', () => {
+      it('should accept requesterPays setting', done => {
         const options = {
           requesterPays: true,
         };
-        storage.request = function(reqOpts) {
+        storage.request = reqOpts => {
           assert.deepStrictEqual(reqOpts.json.billing, options);
           assert.strictEqual(reqOpts.json.requesterPays, undefined);
           done();
@@ -327,9 +327,9 @@ describe('Storage', function() {
     });
   });
 
-  describe('getBuckets', function() {
-    it('should get buckets without a query', function(done) {
-      storage.request = function(reqOpts) {
+  describe('getBuckets', () => {
+    it('should get buckets without a query', done => {
+      storage.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, '/b');
         assert.deepEqual(reqOpts.qs, {project: storage.projectId});
         done();
@@ -337,9 +337,9 @@ describe('Storage', function() {
       storage.getBuckets(util.noop);
     });
 
-    it('should get buckets with a query', function(done) {
+    it('should get buckets with a query', done => {
       const token = 'next-page-token';
-      storage.request = function(reqOpts) {
+      storage.request = reqOpts => {
         assert.deepEqual(reqOpts.qs, {
           project: storage.projectId,
           maxResults: 5,
@@ -350,15 +350,15 @@ describe('Storage', function() {
       storage.getBuckets({maxResults: 5, pageToken: token}, util.noop);
     });
 
-    it('should execute callback with error', function(done) {
+    it('should execute callback with error', done => {
       const error = new Error('Error.');
       const apiResponse = {};
 
-      storage.request = function(reqOpts, callback) {
+      storage.request = (reqOpts, callback) => {
         callback(error, apiResponse);
       };
 
-      storage.getBuckets({}, function(err, buckets, nextQuery, resp) {
+      storage.getBuckets({}, (err, buckets, nextQuery, resp) => {
         assert.strictEqual(err, error);
         assert.strictEqual(buckets, null);
         assert.strictEqual(nextQuery, null);
@@ -367,49 +367,49 @@ describe('Storage', function() {
       });
     });
 
-    it('should return nextQuery if more results exist', function() {
+    it('should return nextQuery if more results exist', () => {
       const token = 'next-page-token';
-      storage.request = function(reqOpts, callback) {
+      storage.request = (reqOpts, callback) => {
         callback(null, {nextPageToken: token, items: []});
       };
-      storage.getBuckets({maxResults: 5}, function(err, results, nextQuery) {
+      storage.getBuckets({maxResults: 5}, (err, results, nextQuery) => {
         assert.equal(nextQuery.pageToken, token);
         assert.strictEqual(nextQuery.maxResults, 5);
       });
     });
 
-    it('should return null nextQuery if there are no more results', function() {
-      storage.request = function(reqOpts, callback) {
+    it('should return null nextQuery if there are no more results', () => {
+      storage.request = (reqOpts, callback) => {
         callback(null, {items: []});
       };
-      storage.getBuckets({maxResults: 5}, function(err, results, nextQuery) {
+      storage.getBuckets({maxResults: 5}, (err, results, nextQuery) => {
         assert.strictEqual(nextQuery, null);
       });
     });
 
-    it('should return Bucket objects', function(done) {
-      storage.request = function(reqOpts, callback) {
+    it('should return Bucket objects', done => {
+      storage.request = (reqOpts, callback) => {
         callback(null, {items: [{id: 'fake-bucket-name'}]});
       };
-      storage.getBuckets(function(err, buckets) {
+      storage.getBuckets((err, buckets) => {
         assert.ifError(err);
         assert(buckets[0] instanceof Bucket);
         done();
       });
     });
 
-    it('should return apiResponse', function(done) {
+    it('should return apiResponse', done => {
       const resp = {items: [{id: 'fake-bucket-name'}]};
-      storage.request = function(reqOpts, callback) {
+      storage.request = (reqOpts, callback) => {
         callback(null, resp);
       };
-      storage.getBuckets(function(err, buckets, nextQuery, apiResponse) {
+      storage.getBuckets((err, buckets, nextQuery, apiResponse) => {
         assert.deepEqual(resp, apiResponse);
         done();
       });
     });
 
-    it('should populate returned Bucket object with metadata', function(done) {
+    it('should populate returned Bucket object with metadata', done => {
       const bucketMetadata = {
         id: 'bucketname',
         contentType: 'x-zebra',
@@ -417,10 +417,10 @@ describe('Storage', function() {
           my: 'custom metadata',
         },
       };
-      storage.request = function(reqOpts, callback) {
+      storage.request = (reqOpts, callback) => {
         callback(null, {items: [bucketMetadata]});
       };
-      storage.getBuckets(function(err, buckets) {
+      storage.getBuckets((err, buckets) => {
         assert.ifError(err);
         assert.deepEqual(buckets[0].metadata, bucketMetadata);
         done();

--- a/test/notification.ts
+++ b/test/notification.ts
@@ -17,7 +17,7 @@
 'use strict';
 
 import assert from 'assert';
-import {ServiceObject, util} from '@google-cloud/common';
+import { ServiceObject, util } from '@google-cloud/common';
 import extend from 'extend';
 import proxyquire from 'proxyquire';
 import nodeUtil from 'util';
@@ -29,7 +29,7 @@ function FakeServiceObject() {
 
 nodeUtil.inherits(FakeServiceObject, ServiceObject);
 
-describe('Notification', function() {
+describe('Notification', () => {
   let Notification;
   let notification;
   let promisified = false;
@@ -47,7 +47,7 @@ describe('Notification', function() {
 
   const ID = '123';
 
-  before(function() {
+  before(() => {
     Notification = proxyquire('../src/notification.js', {
       '@google-cloud/common': {
         ServiceObject: FakeServiceObject,
@@ -56,17 +56,17 @@ describe('Notification', function() {
     }).Notification;
   });
 
-  beforeEach(function() {
-    BUCKET.createNotification = fakeUtil.noop = function() {};
+  beforeEach(() => {
+    BUCKET.createNotification = fakeUtil.noop = () => { };
     notification = new Notification(BUCKET, ID);
   });
 
-  describe('instantiation', function() {
-    it('should promisify all the things', function() {
+  describe('instantiation', () => {
+    it('should promisify all the things', () => {
       assert(promisified);
     });
 
-    it('should inherit from ServiceObject', function() {
+    it('should inherit from ServiceObject', () => {
       assert(notification instanceof FakeServiceObject);
 
       const calledWith = notification.calledWith_[0];
@@ -81,8 +81,8 @@ describe('Notification', function() {
       });
     });
 
-    it('should use Bucket#createNotification for the createMethod', function() {
-      const bound = function() {};
+    it('should use Bucket#createNotification for the createMethod', () => {
+      const bound = () => { };
 
       BUCKET.createNotification = {
         bind(context) {
@@ -97,7 +97,7 @@ describe('Notification', function() {
       assert.strictEqual(calledWith.createMethod, bound);
     });
 
-    it('should convert number IDs to strings', function() {
+    it('should convert number IDs to strings', () => {
       const notification = new Notification(BUCKET, 1);
       const calledWith = notification.calledWith_[0];
 
@@ -105,11 +105,11 @@ describe('Notification', function() {
     });
   });
 
-  describe('delete', function() {
-    it('should make the correct request', function(done) {
+  describe('delete', () => {
+    it('should make the correct request', done => {
       const options = {};
 
-      notification.request = function(reqOpts, callback) {
+      notification.request = (reqOpts, callback) => {
         assert.strictEqual(reqOpts.method, 'DELETE');
         assert.strictEqual(reqOpts.uri, '');
         assert.strictEqual(reqOpts.qs, options);
@@ -119,8 +119,8 @@ describe('Notification', function() {
       notification.delete(options, done);
     });
 
-    it('should optionally accept options', function(done) {
-      notification.request = function(reqOpts, callback) {
+    it('should optionally accept options', done => {
+      notification.request = (reqOpts, callback) => {
         assert.deepEqual(reqOpts.qs, {});
         callback(); // the done fn
       };
@@ -128,10 +128,10 @@ describe('Notification', function() {
       notification.delete(done);
     });
 
-    it('should optionally accept a callback', function(done) {
+    it('should optionally accept a callback', done => {
       fakeUtil.noop = done;
 
-      notification.request = function(reqOpts, callback) {
+      notification.request = (reqOpts, callback) => {
         callback(); // the done fn
       };
 
@@ -139,19 +139,19 @@ describe('Notification', function() {
     });
   });
 
-  describe('get', function() {
-    it('should get the metadata', function(done) {
-      notification.getMetadata = function() {
+  describe('get', () => {
+    it('should get the metadata', done => {
+      notification.getMetadata = () => {
         done();
       };
 
       notification.get(assert.ifError);
     });
 
-    it('should accept an options object', function(done) {
+    it('should accept an options object', done => {
       const options = {};
 
-      notification.getMetadata = function(options_) {
+      notification.getMetadata = options_ => {
         assert.strictEqual(options_, options);
         done();
       };
@@ -159,15 +159,15 @@ describe('Notification', function() {
       notification.get(options, assert.ifError);
     });
 
-    it('should execute callback with error & metadata', function(done) {
+    it('should execute callback with error & metadata', done => {
       const error = new Error('Error.');
       const metadata = {};
 
-      notification.getMetadata = function(options, callback) {
+      notification.getMetadata = (options, callback) => {
         callback(error, metadata);
       };
 
-      notification.get(function(err, instance, metadata_) {
+      notification.get((err, instance, metadata_) => {
         assert.strictEqual(err, error);
         assert.strictEqual(instance, null);
         assert.strictEqual(metadata_, metadata);
@@ -176,14 +176,14 @@ describe('Notification', function() {
       });
     });
 
-    it('should execute callback with instance & metadata', function(done) {
+    it('should execute callback with instance & metadata', done => {
       const metadata = {};
 
-      notification.getMetadata = function(options, callback) {
+      notification.getMetadata = (options, callback) => {
         callback(null, metadata);
       };
 
-      notification.get(function(err, instance, metadata_) {
+      notification.get((err, instance, metadata_) => {
         assert.ifError(err);
 
         assert.strictEqual(instance, notification);
@@ -193,28 +193,28 @@ describe('Notification', function() {
       });
     });
 
-    describe('autoCreate', function() {
+    describe('autoCreate', () => {
       let AUTO_CREATE_CONFIG;
 
-      const ERROR = {code: 404};
+      const ERROR = { code: 404 };
       const METADATA = {};
 
-      beforeEach(function() {
+      beforeEach(() => {
         AUTO_CREATE_CONFIG = {
           autoCreate: true,
         };
 
-        notification.getMetadata = function(options, callback) {
+        notification.getMetadata = (options, callback) => {
           callback(ERROR, METADATA);
         };
       });
 
-      it('should pass config to create if it was provided', function(done) {
+      it('should pass config to create if it was provided', done => {
         const config = extend({}, AUTO_CREATE_CONFIG, {
           maxResults: 5,
         });
 
-        notification.create = function(config_) {
+        notification.create = config_ => {
           assert.strictEqual(config_, config);
           done();
         };
@@ -222,21 +222,21 @@ describe('Notification', function() {
         notification.get(config, assert.ifError);
       });
 
-      it('should pass only a callback to create if no config', function(done) {
-        notification.create = function(callback) {
+      it('should pass only a callback to create if no config', done => {
+        notification.create = callback => {
           callback(); // done()
         };
 
         notification.get(AUTO_CREATE_CONFIG, done);
       });
 
-      describe('error', function() {
-        it('should execute callback with error & API response', function(done) {
+      describe('error', () => {
+        it('should execute callback with error & API response', done => {
           const error = new Error('Error.');
           const apiResponse = {};
 
-          notification.create = function(callback) {
-            notification.get = function(config, callback) {
+          notification.create = callback => {
+            notification.get = (config, callback) => {
               assert.deepEqual(config, {});
               callback(); // done()
             };
@@ -244,7 +244,7 @@ describe('Notification', function() {
             callback(error, null, apiResponse);
           };
 
-          notification.get(AUTO_CREATE_CONFIG, function(err, instance, resp) {
+          notification.get(AUTO_CREATE_CONFIG, (err, instance, resp) => {
             assert.strictEqual(err, error);
             assert.strictEqual(instance, null);
             assert.strictEqual(resp, apiResponse);
@@ -252,13 +252,13 @@ describe('Notification', function() {
           });
         });
 
-        it('should refresh the metadata after a 409', function(done) {
+        it('should refresh the metadata after a 409', done => {
           const error = {
             code: 409,
           };
 
-          notification.create = function(callback) {
-            notification.get = function(config, callback) {
+          notification.create = callback => {
+            notification.get = (config, callback) => {
               assert.deepEqual(config, {});
               callback(); // done()
             };
@@ -272,11 +272,11 @@ describe('Notification', function() {
     });
   });
 
-  describe('getMetadata', function() {
-    it('should make the correct request', function(done) {
+  describe('getMetadata', () => {
+    it('should make the correct request', done => {
       const options = {};
 
-      notification.request = function(reqOpts) {
+      notification.request = reqOpts => {
         assert.strictEqual(reqOpts.uri, '');
         assert.strictEqual(reqOpts.qs, options);
         done();
@@ -285,8 +285,8 @@ describe('Notification', function() {
       notification.getMetadata(options, assert.ifError);
     });
 
-    it('should optionally accept options', function(done) {
-      notification.request = function(reqOpts) {
+    it('should optionally accept options', done => {
+      notification.request = reqOpts => {
         assert.deepEqual(reqOpts.qs, {});
         done();
       };
@@ -294,15 +294,15 @@ describe('Notification', function() {
       notification.getMetadata(assert.ifError);
     });
 
-    it('should return any errors to the callback', function(done) {
+    it('should return any errors to the callback', done => {
       const error = new Error('err');
       const response = {};
 
-      notification.request = function(reqOpts, callback) {
+      notification.request = (reqOpts, callback) => {
         callback(error, response);
       };
 
-      notification.getMetadata(function(err, metadata, resp) {
+      notification.getMetadata((err, metadata, resp) => {
         assert.strictEqual(err, error);
         assert.strictEqual(metadata, null);
         assert.strictEqual(resp, response);
@@ -310,14 +310,14 @@ describe('Notification', function() {
       });
     });
 
-    it('should set and return the metadata', function(done) {
+    it('should set and return the metadata', done => {
       const response = {};
 
-      notification.request = function(reqOpts, callback) {
+      notification.request = (reqOpts, callback) => {
         callback(null, response);
       };
 
-      notification.getMetadata(function(err, metadata, resp) {
+      notification.getMetadata((err, metadata, resp) => {
         assert.ifError(err);
         assert.strictEqual(metadata, response);
         assert.strictEqual(notification.metadata, response);


### PR DESCRIPTION
 - convert all anonymous functions to fat arrow =>
 - fat arrow functions using `arguments` function-scoped argument is fixed (since arrow function doesn't support `arguments`) with ...args splats
 - anonymous functions referencing the object's `this` value is changed to use `extend(obj, { overriddenMethod() { // implementation });`