### PR TITLE
docs: clarify in docs, the meaning of ASIA and coldline

### DIFF
--- a/samples/buckets.js
+++ b/samples/buckets.js
@@ -36,7 +36,11 @@ async function createBucket(bucketName) {
    */
   // const bucketName = 'Name of a bucket, e.g. my-bucket';
 
-  // Creates a new bucket
+  // Creates a new bucket in the Asia region with the coldline default storage
+  // class. Leave the second argument blank for default settings.
+  //
+  // For default values see: https://cloud.google.com/storage/docs/locations and
+  // https://cloud.google.com/storage/docs/storage-classes
   await storage.createBucket(bucketName, {
     location: 'ASIA',
     storageClass: 'COLDLINE',


### PR DESCRIPTION
When @laylasells and I were walking through these code examples for the first time, we found the magic variables `ASIA` and `coldline` somewhat *magical* 🌠; this pull request adds documentation clarifying the meaning of these values.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
