### PR TITLE
Minor docs correction

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2814,7 +2814,7 @@ class File extends ServiceObject {
    *   metadata: {
    *     abc: '123', // will be set.
    *     unsetMe: null, // will be unset (deleted).
-   *     hello: 'goodbye' // will be updated from 'hello' to 'goodbye'.
+   *     hello: 'goodbye' // will be updated from 'world' to 'goodbye'.
    *   }
    * }, function(err, apiResponse) {
    *   // metadata should now be { abc: '123', hello: 'goodbye' }


### PR DESCRIPTION
The value in the example five lines up is 'world', so this line should match that.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
