### PR TITLE
Bucket lock samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test-only": "nyc mocha build/test",
     "test": "npm run test-only",
     "pretest-only": "npm run compile",
-    "lint": "eslint samples/ system-test/ && gts check",
+    "lint": "eslint --fix samples/ system-test/ && gts check",
     "samples-test": "npm link && cd samples/ && npm link ../ && npm test && cd ../",
     "all-test": "npm test && npm run system-test && npm run samples-test",
     "check": "gts check",

--- a/samples/README.md
+++ b/samples/README.md
@@ -18,6 +18,7 @@
   * [Files](#files)
   * [Notifications](#notifications)
   * [Requester Pays](#requester-pays)
+  * [Bucket Lock](#bucket-lock)
 
 ## Before you begin
 
@@ -269,6 +270,56 @@ For more information, see https://cloud.google.com/storage/docs
 
 [requesterPays_5_docs]: https://cloud.google.com/storage/docs
 [requesterPays_5_code]: requesterPays.js
+
+### Bucket Lock
+
+View the [source code][bucketLock_6_code].
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-storage&page=editor&open_in_editor=samples/bucketLock.js,samples/README.md)
+
+__Usage:__ `node bucketLock.js --help`
+
+```
+bucketLock.js <command>
+
+Commands:
+  bucketLock.js set-retention-policy <bucketName> <period>      Defines a retention policy on a given bucket.
+  bucketLock.js remove-retention-policy <bucketName>            Removes a retention policy on a given bucket if the
+                                                                policy is unlocked.
+  bucketLock.js get-retention-policy <bucketName>               Get a retention policy for a given bucket.
+  bucketLock.js enable-default-event-based-hold <bucketName>    Enable default event-based hold for a given bucket.
+  bucketLock.js disable-default-event-based-hold <bucketName>   Disable default event-based hold for a given bucket.
+  bucketLock.js set-event-based-hold <bucketName> <fileName>    Set an event-based hold for a given file.
+  bucketLock.js release-event-based-hold <bucketName>           Release an event-based hold for a given file.
+  <fileName>
+  bucketLock.js set-temporary-hold <bucketName> <fileName>      Set a temporary hold for a given file.
+  bucketLock.js release-temporary-hold <bucketName> <fileName>  Release a temporary hold for a given file.
+
+Options:
+  --version  Show version number                                                                               [boolean]
+  --help     Show help                                                                                         [boolean]
+
+Examples:
+  node bucketLock.js set-retention-policy my-bucket 5           Defines a retention policy of 5 seconds on a
+                                                                "my-bucket".
+  node bucketLock.js remove-retention-policy my-bucket          Removes a retention policy from "my-bucket".
+  node bucketLock.js get-retention-policy my-bucket             Get the retention policy for "my-bucket".
+  node bucketLock.js enable-default-event-based-hold my-bucket  Enable a default event-based hold for "my-bucket".
+  node bucketLock.js disable-default-event-based-hold           Disable a default-event based hold for "my-bucket".
+  my-bucket
+  node bucketLock.js get-default-event-based-hold my-bucket     Get the value of a default-event-based hold for
+                                                                "my-bucket".
+  node bucketLock.js set-event-based-hold my-bucket my-file     Sets an event-based hold on "my-file".
+  node bucketLock.js release-event-based-hold my-bucket         Releases an event-based hold on "my-file".
+  my-file
+  node bucketLock.js set-temporary-hold my-bucket my-file       Sets a temporary hold on "my-file".
+  node bucketLock.js release-temporary-hold my-bucket my-file   Releases a temporary hold on "my-file".
+
+For more information, see https://cloud.google.com/storage/docs
+```
+
+[bucketLock_6_docs]: https://cloud.google.com/storage/docs
+[bucketLock_6_code]: bucketLock.js
 
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-storage&page=editor&open_in_editor=samples/README.md

--- a/samples/bucketLock.js
+++ b/samples/bucketLock.js
@@ -1,0 +1,500 @@
+/**
+ * Copyright 2018, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This application demonstrates how to use Bucket Lock operations on buckets
+ * and objects using the Google Cloud Storage API.
+ *
+ * For more information read the documentation
+ * at https://cloud.google.com/storage/docs/bucket-lock
+ */
+
+'use strict';
+function setRetentionPolicy(bucketName, retentionPeriod) {
+  // [START storage_set_retention_policy]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  storage
+    .bucket(bucketName)
+    .setRetentionPeriod(retentionPeriod)
+    .then(response => {
+      const metadata = response[0];
+      console.log(
+        `Bucket ${bucketName} retention period set for ${
+          metadata.retentionPolicy.retentionPeriod
+        } seconds.`
+      );
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_set_retention_policy]
+}
+
+function getRetentionPolicy(bucketName) {
+  // [START storage_get_retention_policy]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+  storage
+    .bucket(bucketName)
+    .getMetadata()
+    .then(results => {
+      const metadata = results[0];
+      if (metadata.hasOwnProperty('retentionPolicy')) {
+        const retentionPolicy = metadata.retentionPolicy;
+        console.log('Retention policy:');
+        console.log(`\tperiod: ${retentionPolicy.retentionPeriod}`);
+        console.log(`\teffective time: ${retentionPolicy.effectiveTime}`);
+        if (retentionPolicy.hasOwnProperty('isLocked')) {
+          console.log('\tpolicy is locked');
+        } else {
+          console.log('\tpolicy is unlocked');
+        }
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_get_retention_policy]
+}
+
+function removeRetentionPolicy(bucketName) {
+  // [START storage_remove_retention_policy]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+  storage
+    .bucket(bucketName)
+    .getMetadata()
+    .then(results => {
+      const metadata = results[0];
+      if (
+        metadata.hasOwnProperty('retentionPolicy') &&
+        metadata.retentionPolicy.hasOwnProperty('isLocked')
+      ) {
+        console.log(
+          'Unable to remove retention period as retention policy is locked.'
+        );
+        return null;
+      } else {
+        return storage
+          .bucket(bucketName)
+          .removeRetentionPeriod()
+          .then(response => {
+            const metadata = response[0];
+            if (!metadata.hasOwnProperty('retentionPolicy')) {
+              console.log(`Removed bucket ${bucketName} retention policy.`);
+            }
+          });
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_remove_retention_policy]
+}
+
+function lockRetentionPolicy(bucketName) {
+  // [START storage_lock_retention_policy]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+  // get_bucket gets the current metageneration value for the bucket,
+  // required by lock_retention_policy.
+  storage
+    .bucket(bucketName)
+    .getMetadata()
+    .then(results => {
+      const metadata = results[0];
+      // Warning: Once a retention policy is locked it cannot be unlocked
+      // and retention period can only be increased.
+      return storage
+        .bucket(bucketName)
+        .lock(metadata.metageneration)
+        .then(results => {
+          const metadata = results[0];
+          if (metadata.retentionPolicy.isLocked) {
+            console.log(`Retention policy for ${bucketName} is now locked.`);
+            console.log(
+              `Retention policy effective as of ${
+                metadata.retentionPolicy.effectiveTime
+              }`
+            );
+          }
+        });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_lock_retention_policy]
+}
+
+function enableDefaultEventBasedHold(bucketName) {
+  // [START storage_enable_default_event_based_hold]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const bucketName = 'Name of a bucket, e.g. my-bucket';
+
+  // Enables a default event-based hold for the bucket.
+  storage
+    .bucket(bucketName)
+    .setMetadata({
+      defaultEventBasedHold: true,
+    })
+    .then(results => {
+      const metadata = results[0];
+      if (metadata.defaultEventBasedHold) {
+        console.log(`Default event-based hold was enabled for ${bucketName}.`);
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_enable_default_event_based_hold]
+}
+
+function disableDefaultEventBasedHold(bucketName) {
+  // [START storage_disable_default_event_based_hold]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const bucketName = 'Name of a bucket, e.g. my-bucket';
+
+  // Disables a default event-based hold for a bucket.
+  storage
+    .bucket(bucketName)
+    .setMetadata({
+      defaultEventBasedHold: false,
+    })
+    .then(results => {
+      const metadata = results[0];
+      if (
+        metadata.hasOwnProperty('defaultEventBasedHold') &&
+        !metadata.defaultEventBasedHold
+      ) {
+        console.log(`Default event-based hold was disabled for ${bucketName}.`);
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_disable_default_event_based_hold]
+}
+
+function getDefaultEventBasedHold(bucketName) {
+  // [START storage_get_default_event_based_hold]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const bucketName = 'Name of a bucket, e.g. my-bucket';
+
+  // get bucketName metadata
+  storage
+    .bucket(bucketName)
+    .getMetadata()
+    .then(results => {
+      const metadata = results[0];
+      console.log(
+        `Default event-based hold: ${metadata.defaultEventBasedHold}.`
+      );
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_get_default_event_based_hold]
+}
+
+function setEventBasedHold(bucketName, fileName) {
+  // [START storage_set_event_based_hold]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const bucketName = 'Name of a bucket, e.g. my-bucket';
+  // const filename = 'File to access, e.g. file.txt';
+
+  // Set event-based hold
+  storage
+    .bucket(bucketName)
+    .file(fileName)
+    .setMetadata({
+      eventBasedHold: true,
+    })
+    .then(results => {
+      const metadata = results[0];
+      if (
+        metadata.hasOwnProperty('eventBasedHold') &&
+        metadata.eventBasedHold
+      ) {
+        console.log(`Event-based hold was set for ${fileName}.`);
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_set_event_based_hold]
+}
+
+function releaseEventBasedHold(bucketName, fileName) {
+  // [START storage_release_event_based_hold]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const bucketName = 'Name of a bucket, e.g. my-bucket';
+  // const filename = 'File to access, e.g. file.txt';
+
+  storage
+    .bucket(bucketName)
+    .file(fileName)
+    .setMetadata({
+      eventBasedHold: false,
+    })
+    .then(results => {
+      const metadata = results[0];
+      if (
+        metadata.hasOwnProperty('eventBasedHold') &&
+        !metadata.eventBasedHold
+      ) {
+        console.log(`Event-based hold was released for ${fileName}.`);
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_release_event_based_hold]
+}
+
+function setTemporarydHold(bucketName, fileName) {
+  // [START storage_set_temporary_hold]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const bucketName = 'Name of a bucket, e.g. my-bucket';
+  // const filename = 'File to access, e.g. file.txt';
+
+  storage
+    .bucket(bucketName)
+    .file(fileName)
+    .setMetadata({
+      temporaryHold: true,
+    })
+    .then(results => {
+      const metadata = results[0];
+      if (metadata.hasOwnProperty('temporaryHold') && metadata.temporaryHold) {
+        console.log(`Temporary hold was set for ${fileName}.`);
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_set_temporary_hold]
+}
+
+function releaseTemporaryHold(bucketName, fileName) {
+  // [START storage_release_temporary_hold]
+  // Imports the Google Cloud client library
+  const {Storage} = require('@google-cloud/storage');
+
+  // Creates a client
+  const storage = new Storage();
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const bucketName = 'Name of a bucket, e.g. my-bucket';
+  // const filename = 'File to access, e.g. file.txt';
+
+  storage
+    .bucket(bucketName)
+    .file(fileName)
+    .setMetadata({
+      temporaryHold: false,
+    })
+    .then(results => {
+      const metadata = results[0];
+      if (metadata.hasOwnProperty('temporaryHold') && !metadata.temporaryHold) {
+        console.log(`Temporary hold was released for ${fileName}.`);
+      }
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END storage_release_temporary_hold]
+}
+
+require(`yargs`)
+  .demand(1)
+  .command(
+    `set-retention-policy <bucketName> <period>`,
+    `Defines a retention policy on a given bucket.`,
+    {},
+    opts => setRetentionPolicy(opts.bucketName, opts.period)
+  )
+  .command(
+    `remove-retention-policy <bucketName>`,
+    `Removes a retention policy on a given bucket if the policy is unlocked.`,
+    {},
+    opts => removeRetentionPolicy(opts.bucketName)
+  )
+  .command(
+    `get-retention-policy <bucketName>`,
+    `Get a retention policy for a given bucket.`,
+    {},
+    opts => getRetentionPolicy(opts.bucketName)
+  )
+  .command(
+    `lock-retention-policy <bucketName>`,
+    `Lock a retention policy for a given bucket.`,
+    {},
+    opts => lockRetentionPolicy(opts.bucketName)
+  )
+  .command(
+    `enable-default-event-based-hold <bucketName>`,
+    `Enable default event-based hold for a given bucket.`,
+    {},
+    opts => enableDefaultEventBasedHold(opts.bucketName)
+  )
+  .command(
+    `disable-default-event-based-hold <bucketName>`,
+    `Disable default event-based hold for a given bucket.`,
+    {},
+    opts => disableDefaultEventBasedHold(opts.bucketName)
+  )
+  .command(
+    `get-default-event-based-hold <bucketName>`,
+    `Get default event-based hold for a given bucket.`,
+    {},
+    opts => getDefaultEventBasedHold(opts.bucketName)
+  )
+  .command(
+    `set-event-based-hold <bucketName> <fileName>`,
+    `Set an event-based hold for a given file.`,
+    {},
+    opts => setEventBasedHold(opts.bucketName, opts.fileName)
+  )
+  .command(
+    `release-event-based-hold <bucketName> <fileName>`,
+    `Release an event-based hold for a given file.`,
+    {},
+    opts => releaseEventBasedHold(opts.bucketName, opts.fileName)
+  )
+  .command(
+    `set-temporary-hold <bucketName> <fileName>`,
+    `Set a temporary hold for a given file.`,
+    {},
+    opts => setTemporarydHold(opts.bucketName, opts.fileName)
+  )
+  .command(
+    `release-temporary-hold <bucketName> <fileName>`,
+    `Release a temporary hold for a given file.`,
+    {},
+    opts => releaseTemporaryHold(opts.bucketName, opts.fileName)
+  )
+  .example(
+    `node $0 set-retention-policy my-bucket 5`,
+    `Defines a retention policy of 5 seconds on a "my-bucket".`
+  )
+  .example(
+    `node $0 remove-retention-policy my-bucket`,
+    `Removes a retention policy from "my-bucket".`
+  )
+  .example(
+    `node $0 get-retention-policy my-bucket`,
+    `Get the retention policy for "my-bucket".`
+  )
+  .example(
+    `node $0 lock-retention-policy my-bucket`,
+    `Lock the retention policy for "my-bucket".`
+  )
+  .example(
+    `node $0 enable-default-event-based-hold my-bucket`,
+    `Enable a default event-based hold for "my-bucket".`
+  )
+  .example(
+    `node $0 disable-default-event-based-hold my-bucket`,
+    `Disable a default-event based hold for "my-bucket".`
+  )
+  .example(
+    `node $0 get-default-event-based-hold my-bucket`,
+    `Get the value of a default-event-based hold for "my-bucket".`
+  )
+  .example(
+    `node $0 set-event-based-hold my-bucket my-file`,
+    `Sets an event-based hold on "my-file".`
+  )
+  .example(
+    `node $0 release-event-based-hold my-bucket my-file`,
+    `Releases an event-based hold on "my-file".`
+  )
+  .example(
+    `node $0 set-temporary-hold my-bucket my-file`,
+    `Sets a temporary hold on "my-file".`
+  )
+  .example(
+    `node $0 release-temporary-hold my-bucket my-file`,
+    `Releases a temporary hold on "my-file".`
+  )
+  .wrap(120)
+  .recommendCommands()
+  .epilogue(`For more information, see https://cloud.google.com/storage/docs`)
+  .help()
+  .strict().argv;

--- a/samples/files.js
+++ b/samples/files.js
@@ -285,8 +285,14 @@ function getMetadata(bucketName, filename) {
       console.log(`Content-disposition: ${metadata.contentDisposition}`);
       console.log(`Content-encoding: ${metadata.contentEncoding}`);
       console.log(`Content-language: ${metadata.contentLanguage}`);
-      console.log(`Metadata: ${metadata.metadata}`);
       console.log(`Media link: ${metadata.mediaLink}`);
+      console.log(`KMS Key Name: ${metadata.kmsKeyName}`);
+      console.log(`Temporary Hold: ${metadata.temporaryHold}`);
+      console.log(`Event-based hold: ${metadata.eventBasedHold}`);
+      console.log(
+        `Effective Expiration Time: ${metadata.effectiveExpirationTime}`
+      );
+      console.log(`Metadata: ${metadata.metadata}`);
     })
     .catch(err => {
       console.error('ERROR:', err);

--- a/samples/package.json
+++ b/samples/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "*",
-    "@google-cloud/storage": "^2.0.3",
+    "@google-cloud/storage": "+git",
     "uuid": "^3.3.2",
     "yargs": "^12.0.0"
   },

--- a/samples/system-test/bucketLock.test.js
+++ b/samples/system-test/bucketLock.test.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2017, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require(`path`);
+const {Storage} = require(`@google-cloud/storage`);
+const test = require(`ava`);
+const tools = require(`@google-cloud/nodejs-repo-tools`);
+const uuid = require(`uuid`);
+
+const storage = new Storage();
+const cwd = path.join(__dirname, `..`);
+const cmd = `node bucketLock.js`;
+const bucketName = `nodejs-storage-samples-${uuid.v4()}`;
+const bucket = storage.bucket(bucketName);
+const fileName = `test.txt`;
+
+const uploadFilePath = path.join(cwd, `resources`, fileName);
+
+test.before(tools.checkCredentials);
+test.before(async () => {
+  await bucket.create();
+});
+test.before(async () => {
+  await bucket.upload(uploadFilePath);
+});
+
+test.after.always(async () => {
+  try {
+    await bucket.deleteFiles({force: true});
+  } catch (err) {} // ignore error
+  try {
+    await bucket.delete();
+  } catch (err) {} // ignore error
+});
+
+test.beforeEach(tools.stubConsole);
+test.afterEach.always(tools.restoreConsole);
+
+test.serial(`should set a retention policy on a bucket`, async t => {
+  const retentionPeriod = 5;
+  const results = await tools.runAsyncWithIO(
+    `${cmd} set-retention-policy ${bucketName} ${retentionPeriod}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(
+      `Bucket ${bucketName} retention period set for ${retentionPeriod} seconds.`
+    )
+  );
+});
+
+test.serial(`should get a retention policy on a bucket`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} get-retention-policy ${bucketName}`,
+    cwd
+  );
+  t.regex(results.stdout + results.stderr, new RegExp(`Retention policy:`));
+});
+
+test.serial(`should enable default event-based hold on a bucket`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} enable-default-event-based-hold ${bucketName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Default event-based hold was enabled for ${bucketName}.`)
+  );
+});
+
+test.serial(`should get default event-based hold on a bucket`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} get-default-event-based-hold ${bucketName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Default event-based hold: true.`)
+  );
+});
+
+test.serial(`should disable default event-based hold on a bucket`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} disable-default-event-based-hold ${bucketName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Default event-based hold was disabled for ${bucketName}.`)
+  );
+});
+
+test.serial(`should set an event-based hold on a file`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} set-event-based-hold ${bucketName} ${fileName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Event-based hold was set for ${fileName}.`)
+  );
+});
+
+test.serial(`should release an event-based hold on a file`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} release-event-based-hold ${bucketName} ${fileName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Event-based hold was released for ${fileName}.`)
+  );
+});
+
+test.serial(`should remove a retention policy on a bucket`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} remove-retention-policy ${bucketName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Removed bucket ${bucketName} retention policy.`)
+  );
+});
+
+test.serial(`should set an temporary hold on a file`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} set-temporary-hold ${bucketName} ${fileName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Temporary hold was set for ${fileName}.`)
+  );
+});
+
+test.serial(`should release an temporary hold on a file`, async t => {
+  const results = await tools.runAsyncWithIO(
+    `${cmd} release-temporary-hold ${bucketName} ${fileName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Temporary hold was released for ${fileName}.`)
+  );
+});
+
+test.serial(`should lock a bucket with a retention policy`, async t => {
+  const retentionPeriod = 5;
+  await tools.runAsyncWithIO(
+    `${cmd} set-retention-policy ${bucketName} ${retentionPeriod}`,
+    cwd
+  );
+  const results = await tools.runAsyncWithIO(
+    `${cmd} lock-retention-policy ${bucketName}`,
+    cwd
+  );
+  t.regex(
+    results.stdout + results.stderr,
+    new RegExp(`Retention policy for ${bucketName} is now locked.`)
+  );
+});

--- a/samples/system-test/files.test.js
+++ b/samples/system-test/files.test.js
@@ -196,6 +196,7 @@ test.serial(`should get metadata for a file`, async t => {
     cwd
   );
   const output = results.stdout + results.stderr;
+  console.log(`METADATA: ${output}`);
   t.regex(output, new RegExp(`File: ${copiedFileName}`));
   t.regex(output, new RegExp(`Bucket: ${bucketName}`));
 });

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1455,7 +1455,7 @@ class Bucket extends ServiceObject {
   /**
    * @callback GetBucketMetadataCallback
    * @param {?Error} err Request error, if any.
-   * @param {object} files The bucket metadata.
+   * @param {object} metadata The bucket metadata.
    * @param {object} apiResponse The full API response.
    */
   /**
@@ -1584,6 +1584,48 @@ class Bucket extends ServiceObject {
 
           callback(null, notifications, resp);
         });
+  }
+
+  /**
+   * Lock a previously-defined retention policy. This will prevent changes to
+   * the policy.
+   *
+   * @throws {Error} if a metageneration is not provided.
+   *
+   * @param {Number|String} metageneration The bucket's metageneration. This is
+   *     accesssible from calling {@link File#getMetadata}.
+   * @param {SetBucketMetadataCallback} [callback] Callback function.
+   * @returns {Promise<SetBucketMetadataResponse>}
+   *
+   * @example
+   * const storage = require('@google-cloud/storage')();
+   * const bucket = storage.bucket('albums');
+   *
+   * const metageneration = 2;
+   *
+   * bucket.lock(metageneration, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bucket.lock(metageneration).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  lock(metageneration, callback) {
+    if (!is.number(metageneration) && !is.string(metageneration)) {
+      throw new Error('A metageneration must be provided.');
+    }
+
+    this.request(
+        {
+          method: 'POST',
+          uri: '/lockRetentionPolicy',
+          qs: {
+            ifMetagenerationMatch: metageneration,
+          },
+        },
+        callback);
   }
 
   /**
@@ -1859,6 +1901,34 @@ class Bucket extends ServiceObject {
   }
 
   /**
+   * Remove an already-existing retention policy from this bucket, if it is not
+   * locked.
+   *
+   * @param {SetBucketMetadataCallback} [callback] Callback function.
+   * @returns {Promise<SetBucketMetadataResponse>}
+   *
+   * @example
+   * const storage = require('@google-cloud/storage')();
+   * const bucket = storage.bucket('albums');
+   *
+   * bucket.removeRetentionPeriod(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bucket.removeRetentionPeriod().then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  removeRetentionPeriod(callback) {
+    this.setMetadata(
+        {
+          retentionPolicy: null,
+        },
+        callback);
+  }
+
+  /**
    * Makes request and applies userProject query parameter if necessary.
    *
    * @private
@@ -1989,6 +2059,13 @@ class Bucket extends ServiceObject {
    * }, function(err, apiResponse) {});
    *
    * //-
+   * // Set the default event-based hold value for new objects in this bucket.
+   * //-
+   * bucket.setMetadata({
+   *   defaultEventBasedHold: true
+   * }, function(err, apiResponse) {});
+   *
+   * //-
    * // If the callback is omitted, we'll return a Promise.
    * //-
    * bucket.setMetadata(metadata).then(function(data) {
@@ -2020,6 +2097,51 @@ class Bucket extends ServiceObject {
 
           callback(null, resp);
         });
+  }
+
+  /**
+   * Lock all objects contained in the bucket, based on their creation time. Any
+   * attempt to overwrite or delete objects younger than the retention period
+   * will result in a `PERMISSION_DENIED` error.
+   *
+   * An unlocked retention policy can be modified or removed from the bucket via
+   * {@link File#removeRetentionPeriod} and {@link File#setRetentionPeriod}. A
+   * locked retention policy cannot be removed or shortened in duration for the
+   * lifetime of the bucket. Attempting to remove or decrease period of a locked
+   * retention policy will result in a `PERMISSION_DENIED` error. You can still
+   * increase the policy.
+   *
+   * @param {*} duration In seconds, the minimum retention time for all objects
+   *     contained in this bucket.
+   * @param {SetBucketMetadataCallback} [callback] Callback function.
+   * @returns {Promise<SetBucketMetadataResponse>}
+   *
+   * @example
+   * const storage = require('@google-cloud/storage')();
+   * const bucket = storage.bucket('albums');
+   *
+   * const DURATION_SECONDS = 15780000; // 6 months.
+   *
+   * //-
+   * // Lock the objects in this bucket for 6 months.
+   * //-
+   * bucket.setRetentionPeriod(DURATION_SECONDS, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bucket.setRetentionPeriod(DURATION_SECONDS).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  setRetentionPeriod(duration, callback) {
+    this.setMetadata(
+        {
+          retentionPolicy: {
+            retentionPeriod: duration,
+          },
+        },
+        callback);
   }
 
   /**

--- a/src/file.ts
+++ b/src/file.ts
@@ -1501,6 +1501,51 @@ class File extends ServiceObject {
   }
 
   /**
+   * @typedef {array} GetExpirationDateResponse
+   * @property {date} 0 A Date object representing the earliest time this file's
+   *     retention policy will expire.
+   */
+  /**
+   * @callback GetExpirationDateCallback
+   * @param {?Error} err Request error, if any.
+   * @param {date} expirationDate A Date object representing the earliest time
+   *     this file's retention policy will expire.
+   */
+  /**
+   * If this bucket has a retention policy defined, use this method to get a
+   * Date object representing the earliest time this file will expire.
+   *
+   * @param {GetExpirationDateCallback} [callback] Callback function.
+   * @returns {Promise<GetExpirationDateResponse>}
+   *
+   * @example
+   * const storage = require('@google-cloud/storage')();
+   * const myBucket = storage.bucket('my-bucket');
+   *
+   * const file = myBucket.file('my-file');
+   *
+   * file.getExpirationDate(function(err, expirationDate) {
+   *   // expirationDate is a Date object.
+   * });
+   */
+  getExpirationDate(callback) {
+    this.getMetadata((err, metadata, apiResponse) => {
+      if (err) {
+        callback(err, null, apiResponse);
+        return;
+      }
+
+      if (!metadata.retentionExpirationTime) {
+        const error = new Error('An expiration time is not available.');
+        callback(error, null, apiResponse);
+        return;
+      }
+
+      callback(null, new Date(metadata.retentionExpirationTime), apiResponse);
+    });
+  }
+
+  /**
    * @typedef {array} GetFileMetadataResponse
    * @property {object} 0 The {@link File} metadata.
    * @property {object} 1 The full API response.
@@ -2375,6 +2420,24 @@ class File extends ServiceObject {
    * }, function(err, apiResponse) {
    *   // metadata should now be { abc: '123', hello: 'goodbye' }
    * });
+   *
+   * //-
+   * // Set a temporary hold on this file from its bucket's retention period
+   * // configuration.
+   * //
+   * file.setMetadata({
+   *   temporaryHold: true
+   * }, function(err, apiResponse) {});
+   *
+   * //-
+   * // Alternatively, you may set a temporary hold. This will follow the same
+   * // behavior as an event-based hold, with the exception that the bucket's
+   * // retention policy will not renew for this file from the time the hold is
+   * // released.
+   * //-
+   * file.setMetadata({
+   *   eventBasedHold: true
+   * }, function(err, apiResponse) {});
    *
    * //-
    * // If the callback is omitted, we'll return a Promise.

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,6 +361,17 @@ class Storage extends Service {
    * storage.createBucket('new-bucket', metadata, callback);
    *
    * //-
+   * // Create a bucket with a retention policy of 6 months.
+   * //-
+   * const metadata = {
+   *   retentionPolicy: {
+   *     retentionPeriod: 15780000 // 6 months in seconds.
+   *   }
+   * };
+   *
+   * storage.createBucket('new-bucket', metadata, callback);
+   *
+   * //-
    * // Enable versioning on a new bucket.
    * //-
    * const metadata = {

--- a/system-test/storage.js
+++ b/system-test/storage.js
@@ -928,6 +928,212 @@ describe('storage', function() {
     });
   });
 
+  describe('bucket retention policies', function() {
+    const RETENTION_DURATION_SECONDS = 10;
+
+    describe('bucket', function() {
+      it('should create a bucket with a retention policy', function() {
+        const bucket = storage.bucket(generateName());
+
+        return bucket
+          .create({
+            retentionPolicy: {
+              retentionPeriod: RETENTION_DURATION_SECONDS,
+            },
+          })
+          .then(() => bucket.getMetadata())
+          .then(response => {
+            const metadata = response[0];
+
+            assert.strictEqual(
+              metadata.retentionPolicy.retentionPeriod,
+              `${RETENTION_DURATION_SECONDS}`
+            );
+          });
+      });
+
+      it('should set a retention policy', function() {
+        const bucket = storage.bucket(generateName());
+
+        return bucket
+          .create()
+          .then(() => bucket.setRetentionPeriod(RETENTION_DURATION_SECONDS))
+          .then(() => bucket.getMetadata())
+          .then(response => {
+            const metadata = response[0];
+
+            assert.strictEqual(
+              metadata.retentionPolicy.retentionPeriod,
+              `${RETENTION_DURATION_SECONDS}`
+            );
+          });
+      });
+
+      it('should lock the retention period', function(done) {
+        const bucket = storage.bucket(generateName());
+
+        bucket
+          .create()
+          .then(() => bucket.setRetentionPeriod(RETENTION_DURATION_SECONDS))
+          .then(() => bucket.lock())
+          .then(() => bucket.setRetentionPeriod(RETENTION_DURATION_SECONDS / 2))
+          .catch(err => {
+            assert.strictEqual(err.code, 403);
+            done();
+          });
+      });
+
+      it('should remove a retention period', function() {
+        const bucket = storage.bucket(generateName());
+
+        return bucket
+          .create()
+          .then(() => bucket.setRetentionPeriod(RETENTION_DURATION_SECONDS))
+          .then(() => bucket.removeRetentionPeriod())
+          .then(() => bucket.getMetadata())
+          .then(response => {
+            const metadata = response[0];
+
+            assert.strictEqual(metadata.retentionPolicy, undefined);
+          });
+      });
+    });
+
+    describe('file', function() {
+      const BUCKET = storage.bucket(generateName());
+      const FILE = BUCKET.file(generateName());
+
+      before(function() {
+        return BUCKET.create({
+          retentionPolicy: {
+            retentionPeriod: 1,
+          },
+        }).then(() => FILE.save('data'));
+      });
+
+      afterEach(function() {
+        return FILE.setMetadata({temporaryHold: null, eventBasedHold: null});
+      });
+
+      after(function() {
+        return FILE.delete();
+      });
+
+      it('should set and release an event-based hold', function() {
+        return FILE.setMetadata({eventBasedHold: true})
+          .then(response => {
+            const metadata = response[0];
+
+            assert.strictEqual(metadata.eventBasedHold, true);
+          })
+          .then(() => FILE.setMetadata({eventBasedHold: false}))
+          .then(() => FILE.getMetadata())
+          .then(response => {
+            const metadata = response[0];
+
+            assert.strictEqual(metadata.eventBasedHold, false);
+          });
+      });
+
+      it('should set and release a temporary hold', function() {
+        return FILE.setMetadata({temporaryHold: true})
+          .then(response => {
+            const metadata = response[0];
+
+            assert.strictEqual(metadata.temporaryHold, true);
+          })
+          .then(() => FILE.setMetadata({temporaryHold: false}))
+          .then(() => FILE.getMetadata())
+          .then(response => {
+            const metadata = response[0];
+
+            assert.strictEqual(metadata.temporaryHold, false);
+          });
+      });
+
+      it('should get an expiration date', function() {
+        return FILE.getExpirationDate().then(response => {
+          const expirationDate = response[0];
+          assert(expirationDate instanceof Date);
+        });
+      });
+    });
+
+    describe('operations on held objects', function() {
+      const BUCKET = storage.bucket(generateName());
+      const FILES = [];
+
+      const RETENTION_PERIOD_SECONDS = 5; // Each test has this much time!
+
+      function createFile(callback) {
+        const file = BUCKET.file(generateName());
+        FILES.push(file);
+
+        file.save('data', function(err) {
+          if (err) {
+            callback(err);
+            return;
+          }
+
+          callback(null, file);
+        });
+      }
+
+      function deleteFiles(callback) {
+        async.each(
+          FILES,
+          function(file, next) {
+            file.setMetadata({temporaryHold: null}, function(err) {
+              if (err) {
+                next(err);
+                return;
+              }
+
+              file.delete(next);
+            });
+          },
+          callback
+        );
+      }
+
+      before(function() {
+        return BUCKET.create({
+          retentionPolicy: {
+            retentionPeriod: RETENTION_PERIOD_SECONDS,
+          },
+        });
+      });
+
+      after(function(done) {
+        setTimeout(deleteFiles, RETENTION_PERIOD_SECONDS * 1000, done);
+      });
+
+      //verify how the client library behaves when holds are enabled
+      //and attempting to perform an overwrite and delete.
+      it('should block an overwrite request', function(done) {
+        createFile(function(err, file) {
+          assert.ifError(err);
+
+          file.save('new data', function(err) {
+            assert.strictEqual(err.code, 403);
+            done();
+          });
+        });
+      });
+
+      it('should block a delete request', function(done) {
+        createFile(function(err, file) {
+          assert.ifError(err);
+
+          file.delete(function(err) {
+            assert.strictEqual(err.code, 403);
+            done();
+          });
+        });
+      });
+    });
+  });
+
   describe('requester pays', function() {
     const HAS_2ND_PROJECT = is.defined(process.env.GCN_STORAGE_2ND_PROJECT_ID);
     let bucket;

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -1567,6 +1567,34 @@ describe('Bucket', () => {
     });
   });
 
+  describe('lock', () => {
+    it('should throw if a metageneration is not provided', () => {
+      const expectedError = new RegExp('A metageneration must be provided.');
+
+      assert.throws(() => {
+        bucket.lock(assert.ifError);
+      }, expectedError);
+    });
+
+    it('should make the correct request', done => {
+      const metageneration = 8;
+
+      bucket.request = (reqOpts, callback) => {
+        assert.deepStrictEqual(reqOpts, {
+          method: 'POST',
+          uri: '/lockRetentionPolicy',
+          qs: {
+            ifMetagenerationMatch: metageneration,
+          },
+        });
+
+        callback();  // done()
+      };
+
+      bucket.lock(metageneration, done);
+    });
+  });
+
   describe('makePrivate', () => {
     it('should set predefinedAcl & privatize files', done => {
       let didSetPredefinedAcl = false;
@@ -1725,6 +1753,20 @@ describe('Bucket', () => {
       assert(notification instanceof FakeNotification);
       assert.strictEqual(notification.bucket, bucket);
       assert.strictEqual(notification.id, fakeId);
+    });
+  });
+
+  describe('removeRetentionPeriod', () => {
+    it('should call setMetadata correctly', done => {
+      bucket.setMetadata = (metadata, callback) => {
+        assert.deepStrictEqual(metadata, {
+          retentionPolicy: null,
+        });
+
+        callback();  // done()
+      };
+
+      bucket.removeRetentionPeriod(done);
     });
   });
 
@@ -1898,6 +1940,24 @@ describe('Bucket', () => {
         assert.strictEqual(apiResponse_, apiResponse);
         done();
       });
+    });
+  });
+
+  describe('setRetentionPeriod', () => {
+    it('should call setMetadata correctly', done => {
+      const duration = 90000;
+
+      bucket.setMetadata = (metadata, callback) => {
+        assert.deepStrictEqual(metadata, {
+          retentionPolicy: {
+            retentionPeriod: duration,
+          },
+        });
+
+        callback();  // done()
+      };
+
+      bucket.setRetentionPeriod(duration, done);
     });
   });
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -1957,6 +1957,66 @@ describe('File', () => {
     });
   });
 
+  describe('getExpirationDate', () => {
+    it('should refresh metadata', done => {
+      file.getMetadata = () => {
+        done();
+      };
+
+      file.getExpirationDate(assert.ifError);
+    });
+
+    it('should return error from getMetadata', done => {
+      const error = new Error('Error.');
+      const apiResponse = {};
+
+      file.getMetadata = callback => {
+        callback(error, null, apiResponse);
+      };
+
+      file.getExpirationDate((err, expirationDate, apiResponse_) => {
+        assert.strictEqual(err, error);
+        assert.strictEqual(expirationDate, null);
+        assert.strictEqual(apiResponse_, apiResponse);
+        done();
+      });
+    });
+
+    it('should return an error if there is no expiration time', done => {
+      const apiResponse = {};
+
+      file.getMetadata = callback => {
+        callback(null, {}, apiResponse);
+      };
+
+      file.getExpirationDate((err, expirationDate, apiResponse_) => {
+        assert.strictEqual(err.message, `An expiration time is not available.`);
+        assert.strictEqual(expirationDate, null);
+        assert.strictEqual(apiResponse_, apiResponse);
+        done();
+      });
+    });
+
+    it('should return the expiration time as a Date object', done => {
+      const expirationTime = new Date();
+
+      const apiResponse = {
+        retentionExpirationTime: expirationTime.toJSON(),
+      };
+
+      file.getMetadata = callback => {
+        callback(null, apiResponse, apiResponse);
+      };
+
+      file.getExpirationDate((err, expirationDate, apiResponse_) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(expirationDate, expirationTime);
+        assert.strictEqual(apiResponse_, apiResponse);
+        done();
+      });
+    });
+  });
+
   describe('getMetadata', () => {
     it('should make the correct request', done => {
       extend(file.parent, {


### PR DESCRIPTION
## Bucket Lock Samples
Collaboration between @billyjacobson and myself.

- [ ]  Code coverage does not decrease (@stephenplusplus -- what are the expectations for code coverage w.r.t to samples?)
- [ ]  Appropriate docs were updated (@stephenplusplus -- not sure what needs to be done here). This samples will be part of documentation for GCS but not sure if I need to do additional work.
- [x]  Tests
- [x]  linter pass
- [x]  Define a retention policy
- [x]  Remove a retention policy if not locked
- [x]  Lock a retention policy
- [x]  Set temporary hold
- [x]  Release temporary hold
- [x]  Set event-based hold
- [x]  Release event-based hold
- [x]  Set default event-based hold
- [x]  Release default event-based hold
- [x]  View default event-based hold
- [x]  View bucket retention policy metadata
- [x]  View metadata for object
- [x]  Updated CLI
- [x]  Add CLI examples
- [x]  Updated README.md
