### PR TITLE
fix: copy(): Use correct destination file name in URI

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -530,7 +530,7 @@ class File extends ServiceObject {
         {
           method: 'POST',
           uri: `/rewriteTo/b/${destBucket.name}/o/${
-              encodeURIComponent(destName)}`,
+              encodeURIComponent(newFile.name)}`,
           qs: query,
           json: options,
           headers,

--- a/test/file.ts
+++ b/test/file.ts
@@ -453,9 +453,10 @@ describe('File', () => {
       }
 
       it('should allow a string', done => {
-        const newFileName = 'new-file-name.png';
+        const newFileName = '/new-file-name.png';
+        const newFile = new File(BUCKET, newFileName);
         const expectedPath =
-            `/rewriteTo/b/${file.bucket.name}/o/${newFileName}`;
+            `/rewriteTo/b/${file.bucket.name}/o/${newFile.name}`;
         assertPathEquals(file, expectedPath, done);
         file.copy(newFileName);
       });


### PR DESCRIPTION
Fixes #355

cc @Alfredo-Delgado