### PR TITLE
test: Bucket Policy Only related system test

### DIFF
--- a/.kokoro/setup-vars.sh
+++ b/.kokoro/setup-vars.sh
@@ -16,6 +16,7 @@
 
 # nodejs-storage's system tests require additional project and
 # system test key
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/storage-key.json
 export GCN_STORAGE_2ND_PROJECT_ID=gcloud-node-whitelist-ci-tests
 export GCN_STORAGE_2ND_PROJECT_KEY=${KOKORO_GFILE_DIR}/no-whitelist-key.json
 


### PR DESCRIPTION
Contains the following asserts:

- General Bucket Policy Only assertions
  - Object acl get or update fails w/ 400
- Insert a new bucket with Bucket Policy Only Enabled.
  - Verify that objects can be written to the bucket by project Owners and Editors without any further configuration
- Verify that default object acl and object acls are preserved
  - Create a bucket
  - Insert an object
  - Enable BPO
  - Disable BPO
  - Check that the object's ACLs are still there