### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "source-map-support": "^0.5.6",
     "tmp": "^0.0.33",
     "typescript": "~3.1.1",
-    "uuid": "^3.1.0"
+    "uuid": "^3.1.0",
+    "@types/sinon": "5.0.5"
   }
 }


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.