### PR TITLE
fix(docs): move jsdoc away from interface

### DIFF
--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -31,7 +31,7 @@ module.exports = {
   source: {
     excludePattern: '(^|\\/|\\\\)[._]',
     include: [
-      'build'
+      'build/src'
     ],
     includePattern: '\\.js$'
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "storage"
   ],
   "scripts": {
+    "predocs": "npm run compile",
     "docs": "jsdoc -c .jsdoc.js",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
     "system-test": "mocha build/system-test --timeout 600000",

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -112,159 +112,164 @@ class AclRoleAccessorMethods {
 
   private static roles = ['OWNER', 'READER', 'WRITER'];
 
-  /**
-   * An object of convenience methods to add or delete owner ACL permissions for
-   * a given entity.
-   *
-   * The supported methods include:
-   *
-   *   - `myFile.acl.owners.addAllAuthenticatedUsers`
-   *   - `myFile.acl.owners.deleteAllAuthenticatedUsers`
-   *   - `myFile.acl.owners.addAllUsers`
-   *   - `myFile.acl.owners.deleteAllUsers`
-   *   - `myFile.acl.owners.addDomain`
-   *   - `myFile.acl.owners.deleteDomain`
-   *   - `myFile.acl.owners.addGroup`
-   *   - `myFile.acl.owners.deleteGroup`
-   *   - `myFile.acl.owners.addProject`
-   *   - `myFile.acl.owners.deleteProject`
-   *   - `myFile.acl.owners.addUser`
-   *   - `myFile.acl.owners.deleteUser`
-   *
-   * @return {object}
-   *
-   * @example
-   * const storage = require('@google-cloud/storage')();
-   * const myBucket = storage.bucket('my-bucket');
-   * const myFile = myBucket.file('my-file');
-   *
-   * //-
-   * // Add a user as an owner of a file.
-   * //-
-   * const myBucket = gcs.bucket('my-bucket');
-   * const myFile = myBucket.file('my-file');
-   * myFile.acl.owners.addUser('email@example.com', function(err, aclObject)
-   * {});
-   *
-   * //-
-   * // For reference, the above command is the same as running the following.
-   * //-
-   * myFile.acl.add({
-   *   entity: 'user-email@example.com',
-   *   role: gcs.acl.OWNER_ROLE
-   * }, function(err, aclObject) {});
-   *
-   * //-
-   * // If the callback is omitted, we'll return a Promise.
-   * //-
-   * myFile.acl.owners.addUser('email@example.com').then(function(data) {
-   *   const aclObject = data[0];
-   *   const apiResponse = data[1];
-   * });
-   */
   owners = {};
 
-  /**
-   * An object of convenience methods to add or delete reader ACL permissions
-   * for a given entity.
-   *
-   * The supported methods include:
-   *
-   *   - `myFile.acl.readers.addAllAuthenticatedUsers`
-   *   - `myFile.acl.readers.deleteAllAuthenticatedUsers`
-   *   - `myFile.acl.readers.addAllUsers`
-   *   - `myFile.acl.readers.deleteAllUsers`
-   *   - `myFile.acl.readers.addDomain`
-   *   - `myFile.acl.readers.deleteDomain`
-   *   - `myFile.acl.readers.addGroup`
-   *   - `myFile.acl.readers.deleteGroup`
-   *   - `myFile.acl.readers.addProject`
-   *   - `myFile.acl.readers.deleteProject`
-   *   - `myFile.acl.readers.addUser`
-   *   - `myFile.acl.readers.deleteUser`
-   *
-   * @return {object}
-   *
-   * @example
-   * const storage = require('@google-cloud/storage')();
-   * const myBucket = storage.bucket('my-bucket');
-   * const myFile = myBucket.file('my-file');
-   *
-   * //-
-   * // Add a user as a reader of a file.
-   * //-
-   * myFile.acl.readers.addUser('email@example.com', function(err, aclObject)
-   * {});
-   *
-   * //-
-   * // For reference, the above command is the same as running the following.
-   * //-
-   * myFile.acl.add({
-   *   entity: 'user-email@example.com',
-   *   role: gcs.acl.READER_ROLE
-   * }, function(err, aclObject) {});
-   *
-   * //-
-   * // If the callback is omitted, we'll return a Promise.
-   * //-
-   * myFile.acl.readers.addUser('email@example.com').then(function(data) {
-   *   const aclObject = data[0];
-   *   const apiResponse = data[1];
-   * });
-   */
   readers = {};
 
-  /**
-   * An object of convenience methods to add or delete writer ACL permissions
-   * for a given entity.
-   *
-   * The supported methods include:
-   *
-   *   - `myFile.acl.writers.addAllAuthenticatedUsers`
-   *   - `myFile.acl.writers.deleteAllAuthenticatedUsers`
-   *   - `myFile.acl.writers.addAllUsers`
-   *   - `myFile.acl.writers.deleteAllUsers`
-   *   - `myFile.acl.writers.addDomain`
-   *   - `myFile.acl.writers.deleteDomain`
-   *   - `myFile.acl.writers.addGroup`
-   *   - `myFile.acl.writers.deleteGroup`
-   *   - `myFile.acl.writers.addProject`
-   *   - `myFile.acl.writers.deleteProject`
-   *   - `myFile.acl.writers.addUser`
-   *   - `myFile.acl.writers.deleteUser`
-   *
-   * @return {object}
-   *
-   * @example
-   * const storage = require('@google-cloud/storage')();
-   * const myBucket = storage.bucket('my-bucket');
-   * const myFile = myBucket.file('my-file');
-   *
-   * //-
-   * // Add a user as a writer of a file.
-   * //-
-   * myFile.acl.writers.addUser('email@example.com', function(err, aclObject)
-   * {});
-   *
-   * //-
-   * // For reference, the above command is the same as running the following.
-   * //-
-   * myFile.acl.add({
-   *   entity: 'user-email@example.com',
-   *   role: gcs.acl.WRITER_ROLE
-   * }, function(err, aclObject) {});
-   *
-   * //-
-   * // If the callback is omitted, we'll return a Promise.
-   * //-
-   * myFile.acl.writers.addUser('email@example.com').then(function(data) {
-   *   const aclObject = data[0];
-   *   const apiResponse = data[1];
-   * });
-   */
   writers = {};
 
   constructor() {
+    /**
+     * An object of convenience methods to add or delete owner ACL permissions
+     * for a given entity.
+     *
+     * The supported methods include:
+     *
+     *   - `myFile.acl.owners.addAllAuthenticatedUsers`
+     *   - `myFile.acl.owners.deleteAllAuthenticatedUsers`
+     *   - `myFile.acl.owners.addAllUsers`
+     *   - `myFile.acl.owners.deleteAllUsers`
+     *   - `myFile.acl.owners.addDomain`
+     *   - `myFile.acl.owners.deleteDomain`
+     *   - `myFile.acl.owners.addGroup`
+     *   - `myFile.acl.owners.deleteGroup`
+     *   - `myFile.acl.owners.addProject`
+     *   - `myFile.acl.owners.deleteProject`
+     *   - `myFile.acl.owners.addUser`
+     *   - `myFile.acl.owners.deleteUser`
+     *
+     * @name Acl#owners
+     *
+     * @example
+     * const storage = require('@google-cloud/storage')();
+     * const myBucket = storage.bucket('my-bucket');
+     * const myFile = myBucket.file('my-file');
+     *
+     * //-
+     * // Add a user as an owner of a file.
+     * //-
+     * const myBucket = gcs.bucket('my-bucket');
+     * const myFile = myBucket.file('my-file');
+     * myFile.acl.owners.addUser('email@example.com', function(err, aclObject)
+     * {});
+     *
+     * //-
+     * // For reference, the above command is the same as running the following.
+     * //-
+     * myFile.acl.add({
+     *   entity: 'user-email@example.com',
+     *   role: gcs.acl.OWNER_ROLE
+     * }, function(err, aclObject) {});
+     *
+     * //-
+     * // If the callback is omitted, we'll return a Promise.
+     * //-
+     * myFile.acl.owners.addUser('email@example.com').then(function(data) {
+     *   const aclObject = data[0];
+     *   const apiResponse = data[1];
+     * });
+     */
+    this.owners = {};
+
+    /**
+     * An object of convenience methods to add or delete reader ACL permissions
+     * for a given entity.
+     *
+     * The supported methods include:
+     *
+     *   - `myFile.acl.readers.addAllAuthenticatedUsers`
+     *   - `myFile.acl.readers.deleteAllAuthenticatedUsers`
+     *   - `myFile.acl.readers.addAllUsers`
+     *   - `myFile.acl.readers.deleteAllUsers`
+     *   - `myFile.acl.readers.addDomain`
+     *   - `myFile.acl.readers.deleteDomain`
+     *   - `myFile.acl.readers.addGroup`
+     *   - `myFile.acl.readers.deleteGroup`
+     *   - `myFile.acl.readers.addProject`
+     *   - `myFile.acl.readers.deleteProject`
+     *   - `myFile.acl.readers.addUser`
+     *   - `myFile.acl.readers.deleteUser`
+     *
+     * @name Acl#readers
+     *
+     * @example
+     * const storage = require('@google-cloud/storage')();
+     * const myBucket = storage.bucket('my-bucket');
+     * const myFile = myBucket.file('my-file');
+     *
+     * //-
+     * // Add a user as a reader of a file.
+     * //-
+     * myFile.acl.readers.addUser('email@example.com', function(err, aclObject)
+     * {});
+     *
+     * //-
+     * // For reference, the above command is the same as running the following.
+     * //-
+     * myFile.acl.add({
+     *   entity: 'user-email@example.com',
+     *   role: gcs.acl.READER_ROLE
+     * }, function(err, aclObject) {});
+     *
+     * //-
+     * // If the callback is omitted, we'll return a Promise.
+     * //-
+     * myFile.acl.readers.addUser('email@example.com').then(function(data) {
+     *   const aclObject = data[0];
+     *   const apiResponse = data[1];
+     * });
+     */
+    this.readers = {};
+
+    /**
+     * An object of convenience methods to add or delete writer ACL permissions
+     * for a given entity.
+     *
+     * The supported methods include:
+     *
+     *   - `myFile.acl.writers.addAllAuthenticatedUsers`
+     *   - `myFile.acl.writers.deleteAllAuthenticatedUsers`
+     *   - `myFile.acl.writers.addAllUsers`
+     *   - `myFile.acl.writers.deleteAllUsers`
+     *   - `myFile.acl.writers.addDomain`
+     *   - `myFile.acl.writers.deleteDomain`
+     *   - `myFile.acl.writers.addGroup`
+     *   - `myFile.acl.writers.deleteGroup`
+     *   - `myFile.acl.writers.addProject`
+     *   - `myFile.acl.writers.deleteProject`
+     *   - `myFile.acl.writers.addUser`
+     *   - `myFile.acl.writers.deleteUser`
+     *
+     * @name Acl#writers
+     *
+     * @example
+     * const storage = require('@google-cloud/storage')();
+     * const myBucket = storage.bucket('my-bucket');
+     * const myFile = myBucket.file('my-file');
+     *
+     * //-
+     * // Add a user as a writer of a file.
+     * //-
+     * myFile.acl.writers.addUser('email@example.com', function(err, aclObject)
+     * {});
+     *
+     * //-
+     * // For reference, the above command is the same as running the following.
+     * //-
+     * myFile.acl.add({
+     *   entity: 'user-email@example.com',
+     *   role: gcs.acl.WRITER_ROLE
+     * }, function(err, aclObject) {});
+     *
+     * //-
+     * // If the callback is omitted, we'll return a Promise.
+     * //-
+     * myFile.acl.writers.addUser('email@example.com').then(function(data) {
+     *   const aclObject = data[0];
+     *   const apiResponse = data[1];
+     * });
+     */
+    this.writers = {};
     AclRoleAccessorMethods.roles.forEach(this._assignAccessMethods.bind(this));
   }
 

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -53,21 +53,11 @@ interface BucketOptions {
   userProject?: string;
 }
 
-/**
- * @callback GetFilesCallback
- * @param {?Error} err Request error, if any.
- * @param {File[]} files Array of {@link File} instances.
- */
 export interface GetFilesCallback {
   (err: Error|null, files?: File[], nextQuery?: {},
    apiResponse?: request.Response): void;
 }
 
-/**
- * See a [Objects:
- * watchAll request
- * body](https://cloud.google.com/storage/docs/json_api/v1/objects/watchAll).
- */
 interface WatchAllOptions {
   delimiter?: string;
   maxResults?: number;
@@ -78,11 +68,6 @@ interface WatchAllOptions {
   versions?: boolean;
 }
 
-/**
- * @typedef {object} AddLifecycleRuleOptions Configuration options for Bucket#addLifecycleRule().
- * @property {string} [append=true] The new rules will be appended to any
- *     pre-existing rules.
- */
 export interface AddLifecycleRuleOptions {
   append?: boolean;
 }
@@ -93,31 +78,6 @@ export type LifecycleRule = {
   storageClass?: string;
 };
 
-/**
- * Query object for listing files.
- *
- * @typedef {object} GetFilesOptions
- * @property {boolean} [autoPaginate=true] Have pagination handled
- *     automatically.
- * @property {string} [delimiter] Results will contain only objects whose
- *     names, aside from the prefix, do not contain delimiter. Objects whose
- *     names, aside from the prefix, contain delimiter will have their name
- *     truncated after the delimiter, returned in `apiResponse.prefixes`.
- *     Duplicate prefixes are omitted.
- * @property {string} [directory] Filter results based on a directory name, or
- *     more technically, a "prefix".
- * @property {string} [prefix] Filter results to objects whose names begin
- *     with this prefix.
- * @property {number} [maxApiCalls] Maximum number of API calls to make.
- * @property {number} [maxResults] Maximum number of items plus prefixes to
- *     return.
- * @property {string} [pageToken] A previously-returned page token
- *     representing part of the larger set of results to view.
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- * @property {boolean} [versions] If true, returns File objects scoped to
- *     their versions.
- */
 export interface GetFilesOptions {
   autoPaginate?: boolean;
   delimiter?: string;
@@ -130,98 +90,31 @@ export interface GetFilesOptions {
   versions?: boolean;
 }
 
-/**
- * @typedef {object} CombineOptions
- * @property {string} [kmsKeyName] Resource name of the Cloud KMS key, of
- *     the form
- *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`,
- *     that will be used to encrypt the object. Overwrites the object
- * metadata's `kms_key_name` value, if any.
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface CombineOptions {
   kmsKeyName?: string;
   userProject?: string;
 }
 
-/**
- * @callback CombineCallback
- * @param {?Error} err Request error, if any.
- * @param {File} newFile The new {@link File}.
- * @param {object} apiResponse The full API response.
- */
 export interface CombineCallback {
   (err: Error|null, newFile: File|null, apiResponse: request.Response): void;
 }
 
-/**
- * @typedef {array} CombineResponse
- * @property {File} 0 The new {@link File}.
- * @property {object} 1 The full API response.
- */
 export type CombineResponse = [File, request.Response];
 
-/**
- * See a [Objects:
- * watchAll request
- * body](https://cloud.google.com/storage/docs/json_api/v1/objects/watchAll).
- *
- * @typedef {object} CreateChannelConfig
- * @property {string} address The address where notifications are
- *     delivered for this channel.
- */
 export interface CreateChannelConfig extends WatchAllOptions {
   address: string;
 }
 
-/**
- * @typedef {object} CreateChannelOptions
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface CreateChannelOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} CreateChannelResponse
- * @property {Channel} 0 The new {@link Channel}.
- * @property {object} 1 The full API response.
- */
 export type CreateChannelResponse = [Channel, request.Response];
 
-/**
- * @callback CreateChannelCallback
- * @param {?Error} err Request error, if any.
- * @param {Channel} channel The new {@link Channel}.
- * @param {object} apiResponse The full API response.
- */
 export interface CreateChannelCallback {
   (err: Error|null, channel: Channel|null, apiResponse: request.Response): void;
 }
 
-/**
- * Metadata to set for the Notification.
- *
- * @typedef {object} CreateNotificationOptions
- * @property {object} [customAttributes] An optional list of additional
- *     attributes to attach to each Cloud PubSub message published for this
- *     notification subscription.
- * @property {string[]} [eventTypes] If present, only send notifications about
- *     listed event types. If empty, sent notifications for all event types.
- * @property {string} [objectNamePrefix] If present, only apply this
- *     notification configuration to object names that begin with this prefix.
- * @property {string} [payloadFormat] The desired content of the Payload.
- *     Defaults to `JSON_API_V1`.
- *
- *     Acceptable values are:
- *     - `JSON_API_V1`
- *
- *     - `NONE`
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface CreateNotificationOptions {
   customAttributes?: {[key: string]: string};
   eventTypes?: string[];
@@ -230,250 +123,98 @@ export interface CreateNotificationOptions {
   userProject?: string;
 }
 
-/**
- * @callback CreateNotificationCallback
- * @param {?Error} err Request error, if any.
- * @param {Notification} notification The new {@link Notification}.
- * @param {object} apiResponse The full API response.
- */
 export interface CreateNotificationCallback {
   (err: Error|null, notification: Notification|null,
    apiResponse: request.Response): void;
 }
 
-/**
- * @typedef {array} CreateNotificationResponse
- * @property {Notification} 0 The new {@link Notification}.
- * @property {object} 1 The full API response.
- */
 export type CreateNotificationResponse = [Notification, request.Response];
 
-/**
- * @typedef {object} DeleteBucketOptions Configuration options.
- * @param {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface DeleteBucketOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} DeleteBucketResponse
- * @property {object} 0 The full API response.
- */
 export type DeleteBucketResponse = [request.Response];
 
-/**
- * @callback DeleteBucketCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface DeleteBucketCallback extends DeleteCallback {
   (err: Error|null, apiResponse: request.Response): void;
 }
 
-/**
- * @typedef {object} DeleteFilesOptions Query object. See {@link Bucket#getFiles}
- *     for all of the supported properties.
- * @property {boolean} [force] Suppress errors until all files have been
- *     processed.
- */
 export interface DeleteFilesOptions extends GetFilesOptions {
   force?: boolean;
 }
 
-/**
- * @callback DeleteFilesCallback
- * @param {?Error|?Error[]} err Request error, if any, or array of errors from
- *     files that were not able to be deleted.
- * @param {object} [apiResponse] The full API response.
- */
 export interface DeleteFilesCallback {
   (err: Error|Error[]|null, apiResponse?: object): void;
 }
 
-/**
- * @typedef {array} DeleteLabelsResponse
- * @property {object} 0 The full API response.
- */
 export type DeleteLabelsResponse = [request.Response];
 
-/**
- * @callback DeleteLabelsCallback
- * @param {?Error} err Request error, if any.
- * @param {object} metadata Bucket's metadata.
- */
 export interface DeleteLabelsCallback extends SetLabelsCallback {}
 
-/**
- * @typedef {array} DisableRequesterPaysResponse
- * @property {object} 0 The full API response.
- */
 export type DisableRequesterPaysResponse = [request.Response];
 
-/**
- * @callback DisableRequesterPaysCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface DisableRequesterPaysCallback {
   (err?: Error|null, apiResponse?: object): void;
 }
 
-/**
- * @typedef {array} EnableRequesterPaysResponse
- * @property {object} 0 The full API response.
- */
 export type EnableRequesterPaysResponse = [request.Response];
 
-/**
- * @callback EnableRequesterPaysCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface EnableRequesterPaysCallback {
   (err?: Error|null, apiResponse?: request.Response): void;
 }
 
-/**
- * @typedef {object} BucketExistsOptions Configuration options for Bucket#exists().
- * @param {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface BucketExistsOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} BucketExistsResponse
- * @property {boolean} 0 Whether the {@link Bucket} exists.
- */
 export type BucketExistsResponse = [boolean];
 
-/**
- * @callback BucketExistsCallback
- * @param {?Error} err Request error, if any.
- * @param {boolean} exists Whether the {@link Bucket} exists.
- */
 export interface BucketExistsCallback extends ExistsCallback {}
 
-/**
- * @typedef {object} [GetBucketOptions] Configuration options for Bucket#get()
- * @property {boolean} [autoCreate] Automatically create the object if
- *     it does not exist. Default: `false`
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface GetBucketOptions extends GetConfig {
   userProject?: string;
 }
 
-/**
- * @typedef {array} GetBucketResponse
- * @property {Bucket} 0 The {@link Bucket}.
- * @property {object} 1 The full API response.
- */
 export type GetBucketResponse = [Bucket, request.Response];
 
-/**
- * @callback GetBucketCallback
- * @param {?Error} err Request error, if any.
- * @param {Bucket} bucket The {@link Bucket}.
- * @param {object} apiResponse The full API response.
- */
 export interface GetBucketCallback {
   (err: ApiError|null, bucket: Bucket|null,
    apiResponse: request.Response): void;
 }
 
-/**
- * @typedef {object} GetLabelsOptions Configuration options for Bucket#getLabels().
- * @param {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface GetLabelsOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} GetLabelsResponse
- * @property {object} 0 Object of labels currently set on this bucket.
- */
 export type GetLabelsResponse = [request.Response];
 
-/**
- * @callback GetLabelsCallback
- * @param {?Error} err Request error, if any.
- * @param {object} labels Object of labels currently set on this bucket.
- */
 export interface GetLabelsCallback {
   (err: Error|null, labels: object|null): void;
 }
 
-/**
- * @typedef {array} GetBucketMetadataResponse
- * @property {object} 0 The bucket metadata.
- * @property {object} 1 The full API response.
- */
 export type GetBucketMetadataResponse = [Metadata, request.Response];
 
-/**
- * @callback GetBucketMetadataCallback
- * @param {?Error} err Request error, if any.
- * @param {object} metadata The bucket metadata.
- * @param {object} apiResponse The full API response.
- */
 export interface GetBucketMetadataCallback {
   (err: ApiError|null, metadata: Metadata|null,
    apiResponse: request.Response): void;
 }
 
-/**
- * @typedef {object} GetBucketMetadataOptions Configuration options for Bucket#getMetadata().
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface GetBucketMetadataOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {object} GetNotificationOptions Configuration options for Bucket#getNotification().
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface GetNotificationsOptions {
   userProject?: string;
 }
 
-/**
- * @callback GetNotificationsCallback
- * @param {?Error} err Request error, if any.
- * @param {Notification[]} notifications Array of {@link Notification}
- *     instances.
- * @param {object} apiResponse The full API response.
- */
 export interface GetNotificationsCallback {
   (err: Error|null, notifications: Notification[]|null,
    apiResponse: request.Response): void;
 }
 
-/**
- * @typedef {array} GetNotificationsResponse
- * @property {Notification[]} 0 Array of {@link Notification} instances.
- * @property {object} 1 The full API response.
- */
 export type GetNotificationsResponse = [Notification[], request.Response];
 
-/**
- * @typedef {object} MakeBucketPrivateOptions
- * @param {boolean} [includeFiles=false] Make each file in the bucket
- *     private.
- * @param {boolean} [force] Queue errors occurred while making files
- *     private until all files have been processed.
- * @param {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface MakeBucketPrivateOptions {
   includeFiles?: boolean;
   force?: boolean;
@@ -484,206 +225,67 @@ interface MakeBucketPrivateRequest extends MakeBucketPrivateOptions {
   private?: boolean;
 }
 
-/**
- * @typedef {array} MakeBucketPrivateResponse
- * @property {File[]} 0 List of files made private.
- */
 export type MakeBucketPrivateResponse = [File[]];
 
-/**
- * @callback MakeBucketPrivateCallback
- * @param {?Error} err Request error, if any.
- * @param {File[]} files List of files made private.
- */
 export interface MakeBucketPrivateCallback {
   (err?: Error|null, files?: File[]): void;
 }
 
-/**
- * @typedef {object} MakeBucketPublicOptions
- * @param {boolean} [includeFiles=false] Make each file in the bucket
- *     private.
- * @param {boolean} [force] Queue errors occurred while making files
- *     private until all files have been processed.
- */
 export interface MakeBucketPublicOptions {
   includeFiles?: boolean;
   force?: boolean;
 }
 
-/**
- * @callback MakeBucketPublicCallback
- * @param {?Error} err Request error, if any.
- * @param {File[]} files List of files made public.
- */
 export interface MakeBucketPublicCallback {
   (err?: Error|null, files?: File[]): void;
 }
 
-/**
- * @typedef {array} MakeBucketPublicResponse
- * @property {File[]} 0 List of files made public.
- */
 export type MakeBucketPublicResponse = [File[]];
 
-/**
- * @typedef {object} SetBucketMetadataOptions Configuration options for Bucket#setMetadata().
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface SetBucketMetadataOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} SetBucketMetadataResponse
- * @property {object} apiResponse The full API response.
- */
 export type SetBucketMetadataResponse = [request.Response];
 
-/**
- * @callback SetBucketMetadataCallback
- * @param {?Error} err Request error, if any.
- * @param {object} metadata The bucket metadata.
- */
 export interface SetBucketMetadataCallback {
   (err?: Error|null, metadata?: Metadata): void;
 }
 
-/**
- * @callback BucketLockCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface BucketLockCallback {
   (err?: Error|null, apiResponse?: request.Response): void;
 }
 
-/**
- * @typedef {array} SetBucketMetadataResponse
- * @property {object} apiResponse The full API response.
- */
 export type BucketLockResponse = [request.Response];
 
 export type Labels = {
   [key: string]: string;
 };
 
-/**
- * @typedef {object} SetLabelsOptions Configuration options for Bucket#setLabels().
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface SetLabelsOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} SetLabelsResponse
- * @property {object} 0 The bucket metadata.
- */
 export type SetLabelsResponse = [request.Response];
 
-/**
- * @callback SetLabelsCallback
- * @param {?Error} err Request error, if any.
- * @param {object} metadata The bucket metadata.
- */
 export interface SetLabelsCallback {
   (err?: Error|null, metadata?: Metadata): void;
 }
 
-/**
- * @typedef {object} SetBucketStorageClassOptions
- * @param {string} [userProject] - The ID of the project which will be
- *     billed for the request.
- */
 export interface SetBucketStorageClassOptions {
   userProject?: string;
 }
 
-/**
- * @callback SetBucketStorageClassCallback
- * @param {?Error} err Request error, if any.
- */
 export interface SetBucketStorageClassCallback {
   (err?: Error|null): void;
 }
 
-/**
- * @typedef {array} UploadResponse
- * @property {object} 0 The uploaded {@link File}.
- * @property {object} 1 The full API response.
- */
 export type UploadResponse = [File, request.Response];
 
-/**
- * @callback UploadCallback
- * @param {?Error} err Request error, if any.
- * @param {object} file The uploaded {@link File}.
- * @param {object} apiResponse The full API response.
- */
 export interface UploadCallback {
   (err: Error|null, file?: File|null, apiResponse?: request.Response): void;
 }
 
-/**
- * @typedef {object} UploadOptions Configuration options for Bucket#upload().
- * @param {string|File} [options.destination] The place to save
- *     your file. If given a string, the file will be uploaded to the bucket
- *     using the string as a filename. When given a File object, your local
- * file will be uploaded to the File object's bucket and under the File
- * object's name. Lastly, when this argument is omitted, the file is uploaded
- * to your bucket using the name of the local file.
- * @param {string} [options.encryptionKey] A custom encryption key. See
- *     [Customer-supplied Encryption
- * Keys](https://cloud.google.com/storage/docs/encryption#customer-supplied).
- * @param {boolean} [options.gzip] Automatically gzip the file. This will set
- *     `options.metadata.contentEncoding` to `gzip`.
- * @param {string} [options.kmsKeyName] The name of the Cloud KMS key that will
- *     be used to encrypt the object. Must be in the format:
- *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`.
- * @param {object} [options.metadata] See an
- *     [Objects: insert request
- * body](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON).
- * @param {string} [options.offset] The starting byte of the upload stream, for
- *     resuming an interrupted upload. Defaults to 0.
- * @param {string} [options.predefinedAcl] Apply a predefined set of access
- *     controls to this object.
- *
- *     Acceptable values are:
- *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
- *       `allAuthenticatedUsers` get `READER` access.
- *
- *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
- *       project team owners get `OWNER` access.
- *
- *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
- *       team owners get `READER` access.
- *
- *     - **`private`** - Object owner gets `OWNER` access.
- *
- *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
- *       team members get access according to their roles.
- *
- *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
- * get `READER` access.
- * @param {boolean} [options.private] Make the uploaded file private. (Alias for
- *     `options.predefinedAcl = 'private'`)
- * @param {boolean} [options.public] Make the uploaded file public. (Alias for
- *     `options.predefinedAcl = 'publicRead'`)
- * @param {boolean} [options.resumable] Force a resumable upload. (default:
- *     true for files larger than 5 MB).
- * @param {string} [options.uri] The URI for an already-created resumable
- *     upload. See {@link File#createResumableUpload}.
- * @param {string} [options.userProject] The ID of the project which will be
- *     billed for the request.
- * @param {string|boolean} [options.validation] Possible values: `"md5"`,
- *     `"crc32c"`, or `false`. By default, data integrity is validated with an
- *     MD5 checksum for maximum reliability. CRC32c will provide better
- *     performance with less reliability. You may also choose to skip
- * validation completely, however this is **not recommended**.
- */
 export interface UploadOptions extends CreateResumableUploadOptions,
                                        CreateWriteStreamOptions {
   destination?: string|File;
@@ -692,18 +294,6 @@ export interface UploadOptions extends CreateResumableUploadOptions,
   resumable?: boolean;
 }
 
-
-/**
- * @private
- *
- * @typedef {object} MakeAllFilesPublicPrivateOptions
- * @property {boolean} [force] Suppress errors until all files have been
- *     processed.
- * @property {boolean} [private] Make files private.
- * @property {boolean} [public] Make files public.
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface MakeAllFilesPublicPrivateOptions {
   force?: boolean;
   private?: boolean;
@@ -711,21 +301,10 @@ export interface MakeAllFilesPublicPrivateOptions {
   userProject?: string;
 }
 
-/**
- * @private
- *
- * @callback SetBucketMetadataCallback
- * @param {?Error} err Request error, if any.
- * @param {File[]} files Files that were updated.
- */
 interface MakeAllFilesPublicPrivateCallback {
   (err?: Error|Error[]|null, files?: File[]): void;
 }
 
-/**
- * @typedef {array} MakeAllFilesPublicPrivateResponse
- * @property {File[]} 0 List of files affected.
- */
 type MakeAllFilesPublicPrivateResponse = [File[]];
 
 /**
@@ -1011,6 +590,11 @@ class Bucket extends ServiceObject {
   addLifecycleRule(rule: LifecycleRule, callback: SetBucketMetadataCallback):
       void;
   /**
+   * @typedef {object} AddLifecycleRuleOptions Configuration options for Bucket#addLifecycleRule().
+   * @property {string} [append=true] The new rules will be appended to any
+   *     pre-existing rules.
+   */
+  /**
    * Add an object lifecycle management rule to the bucket.
    *
    * By default, an Object Lifecycle Management rule provided to this method
@@ -1195,6 +779,27 @@ class Bucket extends ServiceObject {
       sources: string[]|File[], destination: string|File,
       callback: CombineCallback): void;
   /**
+   * @typedef {object} CombineOptions
+   * @property {string} [kmsKeyName] Resource name of the Cloud KMS key, of
+   *     the form
+   *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`,
+   *     that will be used to encrypt the object. Overwrites the object
+   * metadata's `kms_key_name` value, if any.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @callback CombineCallback
+   * @param {?Error} err Request error, if any.
+   * @param {File} newFile The new {@link File}.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {array} CombineResponse
+   * @property {File} 0 The new {@link File}.
+   * @property {object} 1 The full API response.
+   */
+  /**
    * Combine multiple files into one new file.
    *
    * @see [Objects: compose API Documentation]{@link https://cloud.google.com/storage/docs/json_api/v1/objects/compose}
@@ -1315,6 +920,32 @@ class Bucket extends ServiceObject {
       id: string, config: CreateChannelConfig, options: CreateChannelOptions,
       callback: CreateChannelCallback): void;
   /**
+   * See a [Objects:
+   * watchAll request
+   * body](https://cloud.google.com/storage/docs/json_api/v1/objects/watchAll).
+   *
+   * @typedef {object} CreateChannelConfig
+   * @property {string} address The address where notifications are
+   *     delivered for this channel.
+   * @extends WatchAllOptions
+   */
+  /**
+   * @typedef {object} CreateChannelOptions
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @typedef {array} CreateChannelResponse
+   * @property {Channel} 0 The new {@link Channel}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback CreateChannelCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Channel} channel The new {@link Channel}.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Create a channel that will be notified when objects in this bucket changes.
    *
    * @throws {Error} If an ID is not provided.
@@ -1404,6 +1035,38 @@ class Bucket extends ServiceObject {
       topic: string, options: CreateNotificationOptions,
       callback: CreateNotificationCallback): void;
   createNotification(topic: string, callback: CreateNotificationCallback): void;
+  /**
+   * Metadata to set for the Notification.
+   *
+   * @typedef {object} CreateNotificationOptions
+   * @property {object} [customAttributes] An optional list of additional
+   *     attributes to attach to each Cloud PubSub message published for this
+   *     notification subscription.
+   * @property {string[]} [eventTypes] If present, only send notifications about
+   *     listed event types. If empty, sent notifications for all event types.
+   * @property {string} [objectNamePrefix] If present, only apply this
+   *     notification configuration to object names that begin with this prefix.
+   * @property {string} [payloadFormat] The desired content of the Payload.
+   *     Defaults to `JSON_API_V1`.
+   *
+   *     Acceptable values are:
+   *     - `JSON_API_V1`
+   *
+   *     - `NONE`
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @callback CreateNotificationCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Notification} notification The new {@link Notification}.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {array} CreateNotificationResponse
+   * @property {Notification} 0 The new {@link Notification}.
+   * @property {object} 1 The full API response.
+   */
   /**
    * Creates a notification subscription for the bucket.
    *
@@ -1524,6 +1187,20 @@ class Bucket extends ServiceObject {
   delete(callback: DeleteBucketCallback): void;
   delete(options: DeleteBucketOptions, callback: DeleteBucketCallback): void;
   /**
+   * @typedef {object} DeleteBucketOptions Configuration options.
+   * @param {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @typedef {array} DeleteBucketResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback DeleteBucketCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Delete the bucket.
    *
    * @see [Buckets: delete API Documentation]{@link https://cloud.google.com/storage/docs/json_api/v1/buckets/delete}
@@ -1572,6 +1249,18 @@ class Bucket extends ServiceObject {
   deleteFiles(callback: DeleteFilesCallback): void;
   deleteFiles(query: DeleteFilesOptions, callback: DeleteFilesCallback): void;
   /**
+   * @typedef {object} DeleteFilesOptions Query object. See {@link Bucket#getFiles}
+   *     for all of the supported properties.
+   * @property {boolean} [force] Suppress errors until all files have been
+   *     processed.
+   */
+  /**
+   * @callback DeleteFilesCallback
+   * @param {?Error|?Error[]} err Request error, if any, or array of errors from
+   *     files that were not able to be deleted.
+   * @param {object} [apiResponse] The full API response.
+   */
+  /**
    * Iterate over the bucket's files, calling `file.delete()` on each.
    *
    * <strong>This is not an atomic request.</strong> A delete attempt will be
@@ -1605,7 +1294,7 @@ class Bucket extends ServiceObject {
    * //-
    * // By default, if a file cannot be deleted, this method will stop deleting
    * // files from your bucket. You can override this setting with `force:
-   * true`.
+   * // true`.
    * //-
    * bucket.deleteFiles({
    *   force: true
@@ -1682,6 +1371,15 @@ class Bucket extends ServiceObject {
   deleteLabels(callback: DeleteLabelsCallback): void;
   deleteLabels(labels: string|string[], callback: DeleteLabelsCallback): void;
   /**
+   * @typedef {array} DeleteLabelsResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback DeleteLabelsCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} metadata Bucket's metadata.
+   */
+  /**
    * Delete one or more labels from this bucket.
    *
    * @param {string|string[]} labels The labels to delete. If no labels are
@@ -1754,6 +1452,15 @@ class Bucket extends ServiceObject {
   disableRequesterPays(): Promise<DisableRequesterPaysResponse>;
   disableRequesterPays(callback: DisableRequesterPaysCallback): void;
   /**
+   * @typedef {array} DisableRequesterPaysResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback DisableRequesterPaysCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * <div class="notice">
    *   <strong>Early Access Testers Only</strong>
    *   <p>
@@ -1801,6 +1508,15 @@ class Bucket extends ServiceObject {
 
   enableRequesterPays(): Promise<EnableRequesterPaysResponse>;
   enableRequesterPays(callback: EnableRequesterPaysCallback): void;
+  /**
+   * @typedef {array} EnableRequesterPaysResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback EnableRequesterPaysCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
   /**
    * <div class="notice">
    *   <strong>Early Access Testers Only</strong>
@@ -1852,6 +1568,20 @@ class Bucket extends ServiceObject {
   exists(options?: BucketExistsOptions): Promise<BucketExistsResponse>;
   exists(callback: BucketExistsCallback): void;
   exists(options: BucketExistsOptions, callback: BucketExistsCallback): void;
+  /**
+   * @typedef {object} BucketExistsOptions Configuration options for Bucket#exists().
+   * @param {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @typedef {array} BucketExistsResponse
+   * @property {boolean} 0 Whether the {@link Bucket} exists.
+   */
+  /**
+   * @callback BucketExistsCallback
+   * @param {?Error} err Request error, if any.
+   * @param {boolean} exists Whether the {@link Bucket} exists.
+   */
   /**
    * Check if the bucket exists.
    *
@@ -1934,6 +1664,24 @@ class Bucket extends ServiceObject {
   get(options?: GetBucketOptions): Promise<GetBucketResponse>;
   get(callback: GetBucketCallback): void;
   get(options: GetBucketOptions, callback: GetBucketCallback): void;
+  /**
+   * @typedef {object} [GetBucketOptions] Configuration options for Bucket#get()
+   * @property {boolean} [autoCreate] Automatically create the object if
+   *     it does not exist. Default: `false`
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @typedef {array} GetBucketResponse
+   * @property {Bucket} 0 The {@link Bucket}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback GetBucketCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Bucket} bucket The {@link Bucket}.
+   * @param {object} apiResponse The full API response.
+   */
   /**
    * Get a bucket if it exists.
    *
@@ -2019,6 +1767,36 @@ class Bucket extends ServiceObject {
   /**
    * @typedef {array} GetFilesResponse
    * @property {File[]} 0 Array of {@link File} instances.
+   */
+  /**
+   * @callback GetFilesCallback
+   * @param {?Error} err Request error, if any.
+   * @param {File[]} files Array of {@link File} instances.
+   */
+  /**
+   * Query object for listing files.
+   *
+   * @typedef {object} GetFilesOptions
+   * @property {boolean} [autoPaginate=true] Have pagination handled
+   *     automatically.
+   * @property {string} [delimiter] Results will contain only objects whose
+   *     names, aside from the prefix, do not contain delimiter. Objects whose
+   *     names, aside from the prefix, contain delimiter will have their name
+   *     truncated after the delimiter, returned in `apiResponse.prefixes`.
+   *     Duplicate prefixes are omitted.
+   * @property {string} [directory] Filter results based on a directory name, or
+   *     more technically, a "prefix".
+   * @property {string} [prefix] Filter results to objects whose names begin
+   *     with this prefix.
+   * @property {number} [maxApiCalls] Maximum number of API calls to make.
+   * @property {number} [maxResults] Maximum number of items plus prefixes to
+   *     return.
+   * @property {string} [pageToken] A previously-returned page token
+   *     representing part of the larger set of results to view.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   * @property {boolean} [versions] If true, returns File objects scoped to
+   *     their versions.
    */
   /**
    * Get {@link File} objects for the files currently in the bucket.
@@ -2146,6 +1924,20 @@ class Bucket extends ServiceObject {
   getLabels(callback: GetLabelsCallback): void;
   getLabels(options: GetLabelsOptions, callback: GetLabelsCallback): void;
   /**
+   * @typedef {object} GetLabelsOptions Configuration options for Bucket#getLabels().
+   * @param {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @typedef {array} GetLabelsResponse
+   * @property {object} 0 Object of labels currently set on this bucket.
+   */
+  /**
+   * @callback GetLabelsCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} labels Object of labels currently set on this bucket.
+   */
+  /**
    * Get the labels currently set on this bucket.
    *
    * @param {object} [options] Configuration options.
@@ -2203,6 +1995,22 @@ class Bucket extends ServiceObject {
   getMetadata(
       options: GetBucketMetadataOptions,
       callback: GetBucketMetadataCallback): void;
+  /**
+   * @typedef {array} GetBucketMetadataResponse
+   * @property {object} 0 The bucket metadata.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback GetBucketMetadataCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} metadata The bucket metadata.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {object} GetBucketMetadataOptions Configuration options for Bucket#getMetadata().
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
   /**
    * Get the bucket's metadata.
    *
@@ -2267,6 +2075,23 @@ class Bucket extends ServiceObject {
   getNotifications(
       options: GetNotificationsOptions,
       callback: GetNotificationsCallback): void;
+  /**
+   * @typedef {object} GetNotificationOptions Configuration options for Bucket#getNotification().
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @callback GetNotificationsCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Notification[]} notifications Array of {@link Notification}
+   *     instances.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {array} GetNotificationsResponse
+   * @property {Notification[]} 0 Array of {@link Notification} instances.
+   * @property {object} 1 The full API response.
+   */
   /**
    * Retrieves a list of notification subscriptions for a given bucket.
    *
@@ -2334,6 +2159,11 @@ class Bucket extends ServiceObject {
   lock(metageneration: number|string): Promise<BucketLockResponse>;
   lock(metageneration: number|string, callback: BucketLockCallback): void;
   /**
+   * @callback BucketLockCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Lock a previously-defined retention policy. This will prevent changes to
    * the policy.
    *
@@ -2383,6 +2213,24 @@ class Bucket extends ServiceObject {
   makePrivate(
       options: MakeBucketPrivateOptions,
       callback: MakeBucketPrivateCallback): void;
+  /**
+   * @typedef {array} MakeBucketPrivateResponse
+   * @property {File[]} 0 List of files made private.
+   */
+  /**
+   * @callback MakeBucketPrivateCallback
+   * @param {?Error} err Request error, if any.
+   * @param {File[]} files List of files made private.
+   */
+  /**
+   * @typedef {object} MakeBucketPrivateOptions
+   * @param {boolean} [includeFiles=false] Make each file in the bucket
+   *     private.
+   * @param {boolean} [force] Queue errors occurred while making files
+   *     private until all files have been processed.
+   * @param {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
   /**
    * Make the bucket listing private.
    *
@@ -2501,6 +2349,22 @@ class Bucket extends ServiceObject {
   makePublic(
       options: MakeBucketPublicOptions,
       callback: MakeBucketPublicCallback): void;
+  /**
+   * @typedef {object} MakeBucketPublicOptions
+   * @param {boolean} [includeFiles=false] Make each file in the bucket
+   *     private.
+   * @param {boolean} [force] Queue errors occurred while making files
+   *     private until all files have been processed.
+   */
+  /**
+   * @callback MakeBucketPublicCallback
+   * @param {?Error} err Request error, if any.
+   * @param {File[]} files List of files made public.
+   */
+  /**
+   * @typedef {array} MakeBucketPublicResponse
+   * @property {File[]} 0 List of files made public.
+   */
   /**
    * Make the bucket publicly readable.
    *
@@ -2696,6 +2560,20 @@ class Bucket extends ServiceObject {
       labels: Labels, options: SetLabelsOptions,
       callback: SetLabelsCallback): void;
   /**
+   * @typedef {array} SetLabelsResponse
+   * @property {object} 0 The bucket metadata.
+   */
+  /**
+   * @callback SetLabelsCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} metadata The bucket metadata.
+   */
+  /**
+   * @typedef {object} SetLabelsOptions Configuration options for Bucket#setLabels().
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
    * Set labels on the bucket.
    *
    * This makes an underlying call to {@link Bucket#setMetadata}, which
@@ -2749,6 +2627,20 @@ class Bucket extends ServiceObject {
       metadata: Metadata, options: SetBucketMetadataOptions,
       callback: SetBucketMetadataCallback): void;
   setMetadata(metadata: Metadata, callback: SetBucketMetadataCallback): void;
+  /**
+   * @typedef {object} SetBucketMetadataOptions Configuration options for Bucket#setMetadata().
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @typedef {array} SetBucketMetadataResponse
+   * @property {object} apiResponse The full API response.
+   */
+  /**
+   * @callback SetBucketMetadataCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} metadata The bucket metadata.
+   */
   /**
    * Set the bucket's metadata.
    *
@@ -2903,6 +2795,15 @@ class Bucket extends ServiceObject {
       storageClass: string, options: SetBucketStorageClassOptions,
       callback: SetBucketStorageClassCallback): void;
   /**
+   * @typedef {object} SetBucketStorageClassOptions
+   * @param {string} [userProject] - The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @callback SetBucketStorageClassCallback
+   * @param {?Error} err Request error, if any.
+   */
+  /**
    * Set the default storage class for new files in this bucket.
    *
    * @see [Storage Classes]{@link https://cloud.google.com/storage/docs/storage-classes}
@@ -2978,6 +2879,74 @@ class Bucket extends ServiceObject {
   upload(pathString: string, options: UploadOptions, callback: UploadCallback):
       void;
   upload(pathString: string, callback: UploadCallback): void;
+  /**
+   * @typedef {object} UploadOptions Configuration options for Bucket#upload().
+   * @param {string|File} [options.destination] The place to save
+   *     your file. If given a string, the file will be uploaded to the bucket
+   *     using the string as a filename. When given a File object, your local
+   * file will be uploaded to the File object's bucket and under the File
+   * object's name. Lastly, when this argument is omitted, the file is uploaded
+   * to your bucket using the name of the local file.
+   * @param {string} [options.encryptionKey] A custom encryption key. See
+   *     [Customer-supplied Encryption
+   * Keys](https://cloud.google.com/storage/docs/encryption#customer-supplied).
+   * @param {boolean} [options.gzip] Automatically gzip the file. This will set
+   *     `options.metadata.contentEncoding` to `gzip`.
+   * @param {string} [options.kmsKeyName] The name of the Cloud KMS key that will
+   *     be used to encrypt the object. Must be in the format:
+   *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`.
+   * @param {object} [options.metadata] See an
+   *     [Objects: insert request
+   * body](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON).
+   * @param {string} [options.offset] The starting byte of the upload stream, for
+   *     resuming an interrupted upload. Defaults to 0.
+   * @param {string} [options.predefinedAcl] Apply a predefined set of access
+   *     controls to this object.
+   *
+   *     Acceptable values are:
+   *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
+   *       `allAuthenticatedUsers` get `READER` access.
+   *
+   *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
+   *       project team owners get `OWNER` access.
+   *
+   *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
+   *       team owners get `READER` access.
+   *
+   *     - **`private`** - Object owner gets `OWNER` access.
+   *
+   *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
+   *       team members get access according to their roles.
+   *
+   *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
+   * get `READER` access.
+   * @param {boolean} [options.private] Make the uploaded file private. (Alias for
+   *     `options.predefinedAcl = 'private'`)
+   * @param {boolean} [options.public] Make the uploaded file public. (Alias for
+   *     `options.predefinedAcl = 'publicRead'`)
+   * @param {boolean} [options.resumable] Force a resumable upload. (default:
+   *     true for files larger than 5 MB).
+   * @param {string} [options.uri] The URI for an already-created resumable
+   *     upload. See {@link File#createResumableUpload}.
+   * @param {string} [options.userProject] The ID of the project which will be
+   *     billed for the request.
+   * @param {string|boolean} [options.validation] Possible values: `"md5"`,
+   *     `"crc32c"`, or `false`. By default, data integrity is validated with an
+   *     MD5 checksum for maximum reliability. CRC32c will provide better
+   *     performance with less reliability. You may also choose to skip
+   * validation completely, however this is **not recommended**.
+   */
+  /**
+   * @typedef {array} UploadResponse
+   * @property {object} 0 The uploaded {@link File}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback UploadCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} file The uploaded {@link File}.
+   * @param {object} apiResponse The full API response.
+   */
   /**
    * Upload a file to the bucket. This is a convenience method that wraps
    * {@link File#createWriteStream}.
@@ -3193,6 +3162,28 @@ class Bucket extends ServiceObject {
   makeAllFilesPublicPrivate_(
       options: MakeAllFilesPublicPrivateOptions,
       callback: MakeAllFilesPublicPrivateCallback): void;
+  /**
+   * @private
+   *
+   * @typedef {object} MakeAllFilesPublicPrivateOptions
+   * @property {boolean} [force] Suppress errors until all files have been
+   *     processed.
+   * @property {boolean} [private] Make files private.
+   * @property {boolean} [public] Make files public.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @private
+   *
+   * @callback SetBucketMetadataCallback
+   * @param {?Error} err Request error, if any.
+   * @param {File[]} files Files that were updated.
+   */
+  /**
+   * @typedef {array} MakeAllFilesPublicPrivateResponse
+   * @property {File[]} 0 List of files affected.
+   */
   /**
    * Iterate over all of a bucket's files, calling `file.makePublic()` (public)
    * or `file.makePrivate()` (private) on each.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -22,11 +22,6 @@ import {teenyRequest} from 'teeny-request';
 
 import {Storage} from './storage';
 
-/**
- * @callback StopCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface StopCallback {
   (err: Error|null, apiResponse?: request.Response): void;
 }
@@ -78,6 +73,11 @@ class Channel extends ServiceObject {
   /**
    * @typedef {array} StopResponse
    * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback StopCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
    */
   /**
    * Stop this channel.

--- a/src/file.ts
+++ b/src/file.ts
@@ -74,17 +74,8 @@ interface GetSignedUrlConfigInternal {
   cname?: string;
 }
 
-/**
- * @typedef {array} GetSignedUrlResponse
- * @property {object} 0 The signed URL.
- */
 export type GetSignedUrlResponse = [string];
 
-/**
- * @callback GetSignedUrlCallback
- * @param {?Error} err Request error, if any.
- * @param {object} url The signed URL.
- */
 export interface GetSignedUrlCallback {
   (err: Error|null, url?: string): void;
 }
@@ -95,17 +86,8 @@ export interface PolicyDocument {
   string: string;
 }
 
-/**
- * @typedef {array} GetSignedPolicyResponse
- * @property {object} 0 The document policy.
- */
 export type GetSignedPolicyResponse = [PolicyDocument];
 
-/**
- * @callback GetSignedPolicyCallback
- * @param {?Error} err Request error, if any.
- * @param {object} policy The document policy.
- */
 export interface GetSignedPolicyCallback {
   (err: Error|null, policy?: PolicyDocument): void;
 }
@@ -124,19 +106,8 @@ export interface GetFileMetadataOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} GetFileMetadataResponse
- * @property {object} 0 The {@link File} metadata.
- * @property {object} 1 The full API response.
- */
 export type GetFileMetadataResponse = [Metadata, r.Response];
 
-/**
- * @callback GetFileMetadataCallback
- * @param {?Error} err Request error, if any.
- * @param {object} metadata The {@link File} metadata.
- * @param {object} apiResponse The full API response.
- */
 export interface GetFileMetadataCallback {
   (err: Error|null, metadata?: Metadata, apiResponse?: r.Response): void;
 }
@@ -145,19 +116,8 @@ export interface GetFileOptions extends GetConfig {
   userProject?: string;
 }
 
-/**
- * @typedef {array} GetFileResponse
- * @property {File} 0 The {@link File}.
- * @property {object} 1 The full API response.
- */
 export type GetFileResponse = [File, r.Response];
 
-/**
- * @callback GetFileCallback
- * @param {?Error} err Request error, if any.
- * @param {File} file The {@link File}.
- * @param {object} apiResponse The full API response.
- */
 export interface GetFileCallback {
   (err: Error|null, file?: File, apiResponse?: r.Response): void;
 }
@@ -166,17 +126,8 @@ export interface FileExistsOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} FileExistsResponse
- * @property {boolean} 0 Whether the {@link File} exists.
- */
 export type FileExistsResponse = [boolean];
 
-/**
- * @callback FileExistsCallback
- * @param {?Error} err Request error, if any.
- * @param {boolean} exists Whether the {@link File} exists.
- */
 export interface FileExistsCallback {
   (err: Error|null, exists?: boolean): void;
 }
@@ -185,17 +136,8 @@ export interface DeleteFileOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} DeleteFileResponse
- * @property {object} 0 The full API response.
- */
 export type DeleteFileResponse = [r.Response];
 
-/**
- * @callback DeleteFileCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface DeleteFileCallback {
   (err: Error|null, apiResponse?: r.Response): void;
 }
@@ -214,75 +156,12 @@ export interface CreateResumableUploadOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} CreateResumableUploadResponse
- * @property {string} 0 The resumable upload's unique session URI.
- */
 export type CreateResumableUploadResponse = [string];
 
-/**
- * @callback CreateResumableUploadCallback
- * @param {?Error} err Request error, if any.
- * @param {string} uri The resumable upload's unique session URI.
- */
 export interface CreateResumableUploadCallback {
   (err: Error|null, uri?: string): void;
 }
 
-/**
- * @typedef {object} CreateWriteStreamOptions Configuration options for File#createWriteStream().
- * @property {string} [contentType] Alias for
- *     `options.metadata.contentType`. If set to `auto`, the file name is used
- *     to determine the contentType.
- * @property {string|boolean} [gzip] If true, automatically gzip the file.
- *     If set to `auto`, the contentType is used to determine if the file
- * should be gzipped. This will set `options.metadata.contentEncoding` to
- * `gzip` if necessary.
- * @property {object} [metadata] See the examples below or
- *     [Objects: insert request
- * body](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON)
- *     for more details.
- * @property {number} [offset] The starting byte of the upload stream, for
- *     resuming an interrupted upload. Defaults to 0.
- * @property {string} [predefinedAcl] Apply a predefined set of access
- *     controls to this object.
- *
- *     Acceptable values are:
- *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
- *       `allAuthenticatedUsers` get `READER` access.
- *
- *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
- *       project team owners get `OWNER` access.
- *
- *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
- *       team owners get `READER` access.
- *
- *     - **`private`** - Object owner gets `OWNER` access.
- *
- *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
- *       team members get access according to their roles.
- *
- *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
- * get `READER` access.
- * @property {boolean} [private] Make the uploaded file private. (Alias for
- *     `options.predefinedAcl = 'private'`)
- * @property {boolean} [public] Make the uploaded file public. (Alias for
- *     `options.predefinedAcl = 'publicRead'`)
- * @property {boolean} [resumable] Force a resumable upload. NOTE: When
- *     working with streams, the file format and size is unknown until it's
- *     completely consumed. Because of this, it's best for you to be explicit
- *     for what makes sense given your input.
- * @property {string} [uri] The URI for an already-created resumable
- *     upload. See {@link File#createResumableUpload}.
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- * @property {string|boolean} [validation] Possible values: `"md5"`,
- *     `"crc32c"`, or `false`. By default, data integrity is validated with a
- *     CRC32c checksum. You may use MD5 if preferred, but that hash is not
- *     supported for composite objects. An error will be raised if MD5 is
- *     specified but is not available. You may also choose to skip validation
- *     completely, however this is **not recommended**.
- */
 export interface CreateWriteStreamOptions extends CreateResumableUploadOptions {
   contentType?: string;
   gzip?: string|boolean;
@@ -290,83 +169,32 @@ export interface CreateWriteStreamOptions extends CreateResumableUploadOptions {
   validation?: string|boolean;
 }
 
-/**
- * @typedef {object} MakeFilePrivateOptions Configuration options for File#makePrivate().
- * @property {boolean} [strict] If true, set the file to be private to
- *     only the owner user. Otherwise, it will be private to the project.
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface MakeFilePrivateOptions {
   strict?: boolean;
   userProject?: string;
 }
 
-/**
- * @typedef {array} MakeFilePrivateResponse
- * @property {object} 0 The full API response.
- */
 export type MakeFilePrivateResponse = [r.Response];
 
-/**
- * @callback MakeFilePrivateCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface MakeFilePrivateCallback extends SetFileMetadataCallback {}
 
-/**
- * @typedef {array} MakeFilePublicResponse
- * @property {object} 0 The full API response.
- */
 export type MakeFilePublicResponse = [r.Response];
 
-/**
- * @callback MakeFilePublicCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface MakeFilePublicCallback {
   (err?: Error|null, apiResponse?: r.Response): void;
 }
 
-/**
- * @typedef {array} MoveResponse
- * @property {File} 0 The destination File.
- * @property {object} 1 The full API response.
- */
 export type MoveResponse = [r.Response];
 
-/**
- * @callback MoveCallback
- * @param {?Error} err Request error, if any.
- * @param {?File} destinationFile The destination File.
- * @param {object} apiResponse The full API response.
- */
 export interface MoveCallback {
   (err: Error|null, destinationFile?: File|null,
    apiResponse?: r.Response): void;
 }
-/**
- * @typedef {object} MoveOptions Configuration options for File#move(). See an
- *     [Object
- * resource](https://cloud.google.com/storage/docs/json_api/v1/objects#resource).
- * @param {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
+
 export interface MoveOptions {
   userProject?: string;
 }
 
-/**
- * @param {string|buffer|object} RotateEncryptionKeyOptions Configuration options
- *     for File#rotateEncryptionKey().
- * If a string or Buffer is provided, it is interpreted as an AES-256,
- * customer-supplied encryption key. If you'd like to use a Cloud KMS key name,
- * you must specify an options object with the property name: `kmsKeyName`.
- * @param {string|buffer} [options.encryptionKey] An AES-256 encryption key.
- * @param {string} [options.kmsKeyName] A Cloud KMS key name.
- */
 export type RotateEncryptionKeyOptions = string|Buffer|EncryptionKeyOptions;
 
 export interface EncryptionKeyOptions {
@@ -374,16 +202,8 @@ export interface EncryptionKeyOptions {
   kmsKeyName?: string;
 }
 
-/**
- * @callback RotateEncryptionKeyCallback
- * @extends CopyCallback
- */
 export interface RotateEncryptionKeyCallback extends CopyCallback {}
 
-/**
- * @typedef RotateEncryptionKeyResponse
- * @extends CopyResponse
- */
 export type RotateEncryptionKeyResponse = CopyResponse;
 
 /**
@@ -423,16 +243,6 @@ const STORAGE_UPLOAD_BASE_URL =
  */
 const GS_URL_REGEXP = /^gs:\/\/([a-z0-9_.-]+)\/(.+)$/;
 
-/**
- * Options passed to the File constructor.
- * @param {string} [encryptionKey] A custom encryption key.
- * @param {number} [generation] Generation to scope the file to.
- * @param {string} [kmsKeyName] Cloud KMS Key used to encrypt this
- *     object, if the object is encrypted by such a key. Limited availability;
- *     usable only by enabled projects.
- * @param {string} [userProject] The ID of the project which will be
- *     billed for all requests made from File object.
- */
 export interface FileOptions {
   encryptionKey?: string|Buffer;
   generation?: number|string;
@@ -440,22 +250,6 @@ export interface FileOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {object} CopyOptions Configuration options for File#copy(). See an
- *     [Object
- * resource](https://cloud.google.com/storage/docs/json_api/v1/objects#resource).
- * @property {string} [destinationKmsKeyName] Resource name of the Cloud
- *     KMS key, of the form
- *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`,
- *     that will be used to encrypt the object. Overwrites the object metadata's
- *     `kms_key_name` value, if any.
- * @property {string} [keepAcl] Retain the ACL for the new file.
- * @property {string} [predefinedAcl] Set the ACL for the new file.
- * @property {string} [token] A previously-returned `rewriteToken` from an
- *     unfinished rewrite request.
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface CopyOptions {
   destinationKmsKeyName?: string;
   keepAcl?: string;
@@ -464,28 +258,14 @@ export interface CopyOptions {
   userProject?: string;
 }
 
-/**
- * @typedef {array} CopyResponse
- * @property {File} 0 The copied {@link File}.
- * @property {object} 1 The full API response.
- */
 export type CopyResponse = [File, r.Response];
 
 export interface CopyCallback {
   (err: Error|null, file?: File|null, apiResponse?: r.Response): void;
 }
 
-/**
- * @typedef {array} DownloadResponse
- * @property [0] The contents of a File.
- */
 export type DownloadResponse = [Buffer];
 
-/**
- * @callback DownloadCallback
- * @param err Request error, if any.
- * @param contents The contents of a File.
- */
 export type DownloadCallback = (err: RequestError|null, contents: Buffer) =>
     void;
 
@@ -516,83 +296,30 @@ interface SignedUrlQuery {
 }
 
 export interface CreateReadStreamOptions {
-  /**
-   * The ID of the project which will be billed for the request.
-   */
   userProject?: string;
-  /**
-   * By default, data integrity is validated with a
-   * CRC32c checksum. You may use MD5 if preferred, but that hash is not
-   * supported for composite objects. An error will be raised if MD5 is
-   * specified but is not available. You may also choose to skip validation
-   * completely, however this is **not recommended**.
-   */
   validation?: 'md5'|'crc32c'|false|true;
-  /**
-   * A byte offset to begin the file's download
-   * from. Default is 0. NOTE: Byte ranges are inclusive; that is,
-   * `options.start = 0` and `options.end = 999` represent the first 1000
-   * bytes in a file or object. NOTE: when specifying a byte range, data
-   * integrity is not available.
-   */
   start?: number;
-  /**
-   * A byte offset to stop reading the file at.
-   * NOTE: Byte ranges are inclusive; that is, `options.start = 0` and
-   * `options.end = 999` represent the first 1000 bytes in a file or object.
-   * NOTE: when specifying a byte range, data integrity is not available.
-   */
   end?: number;
 }
 
-/**
- * @typedef {object} SaveOptions
- * @extends CreateWriteStreamOptions
- */
 export interface SaveOptions extends CreateWriteStreamOptions {}
 
-/**
- * @callback SaveCallback
- * @param {?Error} err Request error, if any.
- */
 export interface SaveCallback {
   (err?: Error|null): void;
 }
 
-/**
- * @typedef {object} SetFileMetadataOptions Configuration options for File#setMetadata().
- * @param {string} [userProject] The ID of the project which will be billed for the request.
- */
 export interface SetFileMetadataOptions {
   userProject?: string;
 }
 
-/**
- * @callback SetFileMetadataCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface SetFileMetadataCallback {
   (err?: Error|null, apiResponse?: r.Response): void;
 }
 
-/**
- * @typedef {array} SetFileMetadataResponse
- * @property {object} 0 The full API response.
- */
 export type SetFileMetadataResponse = [r.Response];
 
-/**
- * @typedef {array} SetStorageClassResponse
- * @property {object} 0 The full API response.
- */
 export type SetStorageClassResponse = [r.Response];
 
-/**
- * @typedef {object} SetStorageClassOptions Configuration options for File#setStorageClass().
- * @property {string} [userProject] The ID of the project which will be
- *     billed for the request.
- */
 export interface SetStorageClassOptions {
   userProject?: string;
 }
@@ -601,11 +328,6 @@ interface SetStorageClassRequest extends SetStorageClassOptions {
   storageClass?: string;
 }
 
-/**
- * @callback SetStorageClassCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
 export interface SetStorageClassCallback {
   (err?: Error|null, apiResponse?: r.Response): void;
 }
@@ -620,23 +342,6 @@ class RequestError extends Error {
  * {@link Bucket#file}.
  *
  * @class
- * @param {Bucket} bucket The Bucket instance this file is
- *     attached to.
- * @param {string} name The name of the remote file.
- * @param {object} [options] Configuration options.
- * @param {string} [options.encryptionKey] A custom encryption key.
- * @param {number} [options.generation] Generation to scope the file to.
- * @param {string} [options.kmsKeyName] Cloud KMS Key used to encrypt this
- *     object, if the object is encrypted by such a key. Limited availability;
- *     usable only by enabled projects.
- * @param {string} [options.userProject] The ID of the project which will be
- *     billed for all requests made from File object.
- * @example
- * const {Storage} = require('@google-cloud/storage');
- * const storage = new Storage();
- * const myBucket = storage.bucket('my-bucket');
- *
- * const file = myBucket.file('my-file');
  */
 class File extends ServiceObject {
   /**
@@ -698,6 +403,30 @@ class File extends ServiceObject {
   private encryptionKeyInterceptor?:
       {request: (reqOpts: r.OptionsWithUri) => r.OptionsWithUri;};
 
+  /**
+   * @typedef {object} FileOptions Options passed to the File constructor.
+   * @property {string} [encryptionKey] A custom encryption key.
+   * @property {number} [generation] Generation to scope the file to.
+   * @property {string} [kmsKeyName] Cloud KMS Key used to encrypt this
+   *     object, if the object is encrypted by such a key. Limited availability;
+   *     usable only by enabled projects.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for all requests made from File object.
+   */
+  /**
+   * Constructs a file object.
+   *
+   * @param {Bucket} bucket The Bucket instance this file is
+   *     attached to.
+   * @param {string} name The name of the remote file.
+   * @param {FileOptions} [options] Configuration options.
+   * @example
+   * const {Storage} = require('@google-cloud/storage');
+   * const storage = new Storage();
+   * const myBucket = storage.bucket('my-bucket');
+   *
+   * const file = myBucket.file('my-file');
+   */
   constructor(bucket: Bucket, name: string, options: FileOptions = {}) {
     name = name.replace(/^\/+/, '');
 
@@ -749,10 +478,31 @@ class File extends ServiceObject {
       destination: string|Bucket|File, options: CopyOptions,
       callback: CopyCallback): void;
   /**
+   * @typedef {array} CopyResponse
+   * @property {File} 0 The copied {@link File}.
+   * @property {object} 1 The full API response.
+   */
+  /**
    * @callback CopyCallback
    * @param {?Error} err Request error, if any.
    * @param {File} copiedFile The copied {@link File}.
    * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {object} CopyOptions Configuration options for File#copy(). See an
+   *     [Object
+   * resource](https://cloud.google.com/storage/docs/json_api/v1/objects#resource).
+   * @property {string} [destinationKmsKeyName] Resource name of the Cloud
+   *     KMS key, of the form
+   *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`,
+   *     that will be used to encrypt the object. Overwrites the object
+   * metadata's `kms_key_name` value, if any.
+   * @property {string} [keepAcl] Retain the ACL for the new file.
+   * @property {string} [predefinedAcl] Set the ACL for the new file.
+   * @property {string} [token] A previously-returned `rewriteToken` from an
+   *     unfinished rewrite request.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
    */
   /**
    * Copy this file to another file. By default, this will copy the file to the
@@ -978,6 +728,26 @@ class File extends ServiceObject {
   }
 
   /**
+   * @typedef {object} CreateReadStreamOptions Configuration options for File#createReadStream.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   * @property {string|boolean} [validation] Possible values: `"md5"`,
+   *     `"crc32c"`, or `false`. By default, data integrity is validated with a
+   *     CRC32c checksum. You may use MD5 if preferred, but that hash is not
+   *     supported for composite objects. An error will be raised if MD5 is
+   *     specified but is not available. You may also choose to skip validation
+   *     completely, however this is **not recommended**.
+   * @property {number} [start] A byte offset to begin the file's download
+   *     from. Default is 0. NOTE: Byte ranges are inclusive; that is,
+   *     `options.start = 0` and `options.end = 999` represent the first 1000
+   *     bytes in a file or object. NOTE: when specifying a byte range, data
+   *     integrity is not available.
+   * @property {number} [end] A byte offset to stop reading the file at.
+   *     NOTE: Byte ranges are inclusive; that is, `options.start = 0` and
+   *     `options.end = 999` represent the first 1000 bytes in a file or object.
+   *     NOTE: when specifying a byte range, data integrity is not available.
+   */
+  /**
    * Create a readable stream to read the contents of the remote file. It can be
    * piped to a writable stream or listened to for 'data' events to read a
    * file's contents.
@@ -995,24 +765,7 @@ class File extends ServiceObject {
    * NOTE: Readable streams will emit the `end` event when the file is fully
    * downloaded.
    *
-   * @param {object} [options] Configuration options.
-   * @param {string} [options.userProject] The ID of the project which will be
-   *     billed for the request.
-   * @param {string|boolean} [options.validation] Possible values: `"md5"`,
-   *     `"crc32c"`, or `false`. By default, data integrity is validated with a
-   *     CRC32c checksum. You may use MD5 if preferred, but that hash is not
-   *     supported for composite objects. An error will be raised if MD5 is
-   *     specified but is not available. You may also choose to skip validation
-   *     completely, however this is **not recommended**.
-   * @param {number} [options.start] A byte offset to begin the file's download
-   *     from. Default is 0. NOTE: Byte ranges are inclusive; that is,
-   *     `options.start = 0` and `options.end = 999` represent the first 1000
-   *     bytes in a file or object. NOTE: when specifying a byte range, data
-   *     integrity is not available.
-   * @param {number} [options.end] A byte offset to stop reading the file at.
-   *     NOTE: Byte ranges are inclusive; that is, `options.start = 0` and
-   *     `options.end = 999` represent the first 1000 bytes in a file or object.
-   *     NOTE: when specifying a byte range, data integrity is not available.
+   * @param {CreateReadStreamOptions} [options] Configuration options.
    * @returns {ReadableStream}
    *
    * @example
@@ -1272,25 +1025,19 @@ class File extends ServiceObject {
       callback: CreateResumableUploadCallback): void;
   createResumableUpload(callback: CreateResumableUploadCallback): void;
   /**
-   * Create a unique resumable upload session URI. This is the first step when
-   * performing a resumable upload.
-   *
-   * See the [Resumable upload
-   * guide](https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload)
-   * for more on how the entire process works.
-   *
-   * <h4>Note</h4>
-   *
-   * If you are just looking to perform a resumable upload without worrying
-   * about any of the details, see {@link File#createWriteStream}. Resumable
-   * uploads are performed by default.
-   *
-   * @see [Resumable upload guide]{@link https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload}
-   *
-   * @param {object} [options] Configuration options.
-   * @param {object} [options.metadata] Metadata to set on the file.
-   * @param {string} [options.origin] Origin header to set for the upload.
-   * @param {string} [options.predefinedAcl] Apply a predefined set of access
+   * @callback CreateResumableUploadCallback
+   * @param {?Error} err Request error, if any.
+   * @param {string} uri The resumable upload's unique session URI.
+   */
+  /**
+   * @typedef {array} CreateResumableUploadResponse
+   * @property {string} 0 The resumable upload's unique session URI.
+   */
+  /**
+   * @typedef {object} CreateResumableUploadOptions
+   * @property {object} [metadata] Metadata to set on the file.
+   * @property {string} [origin] Origin header to set for the upload.
+   * @property {string} [predefinedAcl] Apply a predefined set of access
    *     controls to this object.
    *
    *     Acceptable values are:
@@ -1310,12 +1057,30 @@ class File extends ServiceObject {
    *
    *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
    * get `READER` access.
-   * @param {boolean} [options.private] Make the uploaded file private. (Alias for
+   * @property {boolean} [private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
-   * @param {boolean} [options.public] Make the uploaded file public. (Alias for
+   * @property {boolean} [public] Make the uploaded file public. (Alias for
    *     `options.predefinedAcl = 'publicRead'`)
-   * @param {string} [options.userProject] The ID of the project which will be
+   * @property {string} [userProject] The ID of the project which will be
    *     billed for the request.
+   */
+  /**
+   * Create a unique resumable upload session URI. This is the first step when
+   * performing a resumable upload.
+   *
+   * See the [Resumable upload
+   * guide](https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload)
+   * for more on how the entire process works.
+   *
+   * <h4>Note</h4>
+   *
+   * If you are just looking to perform a resumable upload without worrying
+   * about any of the details, see {@link File#createWriteStream}. Resumable
+   * uploads are performed by default.
+   *
+   * @see [Resumable upload guide]{@link https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload}
+   *
+   * @param {CreateResumableUploadOptions} [options] Configuration options.
    * @param {CreateResumableUploadCallback} [callback] Callback function.
    * @returns {Promise<CreateResumableUploadResponse>}
    *
@@ -1367,6 +1132,60 @@ class File extends ServiceObject {
         callback!);
   }
 
+  /**
+   * @typedef {object} CreateWriteStreamOptions Configuration options for File#createWriteStream().
+   * @property {string} [contentType] Alias for
+   *     `options.metadata.contentType`. If set to `auto`, the file name is used
+   *     to determine the contentType.
+   * @property {string|boolean} [gzip] If true, automatically gzip the file.
+   *     If set to `auto`, the contentType is used to determine if the file
+   * should be gzipped. This will set `options.metadata.contentEncoding` to
+   * `gzip` if necessary.
+   * @property {object} [metadata] See the examples below or
+   *     [Objects: insert request
+   * body](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON)
+   *     for more details.
+   * @property {number} [offset] The starting byte of the upload stream, for
+   *     resuming an interrupted upload. Defaults to 0.
+   * @property {string} [predefinedAcl] Apply a predefined set of access
+   *     controls to this object.
+   *
+   *     Acceptable values are:
+   *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
+   *       `allAuthenticatedUsers` get `READER` access.
+   *
+   *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
+   *       project team owners get `OWNER` access.
+   *
+   *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
+   *       team owners get `READER` access.
+   *
+   *     - **`private`** - Object owner gets `OWNER` access.
+   *
+   *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
+   *       team members get access according to their roles.
+   *
+   *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
+   * get `READER` access.
+   * @property {boolean} [private] Make the uploaded file private. (Alias for
+   *     `options.predefinedAcl = 'private'`)
+   * @property {boolean} [public] Make the uploaded file public. (Alias for
+   *     `options.predefinedAcl = 'publicRead'`)
+   * @property {boolean} [resumable] Force a resumable upload. NOTE: When
+   *     working with streams, the file format and size is unknown until it's
+   *     completely consumed. Because of this, it's best for you to be explicit
+   *     for what makes sense given your input.
+   * @property {string} [uri] The URI for an already-created resumable
+   *     upload. See {@link File#createResumableUpload}.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   * @property {string|boolean} [validation] Possible values: `"md5"`,
+   *     `"crc32c"`, or `false`. By default, data integrity is validated with a
+   *     CRC32c checksum. You may use MD5 if preferred, but that hash is not
+   *     supported for composite objects. An error will be raised if MD5 is
+   *     specified but is not available. You may also choose to skip validation
+   *     completely, however this is **not recommended**.
+   */
   /**
    * Create a writable stream to overwrite the contents of the file in your
    * bucket.
@@ -1438,8 +1257,7 @@ class File extends ServiceObject {
    *
    * //-
    * // Downloading the file with `createReadStream` will automatically decode
-   * the
-   * // file.
+   * // the file.
    * //-
    *
    * //-
@@ -1626,6 +1444,15 @@ class File extends ServiceObject {
   delete(options: DeleteFileOptions, callback: DeleteFileCallback): void;
   delete(callback: DeleteFileCallback): void;
   /**
+   * @typedef {array} DeleteFileResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback DeleteFileCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Delete the file.
    *
    * @see [Objects: delete API Documentation]{@link https://cloud.google.com/storage/docs/json_api/v1/objects/delete}
@@ -1669,6 +1496,15 @@ class File extends ServiceObject {
   download(options?: DownloadOptions): Promise<DownloadResponse>;
   download(options: DownloadOptions, callback: DownloadCallback): void;
   download(callback: DownloadCallback): void;
+  /**
+   * @typedef {array} DownloadResponse
+   * @property [0] The contents of a File.
+   */
+  /**
+   * @callback DownloadCallback
+   * @param err Request error, if any.
+   * @param contents The contents of a File.
+   */
   /**
    * Convenience method to download a file into memory or to a local
    * destination.
@@ -1753,6 +1589,15 @@ class File extends ServiceObject {
   exists(options?: FileExistsOptions): Promise<FileExistsResponse>;
   exists(options: FileExistsOptions, callback: FileExistsCallback): void;
   exists(callback: FileExistsCallback): void;
+  /**
+   * @typedef {array} FileExistsResponse
+   * @property {boolean} 0 Whether the {@link File} exists.
+   */
+  /**
+   * @callback FileExistsCallback
+   * @param {?Error} err Request error, if any.
+   * @param {boolean} exists Whether the {@link File} exists.
+   */
   /**
    * Check if the file exists.
    *
@@ -1861,6 +1706,17 @@ class File extends ServiceObject {
   get(options?: GetFileOptions): Promise<GetFileResponse>;
   get(options: GetFileOptions, callback: GetFileCallback): void;
   get(callback: GetFileCallback): void;
+  /**
+   * @typedef {array} GetFileResponse
+   * @property {File} 0 The {@link File}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback GetFileCallback
+   * @param {?Error} err Request error, if any.
+   * @param {File} file The {@link File}.
+   * @param {object} apiResponse The full API response.
+   */
   /**
    * Get a file object and its metadata if it exists.
    *
@@ -2198,6 +2054,15 @@ class File extends ServiceObject {
   getSignedUrl(cfg: GetSignedUrlConfig): Promise<GetSignedUrlResponse>;
   getSignedUrl(cfg: GetSignedUrlConfig, callback: GetSignedUrlCallback): void;
   /**
+   * @typedef {array} GetSignedUrlResponse
+   * @property {object} 0 The signed URL.
+   */
+  /**
+   * @callback GetSignedUrlCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} url The signed URL.
+   */
+  /**
    * Get a signed URL to allow limited time access to the file.
    *
    * In Google Cloud Platform environments, such as Cloud Functions and App
@@ -2407,6 +2272,22 @@ class File extends ServiceObject {
   makePrivate(
       options: MakeFilePrivateOptions, callback: MakeFilePrivateCallback): void;
   /**
+   * @typedef {object} MakeFilePrivateOptions Configuration options for File#makePrivate().
+   * @property {boolean} [strict] If true, set the file to be private to
+   *     only the owner user. Otherwise, it will be private to the project.
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @callback MakeFilePrivateCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {array} MakeFilePrivateResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
    * Make a file private to the project and remove all other permissions.
    * Set `options.strict` to true to make the file private to only the owner.
    *
@@ -2471,6 +2352,10 @@ class File extends ServiceObject {
   makePublic(): Promise<MakeFilePublicResponse>;
   makePublic(callback: MakeFilePublicCallback): void;
   /**
+   * @typedef {array} MakeFilePublicResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
    * @callback MakeFilePublicCallback
    * @param {?Error} err Request error, if any.
    * @param {object} apiResponse The full API response.
@@ -2522,6 +2407,24 @@ class File extends ServiceObject {
   move(
       destination: string|Bucket|File, options: MoveOptions,
       callback: MoveCallback): void;
+  /**
+   * @typedef {array} MoveResponse
+   * @property {File} 0 The destination File.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback MoveCallback
+   * @param {?Error} err Request error, if any.
+   * @param {?File} destinationFile The destination File.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {object} MoveOptions Configuration options for File#move(). See an
+   *     [Object
+   * resource](https://cloud.google.com/storage/docs/json_api/v1/objects#resource).
+   * @param {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
   /**
    * Move this file to another location. By default, this will rename the file
    * and keep it in the same bucket, but you can choose to move it to another
@@ -2681,6 +2584,24 @@ class File extends ServiceObject {
       options: RotateEncryptionKeyOptions,
       callback: RotateEncryptionKeyCallback): void;
   /**
+   * @callback RotateEncryptionKeyCallback
+   * @extends CopyCallback
+   */
+  /**
+   * @typedef RotateEncryptionKeyResponse
+   * @extends CopyResponse
+   */
+  /**
+   * @param {string|buffer|object} RotateEncryptionKeyOptions Configuration options
+   *     for File#rotateEncryptionKey().
+   * If a string or Buffer is provided, it is interpreted as an AES-256,
+   * customer-supplied encryption key. If you'd like to use a Cloud KMS key
+   * name, you must specify an options object with the property name:
+   * `kmsKeyName`.
+   * @param {string|buffer} [options.encryptionKey] An AES-256 encryption key.
+   * @param {string} [options.kmsKeyName] A Cloud KMS key name.
+   */
+  /**
    * This method allows you to update the encryption key associated with this
    * file.
    *
@@ -2719,6 +2640,14 @@ class File extends ServiceObject {
   save(data: any, options?: SaveOptions): Promise<void>;
   save(data: any, callback: SaveCallback): void;
   save(data: any, options: SaveOptions, callback: SaveCallback): void;
+  /**
+   * @typedef {object} SaveOptions
+   * @extends CreateWriteStreamOptions
+   */
+  /**
+   * @callback SaveCallback
+   * @param {?Error} err Request error, if any.
+   */
   /**
    * Write arbitrary data to a file.
    *
@@ -2780,6 +2709,19 @@ class File extends ServiceObject {
   setMetadata(
       metadata: Metadata, options: SetFileMetadataOptions,
       callback: SetFileMetadataCallback): void;
+  /**
+   * @typedef {object} SetFileMetadataOptions Configuration options for File#setMetadata().
+   * @param {string} [userProject] The ID of the project which will be billed for the request.
+   */
+  /**
+   * @callback SetFileMetadataCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * @typedef {array} SetFileMetadataResponse
+   * @property {object} 0 The full API response.
+   */
   /**
    * Merge the given metadata with the current remote file's metadata. This
    * will set metadata if it was previously unset or update previously set
@@ -2878,6 +2820,20 @@ class File extends ServiceObject {
       callback: SetStorageClassCallback): void;
   setStorageClass(storageClass: string, callback?: SetStorageClassCallback):
       void;
+  /**
+   * @typedef {array} SetStorageClassResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @typedef {object} SetStorageClassOptions Configuration options for File#setStorageClass().
+   * @property {string} [userProject] The ID of the project which will be
+   *     billed for the request.
+   */
+  /**
+   * @callback SetStorageClassCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
   /**
    * Set the storage class for this file.
    *

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -55,23 +55,6 @@ export interface BucketOptions {
   userProject?: string;
 }
 
-/**
- * Metadata to set for the bucket.
- *
- * @typedef {object} CreateBucketRequest
- * @property {boolean} [coldline=false] Specify the storage class as Coldline.
- * @property {boolean} [dra=false] Specify the storage class as Durable Reduced
- *     Availability.
- * @property {boolean} [multiRegional=false] Specify the storage class as
- *     Multi-Regional.
- * @property {boolean} [nearline=false] Specify the storage class as Nearline.
- * @property {boolean} [regional=false] Specify the storage class as Regional.
- * @property {boolean} [requesterPays=false] **Early Access Testers Only**
- *     Force the use of the User Project metadata field to assign operational
- *     costs when an operation is made on a Bucket and its objects.
- * @property {string} [userProject] The ID of the project which will be billed
- *     for the request.
- */
 export interface CreateBucketRequest {
   coldline?: boolean;
   dra?: boolean;
@@ -84,19 +67,8 @@ export interface CreateBucketRequest {
   location?: string;
 }
 
-/**
- * @typedef {array} CreateBucketResponse
- * @property {Bucket} 0 The new {@link Bucket}.
- * @property {object} 1 The full API response.
- */
 export type CreateBucketResponse = [Bucket, r.Response];
 
-/**
- * @callback CreateBucketCallback
- * @param {?Error} err Request error, if any.
- * @param {Bucket} bucket The new {@link Bucket}.
- * @param {object} apiResponse The full API response.
- */
 export interface BucketCallback {
   (err: Error|null, bucket?: Bucket|null, apiResponse?: r.Response): void;
 }
@@ -115,32 +87,6 @@ export interface GetBucketsRequest {
   userProject?: string;
 }
 
-/**
- * @typedef {object} ClientConfig
- * @property {string} [projectId] The project ID from the Google Developer's
- *     Console, e.g. 'grape-spaceship-123'. We will also check the environment
- *     variable `GCLOUD_PROJECT` for your project ID. If your app is running in
- *     an environment which supports {@link
- * https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
- * Application Default Credentials}, your project ID will be detected
- * automatically.
- * @property {string} [keyFilename] Full path to the a .json, .pem, or .p12 key
- *     downloaded from the Google Developers Console. If you provide a path to a
- *     JSON file, the `projectId` option above is not necessary. NOTE: .pem and
- *     .p12 require you to specify the `email` option as well.
- * @property {string} [email] Account email address. Required when using a .pem
- *     or .p12 keyFilename.
- * @property {object} [credentials] Credentials object.
- * @property {string} [credentials.client_email]
- * @property {string} [credentials.private_key]
- * @property {boolean} [autoRetry=true] Automatically retry requests if the
- *     response is related to rate limits or certain intermittent server errors.
- *     We will exponentially backoff subsequent requests by default.
- * @property {number} [maxRetries=3] Maximum number of automatic retries
- *     attempted before returning the error.
- * @property {Constructor} [promise] Custom promise module to use instead of
- *     native Promises.
- */
 
 /*! Developer Documentation
  *
@@ -162,20 +108,6 @@ export interface GetBucketsRequest {
  * @see [Access Control]{@link https://cloud.google.com/storage/docs/access-control}
  *
  * @class
- * @hideconstructor
- *
- * @example <caption>Create a client that uses Application Default Credentials
- * (ADC)</caption> const {Storage} = require('@google-cloud/storage'); const
- * storage = new Storage();
- *
- * @example <caption>Create a client with explicit credentials</caption>
- * storage');/storage');
- * const storage = new Storage({
- *   projectId: 'your-project-id',
- *   keyFilename: '/path/to/keyfile.json'
- * });
- *
- * @param {ClientConfig} [options] Configuration options.
  */
 export class Storage extends Service {
   /**
@@ -304,6 +236,48 @@ export class Storage extends Service {
    */
   getBucketsStream: () => Readable;
 
+  /**
+   * @typedef {object} StorageOptions
+   * @property {string} [projectId] The project ID from the Google Developer's
+   *     Console, e.g. 'grape-spaceship-123'. We will also check the environment
+   *     variable `GCLOUD_PROJECT` for your project ID. If your app is running
+   * in an environment which supports {@link
+   * https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
+   * Application Default Credentials}, your project ID will be detected
+   * automatically.
+   * @property {string} [keyFilename] Full path to the a .json, .pem, or .p12 key
+   *     downloaded from the Google Developers Console. If you provide a path to
+   * a JSON file, the `projectId` option above is not necessary. NOTE: .pem and
+   *     .p12 require you to specify the `email` option as well.
+   * @property {string} [email] Account email address. Required when using a .pem
+   *     or .p12 keyFilename.
+   * @property {object} [credentials] Credentials object.
+   * @property {string} [credentials.client_email]
+   * @property {string} [credentials.private_key]
+   * @property {boolean} [autoRetry=true] Automatically retry requests if the
+   *     response is related to rate limits or certain intermittent server
+   * errors. We will exponentially backoff subsequent requests by default.
+   * @property {number} [maxRetries=3] Maximum number of automatic retries
+   *     attempted before returning the error.
+   * @property {Constructor} [promise] Custom promise module to use instead of
+   *     native Promises.
+   */
+  /**
+   * Constructs the Storage client.
+   *
+   * @example <caption>Create a client that uses Application Default Credentials
+   * (ADC)</caption> const {Storage} = require('@google-cloud/storage'); const
+   * storage = new Storage();
+   *
+   * @example <caption>Create a client with explicit credentials</caption>
+   * storage');/storage');
+   * const storage = new Storage({
+   *   projectId: 'your-project-id',
+   *   keyFilename: '/path/to/keyfile.json'
+   * });
+   *
+   * @param {StorageOptions} [options] Configuration options.
+   */
   constructor(options: StorageOptions = {}) {
     const config = {
       baseUrl: 'https://www.googleapis.com/storage/v1',
@@ -378,6 +352,34 @@ export class Storage extends Service {
   createBucket(
       name: string, metadata: CreateBucketRequest,
       callback: BucketCallback): void;
+  /**
+   * @typedef {array} CreateBucketResponse
+   * @property {Bucket} 0 The new {@link Bucket}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback CreateBucketCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Bucket} bucket The new {@link Bucket}.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Metadata to set for the bucket.
+   *
+   * @typedef {object} CreateBucketRequest
+   * @property {boolean} [coldline=false] Specify the storage class as Coldline.
+   * @property {boolean} [dra=false] Specify the storage class as Durable Reduced
+   *     Availability.
+   * @property {boolean} [multiRegional=false] Specify the storage class as
+   *     Multi-Regional.
+   * @property {boolean} [nearline=false] Specify the storage class as Nearline.
+   * @property {boolean} [regional=false] Specify the storage class as Regional.
+   * @property {boolean} [requesterPays=false] **Early Access Testers Only**
+   *     Force the use of the User Project metadata field to assign operational
+   *     costs when an operation is made on a Bucket and its objects.
+   * @property {string} [userProject] The ID of the project which will be billed
+   *     for the request.
+   */
   /**
    * Create a bucket.
    *


### PR DESCRIPTION
JSDoc comments above interfaces are not preserved when compiling to
TypeScript, this is casuing current docs to have missing types.

See https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/File#copy
The `options` parameter to File#copy is missing a link to type `CopyOptions`.