### PR TITLE
Support Bucket/Object lock operations

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1614,15 +1614,14 @@ class Bucket extends ServiceObject {
       }
 
       this.request(
-        {
-          method: 'POST',
-          uri: '/lockRetentionPolicy',
-          qs: {
-            ifMetagenerationMatch: metadata.metageneration,
+          {
+            method: 'POST',
+            uri: '/lockRetentionPolicy',
+            qs: {
+              ifMetagenerationMatch: metadata.metageneration,
+            },
           },
-        },
-        callback
-      );
+          callback);
     });
   }
 
@@ -1920,11 +1919,10 @@ class Bucket extends ServiceObject {
    */
   removeRetentionPeriod(callback) {
     this.setMetadata(
-      {
-        retentionPolicy: null,
-      },
-      callback
-    );
+        {
+          retentionPolicy: null,
+        },
+        callback);
   }
 
   /**
@@ -2135,13 +2133,12 @@ class Bucket extends ServiceObject {
    */
   setRetentionPeriod(duration, callback) {
     this.setMetadata(
-      {
-        retentionPolicy: {
-          retentionPeriod: duration,
+        {
+          retentionPolicy: {
+            retentionPeriod: duration,
+          },
         },
-      },
-      callback
-    );
+        callback);
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1896,7 +1896,8 @@ class Bucket extends ServiceObject {
   }
 
   /**
-   * Remove an already-existing retention policy from this bucket.
+   * Remove an already-existing retention policy from this bucket, if it is not
+   * locked.
    *
    * @param {SetBucketMetadataCallback} [callback] Callback function.
    * @returns {Promise<SetBucketMetadataResponse>}
@@ -2103,7 +2104,8 @@ class Bucket extends ServiceObject {
    * {@link File#removeRetentionPeriod} and {@link File#setRetentionPeriod}. A
    * locked retention policy cannot be removed or shortened in duration for the
    * lifetime of the bucket. Attempting to remove or decrease period of a locked
-   * retention policy will result in a `PERMISSION_DENIED` error.
+   * retention policy will result in a `PERMISSION_DENIED` error. You can still
+   * increase the policy.
    *
    * @param {*} duration In seconds, the minimum retention time for all objects
    *     contained in this bucket.

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1601,12 +1601,14 @@ class Bucket extends ServiceObject {
    * const storage = require('@google-cloud/storage')();
    * const bucket = storage.bucket('albums');
    *
-   * bucket.lock(function(err, apiResponse) {});
+   * const metageneration = 2;
+   *
+   * bucket.lock(metageneration, function(err, apiResponse) {});
    *
    * //-
    * // If the callback is omitted, we'll return a Promise.
    * //-
-   * bucket.lock().then(function(data) {
+   * bucket.lock(metageneration).then(function(data) {
    *   const apiResponse = data[0];
    * });
    */

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1455,7 +1455,7 @@ class Bucket extends ServiceObject {
   /**
    * @callback GetBucketMetadataCallback
    * @param {?Error} err Request error, if any.
-   * @param {object} files The bucket metadata.
+   * @param {object} metadata The bucket metadata.
    * @param {object} apiResponse The full API response.
    */
   /**
@@ -1590,6 +1590,9 @@ class Bucket extends ServiceObject {
    * Lock a previously-defined retention policy. This will prevent changes to
    * the policy.
    *
+   * @param {SetBucketMetadataCallback} [callback] Callback function.
+   * @returns {Promise<SetBucketMetadataResponse>}
+   *
    * @example
    * const storage = require('@google-cloud/storage')();
    * const bucket = storage.bucket('albums');
@@ -1604,9 +1607,9 @@ class Bucket extends ServiceObject {
    * });
    */
   lock(callback) {
-    this.getMetadata((err, metadata) => {
+    this.getMetadata((err, metadata, apiResponse) => {
       if (err) {
-        callback(err);
+        callback(err, null, apiResponse);
         return;
       }
 

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1590,6 +1590,10 @@ class Bucket extends ServiceObject {
    * Lock a previously-defined retention policy. This will prevent changes to
    * the policy.
    *
+   * @throws {Error} if a metageneration is not provided.
+   *
+   * @param {Number|String} metageneration The bucket's metageneration. This is
+   *     accesssible from calling {@link File#getMetadata}.
    * @param {SetBucketMetadataCallback} [callback] Callback function.
    * @returns {Promise<SetBucketMetadataResponse>}
    *
@@ -1606,23 +1610,20 @@ class Bucket extends ServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  lock(callback) {
-    this.getMetadata((err, metadata, apiResponse) => {
-      if (err) {
-        callback(err, null, apiResponse);
-        return;
-      }
+  lock(metageneration, callback) {
+    if (!is.number(metageneration) && !is.string(metageneration)) {
+      throw new Error('A metageneration must be provided.');
+    }
 
-      this.request(
-          {
-            method: 'POST',
-            uri: '/lockRetentionPolicy',
-            qs: {
-              ifMetagenerationMatch: metadata.metageneration,
-            },
+    this.request(
+        {
+          method: 'POST',
+          uri: '/lockRetentionPolicy',
+          qs: {
+            ifMetagenerationMatch: metageneration,
           },
-          callback);
-    });
+        },
+        callback);
   }
 
   /**

--- a/src/file.ts
+++ b/src/file.ts
@@ -1512,7 +1512,8 @@ class File extends ServiceObject {
    *     retention policy will expire.
    */
   /**
-   * Get a Date object representing the earliest time this file will expire.
+   * If this bucket has a retention policy defined, use this method to get a
+   * Date object representing the earliest time this file will expire.
    *
    * @param {GetExpirationDateCallback} [callback] Callback function.
    * @returns {Promise<GetExpirationDateResponse>}

--- a/src/file.ts
+++ b/src/file.ts
@@ -1508,8 +1508,8 @@ class File extends ServiceObject {
   /**
    * @callback GetExpirationDateCallback
    * @param {?Error} err Request error, if any.
-   * @param {date} file A Date object representing the earliest time this file's
-   *     retention policy will expire.
+   * @param {date} expirationDate A Date object representing the earliest time
+   *     this file's retention policy will expire.
    */
   /**
    * If this bucket has a retention policy defined, use this method to get a

--- a/src/file.ts
+++ b/src/file.ts
@@ -1992,41 +1992,6 @@ class File extends ServiceObject {
   }
 
   /**
-   * Hold this file from its bucket's retention period configuration.
-   *
-   * By default, this will set an event-based hold. This is a way to retain
-   * objects until an event occurs, which is signified by the hold's release
-   * (i.e. this value is set to false (see @{link File#release})). After being
-   * released, this object will be subject to bucket-level retention (if any).
-   *
-   * Alternatively, you may set a temporary hold. This will follow the same
-   * behavior as an event-based hold, with the exception that the bucket's
-   * retention policy will not renew for this file from the time the hold is
-   * released.
-   *
-   * @param {object} [options] Configuration object.
-   * @param {boolean} [options.temporary=false] - Set a temporary hold.
-   * @param {SetFileMetadataCallback} [callback] Callback function.
-   * @returns {Promise<SetFileMetadataResponse>}
-   */
-  hold(options, callback) {
-    if (is.fn(options)) {
-      callback = options;
-      options = {};
-    }
-
-    const metadata = {};
-
-    if (options.temporary) {
-      metadata.temporaryHold = true;
-    } else {
-      metadata.eventBasedHold = true;
-    }
-
-    this.setMetadata(metadata, callback);
-  }
-
-  /**
    * @typedef {array} MakeFilePrivateResponse
    * @property {object} 0 The full API response.
    */
@@ -2297,31 +2262,6 @@ class File extends ServiceObject {
   }
 
   /**
-   * Release this file from an event-based or temporary hold.
-   *
-   * @param {object} [options] Configuration object.
-   * @param {boolean} [options.temporary=false] - Release a temporary hold.
-   * @param {SetFileMetadataCallback} [callback] Callback function.
-   * @returns {Promise<SetFileMetadataResponse>}
-   */
-  release(options, callback) {
-    if (is.fn(options)) {
-      callback = options;
-      options = {};
-    }
-
-    const metadata = {};
-
-    if (options.temporary) {
-      metadata.temporaryHold = false;
-    } else {
-      metadata.eventBasedHold = false;
-    }
-
-    this.setMetadata(metadata, callback);
-  }
-
-  /**
    * Makes request and applies userProject query parameter if necessary.
    *
    * @private
@@ -2480,6 +2420,24 @@ class File extends ServiceObject {
    * }, function(err, apiResponse) {
    *   // metadata should now be { abc: '123', hello: 'goodbye' }
    * });
+   *
+   * //-
+   * // Set a temporary hold on this file from its bucket's retention period
+   * // configuration.
+   * //
+   * file.setMetadata({
+   *   temporaryHold: true
+   * }, function(err, apiResponse) {});
+   *
+   * //-
+   * // Alternatively, you may set a temporary hold. This will follow the same
+   * // behavior as an event-based hold, with the exception that the bucket's
+   * // retention policy will not renew for this file from the time the hold is
+   * // released.
+   * //-
+   * file.setMetadata({
+   *   eventBasedHold: true
+   * }, function(err, apiResponse) {});
    *
    * //-
    * // If the callback is omitted, we'll return a Promise.

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,6 +361,17 @@ class Storage extends Service {
    * storage.createBucket('new-bucket', metadata, callback);
    *
    * //-
+   * // Create a bucket with a retention policy of 6 months.
+   * //-
+   * const metadata = {
+   *   retentionPolicy: {
+   *     retentionPeriod: 15780000 // 6 months in seconds.
+   *   }
+   * };
+   *
+   * storage.createBucket('new-bucket', metadata, callback);
+   *
+   * //-
    * // Enable versioning on a new bucket.
    * //-
    * const metadata = {

--- a/system-test/storage.js
+++ b/system-test/storage.js
@@ -1080,16 +1080,20 @@ describe('storage', function() {
       }
 
       function deleteFiles(callback) {
-        async.each(FILES, function(file, next) {
-          file.setMetadata({temporaryHold: null}, function(err) {
-            if (err) {
-              next(err);
-              return;
-            }
+        async.each(
+          FILES,
+          function(file, next) {
+            file.setMetadata({temporaryHold: null}, function(err) {
+              if (err) {
+                next(err);
+                return;
+              }
 
-            file.delete(next);
-          });
-        }, callback);
+              file.delete(next);
+            });
+          },
+          callback
+        );
       }
 
       before(function() {

--- a/system-test/storage.js
+++ b/system-test/storage.js
@@ -1020,13 +1020,13 @@ describe('storage', function() {
       });
 
       it('should set and release an event-based hold', function() {
-        return FILE.hold()
+        return FILE.setMetadata({eventBasedHold: true})
           .then(response => {
             const metadata = response[0];
 
             assert.strictEqual(metadata.eventBasedHold, true);
           })
-          .then(() => FILE.release())
+          .then(() => FILE.setMetadata({eventBasedHold: false}))
           .then(() => FILE.getMetadata())
           .then(response => {
             const metadata = response[0];
@@ -1036,13 +1036,13 @@ describe('storage', function() {
       });
 
       it('should set and release a temporary hold', function() {
-        return FILE.hold({temporary: true})
+        return FILE.setMetadata({temporaryHold: true})
           .then(response => {
             const metadata = response[0];
 
             assert.strictEqual(metadata.temporaryHold, true);
           })
-          .then(() => FILE.release({temporary: true}))
+          .then(() => FILE.setMetadata({temporaryHold: false}))
           .then(() => FILE.getMetadata())
           .then(response => {
             const metadata = response[0];

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -1569,7 +1569,7 @@ describe('Bucket', () => {
 
     it('should return error from getMetadata', done => {
       const error = new Error('Error.');
-      const apiResponse = {}
+      const apiResponse = {};
 
       bucket.getMetadata = callback => {
         callback(error, null, apiResponse);
@@ -1601,7 +1601,7 @@ describe('Bucket', () => {
           },
         });
 
-        callback(); // done()
+        callback();  // done()
       };
 
       bucket.lock(done);
@@ -1776,7 +1776,7 @@ describe('Bucket', () => {
           retentionPolicy: null,
         });
 
-        callback(); // done()
+        callback();  // done()
       };
 
       bucket.removeRetentionPeriod(done);
@@ -1961,7 +1961,7 @@ describe('Bucket', () => {
           },
         });
 
-        callback(); // done()
+        callback();  // done()
       };
 
       bucket.setRetentionPeriod(duration, done);

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -1559,52 +1559,30 @@ describe('Bucket', () => {
   });
 
   describe('lock', () => {
-    it('should refresh metadata', done => {
-      bucket.getMetadata = () => {
-        done();
-      };
+    it('should throw if a metageneration is not provided', () => {
+      const expectedError = new RegExp('A metageneration must be provided.');
 
-      bucket.lock(assert.ifError);
-    });
-
-    it('should return error from getMetadata', done => {
-      const error = new Error('Error.');
-      const apiResponse = {};
-
-      bucket.getMetadata = callback => {
-        callback(error, null, apiResponse);
-      };
-
-      bucket.lock((err, metadata, apiResponse_) => {
-        assert.strictEqual(err, error);
-        assert.strictEqual(metadata, null);
-        assert.strictEqual(apiResponse_, apiResponse);
-        done();
-      });
+      assert.throws(() => {
+        bucket.lock(assert.ifError);
+      }, expectedError);
     });
 
     it('should make the correct request', done => {
-      const metadata = {
-        metageneration: 8,
-      };
-
-      bucket.getMetadata = callback => {
-        callback(null, metadata);
-      };
+      const metageneration = 8;
 
       bucket.request = (reqOpts, callback) => {
         assert.deepStrictEqual(reqOpts, {
           method: 'POST',
           uri: '/lockRetentionPolicy',
           qs: {
-            ifMetagenerationMatch: metadata.metageneration,
+            ifMetagenerationMatch: metageneration,
           },
         });
 
         callback();  // done()
       };
 
-      bucket.lock(done);
+      bucket.lock(metageneration, done);
     });
   });
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -1966,6 +1966,66 @@ describe('File', () => {
     });
   });
 
+  describe('getExpirationDate', () => {
+    it('should refresh metadata', done => {
+      file.getMetadata = () => {
+        done();
+      };
+
+      file.getExpirationDate(assert.ifError);
+    });
+
+    it('should return error from getMetadata', done => {
+      const error = new Error('Error.');
+      const apiResponse = {};
+
+      file.getMetadata = callback => {
+        callback(error, null, apiResponse);
+      };
+
+      file.getExpirationDate((err, expirationDate, apiResponse_) => {
+        assert.strictEqual(err, error);
+        assert.strictEqual(expirationDate, null);
+        assert.strictEqual(apiResponse_, apiResponse);
+        done();
+      });
+    });
+
+    it('should return an error if there is no expiration time', done => {
+      const apiResponse = {};
+
+      file.getMetadata = callback => {
+        callback(null, {}, apiResponse);
+      };
+
+      file.getExpirationDate((err, expirationDate, apiResponse_) => {
+        assert.strictEqual(err.message, `An expiration time is not available.`);
+        assert.strictEqual(expirationDate, null);
+        assert.strictEqual(apiResponse_, apiResponse);
+        done();
+      });
+    });
+
+    it('should return the expiration time as a Date object', done => {
+      const expirationTime = new Date();
+
+      const apiResponse = {
+        retentionExpirationTime: expirationTime.toJSON(),
+      };
+
+      file.getMetadata = callback => {
+        callback(null, apiResponse, apiResponse);
+      };
+
+      file.getExpirationDate((err, expirationDate, apiResponse_) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(expirationDate, expirationTime);
+        assert.strictEqual(apiResponse_, apiResponse);
+        done();
+      });
+    });
+  });
+
   describe('getMetadata', () => {
     it('should make the correct request', done => {
       extend(file.parent, {


### PR DESCRIPTION
#### To Dos
- Tests
  - [x] System
  - [ ] Unit

#### References
- https://docs.google.com/document/d/1wRpiAxTHZoypR1NLVP97Cj0WCGVKx43Tivso0xXhyEA/edit?ts=5b60f543#
- https://www.googleapis.com/discovery/v1/apis/storage/v1/rest

This introduces new behavior:

# Buckets

- **bucket#lock()**
Lock a previously-defined retention policy. This will prevent changes to the policy.

- **bucket#removeRetentionPeriod()**
Remove an already-existing retention policy from this bucket.

- **bucket#setRetentionPeriod(durationInSeconds)**
Lock all objects contained in the bucket, based on their creation time.

# Files

- **file#getExpirationDate()**
Get a Date object representing the earliest time this file will expire.

---

Additionally, `bucket#getMetadata()`, `bucket#setMetadata()`, `file#getMetadata()`, and `file#setMetadata()` are available if users wish to interact with the raw resource schemas as defined by the API.