### PR TITLE
fix(tests): system-test compiles to ./build, fix relative path

### DIFF
--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -1006,7 +1006,7 @@ describe('storage', () => {
                 // for the key file.
                 let key2 = process.env.GCN_STORAGE_2ND_PROJECT_KEY;
                 if (key2 && key2.charAt(0) === '.') {
-                  key2 = `${__dirname}/../${key2}`;
+                  key2 = `${__dirname}/../../${key2}`;
                 }
 
                 // Get the service account for the "second" account (the


### PR DESCRIPTION
This fixes the [CircleCI test failure](https://circleci.com/gh/googleapis/nodejs-storage/9081) as a result of converting system-test to TypeScript on master.

There's no effect on Kokoro builds since we use absolute path for the 2nd key file: https://github.com/googleapis/nodejs-storage/blob/master/.kokoro/setup-vars.sh#L20