### PR TITLE
fix: re-enable typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "repository": "googleapis/nodejs-storage",
   "main": "./build/src/index.js",
+  "types": "./build/src/index.d.ts",
   "files": [
     "build/src",
     "!build/src/**/*.map",


### PR DESCRIPTION
This turns TypeScript types back on. Fixes #443. Fixes #384.