### PR TITLE
test: skip public bucket system tests running under VPCSC

### DIFF
--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -137,7 +137,7 @@ describe('storage', () => {
         bucket = storageWithoutAuth.bucket('gcp-public-data-landsat');
       });
 
-      it('should list and download a file', (done) => {
+      it('should list and download a file', done => {
         bucket.getFiles(
             {
               autoPaginate: false,

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -29,6 +29,10 @@ import {Storage, Bucket, File, AccessControlObject, Notification, GetNotificatio
 import * as nock from 'nock';
 const {PubSub} = require('@google-cloud/pubsub');
 
+// When set to true, skips all tests that is not compatible for
+// running inside VPCSC.
+const RUNNING_IN_VPCSC = !!process.env['GOOGLE_CLOUD_TESTS_IN_VPCSC'];
+
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
 nock('http://metadata.google.internal')
     .get(url => true)
@@ -123,13 +127,17 @@ describe('storage', () => {
     });
 
     describe('public data', () => {
+      if (RUNNING_IN_VPCSC) {
+        return;
+      }
+
       let bucket: Bucket;
 
       before(() => {
         bucket = storageWithoutAuth.bucket('gcp-public-data-landsat');
       });
 
-      it('should list and download a file', done => {
+      it('should list and download a file', (done) => {
         bucket.getFiles(
             {
               autoPaginate: false,
@@ -767,6 +775,10 @@ describe('storage', () => {
   });
 
   describe('unicode validation', () => {
+    if (RUNNING_IN_VPCSC) {
+      return;
+    }
+
     let bucket: Bucket;
 
     before(() => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -127,9 +127,9 @@ describe('storage', () => {
     });
 
     describe('public data', () => {
-      if (RUNNING_IN_VPCSC) {
-        return;
-      }
+      before(function() {
+        if (RUNNING_IN_VPCSC) return this.skip();
+      });
 
       let bucket: Bucket;
 
@@ -775,9 +775,9 @@ describe('storage', () => {
   });
 
   describe('unicode validation', () => {
-    if (RUNNING_IN_VPCSC) {
-      return;
-    }
+    before(function() {
+      if (RUNNING_IN_VPCSC) return this.skip();
+    });
 
     let bucket: Bucket;
 

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -128,7 +128,7 @@ describe('storage', () => {
 
     describe('public data', () => {
       before(function() {
-        if (RUNNING_IN_VPCSC) return this.skip();
+        if (RUNNING_IN_VPCSC) this.skip();
       });
 
       let bucket: Bucket;
@@ -776,7 +776,7 @@ describe('storage', () => {
 
   describe('unicode validation', () => {
     before(function() {
-      if (RUNNING_IN_VPCSC) return this.skip();
+      if (RUNNING_IN_VPCSC) this.skip();
     });
 
     let bucket: Bucket;


### PR DESCRIPTION
When running under VPCSC, the process will have no egress access to
public buckets. Skipping these system tests when
GOOGLE_CLOUD_TESTS_IN_VPCSC=true environment variable is set.

This is the same variable used in the Python system-test:
https://github.com/googleapis/google-cloud-python/blob/master/storage/tests/system.py#L37