### PR TITLE
fix: make dependency on request explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "mime-types": "^2.0.8",
     "once": "^1.3.1",
     "pumpify": "^1.5.1",
+    "request": "^2.88.0",
     "snakeize": "^0.1.0",
     "stream-events": "^1.0.1",
     "through2": "^2.0.0",


### PR DESCRIPTION
Somehow we got away without including request as dependency. Making
that implicit so we don't run into problems when pubsub updates.

 ```
npm ls request
@google-cloud/storage@2.0.0 /Users/franzih/code/gcp/nodejs-storage
├─┬ @google-cloud/pubsub@0.19.0
│ ├─┬ @google-cloud/common@0.16.2
│ │ ├─┬ google-auto-auth@0.9.7
│ │ │ └── request@2.88.0  deduped
│ │ ├── request@2.88.0  deduped
│ │ └─┬ retry-request@3.3.2
│ │   └── request@2.88.0  deduped
│ └─┬ google-auto-auth@0.10.1
│   └── request@2.88.0  deduped
├─┬ codecov@3.0.2
│ └── request@2.88.0
└─┬ gcs-resumable-upload@0.12.0
  └── request@2.88.0  deduped
```

Prerequisite for https://github.com/googleapis/nodejs-storage/issues/207 so we can switch to smaller HTTP dependency. 