### PR TITLE
docs: File#setMetadata in parallel results in unpredictable state

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2785,8 +2785,9 @@ class File extends ServiceObject {
    * object, however the other properties outside of this object must adhere
    * to the [official API documentation](https://goo.gl/BOnnCK).
    *
-   * NOTE: multiple calls to setMetadata in parallel might result in unpredictable
-   * results. See [issue]{@link https://github.com/googleapis/nodejs-storage/issues/274}.
+   * NOTE: multiple calls to setMetadata in parallel might result in
+   * unpredictable results. See [issue]{@link
+   * https://github.com/googleapis/nodejs-storage/issues/274}.
    *
    * See the examples below for more information.
    *

--- a/src/file.ts
+++ b/src/file.ts
@@ -2785,6 +2785,9 @@ class File extends ServiceObject {
    * object, however the other properties outside of this object must adhere
    * to the [official API documentation](https://goo.gl/BOnnCK).
    *
+   * NOTE: multiple calls to setMetadata in parallel might result in unpredictable
+   * results. See [issue]{@link https://github.com/googleapis/nodejs-storage/issues/274}.
+   *
    * See the examples below for more information.
    *
    * @see [Objects: patch API Documentation]{@link https://cloud.google.com/storage/docs/json_api/v1/objects/patch}


### PR DESCRIPTION
Addresses question raised in #274 where @eleith notice unpredictable results when File.setMetadata is called in parallel.

fixes #274 
