### PR TITLE
Fixes getSignedUrl Return Type

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2314,7 +2314,7 @@ class File extends ServiceObject {
   getSignedUrl(cfg: GetSignedUrlConfig): Promise<GetSignedUrlResponse>;
   getSignedUrl(cfg: GetSignedUrlConfig, callback: GetSignedUrlCallback): void;
   getSignedUrl(cfg: GetSignedUrlConfig, callback?: GetSignedUrlCallback):
-      void|Promise<GetSignedPolicyResponse> {
+      void|Promise<GetSignedUrlResponse> {
     const expiresInMSeconds = new Date(cfg.expires).valueOf();
 
     if (expiresInMSeconds < Date.now()) {


### PR DESCRIPTION
Fixes #497 

Currently, the getSignedUrl type is returning GetSignedPolicyResponse. It should be GetSignedUrlResponse

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
