### PR TITLE
build(kokoro): run docker as user node

### DIFF
--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -16,7 +16,7 @@ build_file: "nodejs-storage/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:10"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/continuous/node10/common.cfg
+++ b/.kokoro/continuous/node10/common.cfg
@@ -16,7 +16,7 @@ build_file: "nodejs-storage/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:10"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/continuous/node6/common.cfg
+++ b/.kokoro/continuous/node6/common.cfg
@@ -16,7 +16,7 @@ build_file: "nodejs-storage/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:6"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:6-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/continuous/node8/common.cfg
+++ b/.kokoro/continuous/node8/common.cfg
@@ -16,7 +16,7 @@ build_file: "nodejs-storage/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:8"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:8-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/docs.sh
+++ b/.kokoro/docs.sh
@@ -16,6 +16,8 @@
 
 set -xeo pipefail
 
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
 cd $(dirname $0)/..
 
 npm install

--- a/.kokoro/lint.sh
+++ b/.kokoro/lint.sh
@@ -16,6 +16,8 @@
 
 set -xeo pipefail
 
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
 cd $(dirname $0)/..
 
 npm install

--- a/.kokoro/presubmit/node10/common.cfg
+++ b/.kokoro/presubmit/node10/common.cfg
@@ -16,7 +16,7 @@ build_file: "nodejs-storage/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:10"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/presubmit/node6/common.cfg
+++ b/.kokoro/presubmit/node6/common.cfg
@@ -16,7 +16,7 @@ build_file: "nodejs-storage/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:6"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:6-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/presubmit/node8/common.cfg
+++ b/.kokoro/presubmit/node8/common.cfg
@@ -16,7 +16,7 @@ build_file: "nodejs-storage/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:8"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:8-user"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/samples-test.sh
+++ b/.kokoro/samples-test.sh
@@ -16,6 +16,8 @@
 
 set -xeo pipefail
 
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
 # Setup service account credentials.
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
 export GCLOUD_PROJECT=long-door-651

--- a/.kokoro/system-test.sh
+++ b/.kokoro/system-test.sh
@@ -16,6 +16,8 @@
 
 set -xeo pipefail
 
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
 # Setup service account credentials.
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
 

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -16,6 +16,8 @@
 
 set -xeo pipefail
 
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
 cd $(dirname $0)/..
 
 npm install


### PR DESCRIPTION
This should fix `ci/kokoro: lint`, where `npm install` fails when running under `root`.