### PR TITLE
samples: don't use USA formatted dates for expiry

### DIFF
--- a/samples/files.js
+++ b/samples/files.js
@@ -339,7 +339,7 @@ function generateSignedUrl(bucketName, filename) {
   // These options will allow temporary read access to the file
   const options = {
     action: 'read',
-    expires: Date.now() + (1000 * 60 * 60), // one hour
+    expires: Date.now() + 1000 * 60 * 60, // one hour
   };
 
   // Get a signed URL for the file

--- a/samples/files.js
+++ b/samples/files.js
@@ -339,7 +339,7 @@ function generateSignedUrl(bucketName, filename) {
   // These options will allow temporary read access to the file
   const options = {
     action: 'read',
-    expires: '03-17-2025',
+    expires: Date.now() + (1000 * 60 * 60), // one hour
   };
 
   // Get a signed URL for the file


### PR DESCRIPTION
Found via https://twitter.com/iaincollins/status/1040247045246930946
"I ran into the Google Cloud SDK documentation (and code examples!) using MM-DD-YYYY yesterday"

Docs state:
"A timestamp when this policy will expire. Any value given is passed to new Date()."