### PR TITLE
fix: getSigned(Policy|Url) throws if expiration is invalid Date

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2045,6 +2045,10 @@ class File extends ServiceObject<File> {
     const callback = args.callback;
     const expires = new Date((options as GetSignedPolicyOptions).expires);
 
+    if (isNaN(expires.getTime())) {
+      throw new Error('The expiration date provided was invalid.');
+    }
+
     if (expires.valueOf() < Date.now()) {
       throw new Error('An expiration date cannot be in the past.');
     }
@@ -2261,6 +2265,10 @@ class File extends ServiceObject<File> {
   getSignedUrl(cfg: GetSignedUrlConfig, callback?: GetSignedUrlCallback):
       void|Promise<GetSignedUrlResponse> {
     const expiresInMSeconds = new Date(cfg.expires).valueOf();
+
+    if (isNaN(expiresInMSeconds)) {
+      throw new Error('The expiration date provided was invalid.');
+    }
 
     if (expiresInMSeconds < Date.now()) {
       throw new Error('An expiration date cannot be in the past.');

--- a/test/file.ts
+++ b/test/file.ts
@@ -2146,6 +2146,18 @@ describe('File', () => {
             });
       });
 
+      it('should throw if a date is invalid', () => {
+        const expires = new Date('31-12-2019');
+
+        assert.throws(() => {
+          file.getSignedPolicy(
+              {
+                expires,
+              },
+              () => {});
+        }, /The expiration date provided was invalid\./);
+      });
+
       it('should throw if a date from the past is given', () => {
         const expires = Date.now() - 5;
 
@@ -2552,6 +2564,19 @@ describe('File', () => {
               assert.strictEqual(expires_, expectedExpires.toString());
               done();
             });
+      });
+
+      it('should throw if a date is invalid', () => {
+        const expires = new Date('31-12-2019');
+
+        assert.throws(() => {
+          file.getSignedUrl(
+              {
+                action: 'read',
+                expires,
+              },
+              () => {});
+        }, /The expiration date provided was invalid\./);
       });
 
       it('should throw if a date from the past is given', () => {


### PR DESCRIPTION
Fixes #613 

If the user provides an invalid Date to `file.getSignedPolicy()` or `file.getSignedUrl()`, we will now throw.