### PR TITLE
deps: update @google-cloud/common

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "predocs": "npm run compile",
     "docs": "jsdoc -c .jsdoc.js",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
-    "system-test": "mocha build/system-test --timeout 600000",
+    "system-test": "mocha build/system-test --timeout 600001",
     "presystem-test": "npm run compile",
     "test": "nyc mocha build/test",
     "pretest": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prepare": "npm run compile"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.30.2",
+    "@google-cloud/common": "^0.31.0",
     "@google-cloud/paginator": "^0.1.0",
     "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "predocs": "npm run compile",
     "docs": "jsdoc -c .jsdoc.js",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
-    "system-test": "mocha build/system-test --timeout 600001",
+    "system-test": "mocha build/system-test --timeout 600000",
     "presystem-test": "npm run compile",
     "test": "nyc mocha build/test",
     "pretest": "npm run compile",


### PR DESCRIPTION
Fixes #27 

This updates @google-cloud/common, which includes the `timeout: 0` fix for streaming file uploads.