### PR TITLE
turn off types for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "repository": "googleapis/nodejs-storage",
   "main": "./build/src/index.js",
-  "types": "./build/src/index.d.ts",
   "files": [
     "build/src",
     "AUTHORS",


### PR DESCRIPTION
We still have a bit of work to fully implement TypeScript here. Let's disable typings for now so dependents can compile for now.

Intended as a patch release to v2.0.x