### PR TITLE
docs: document destination option

### DIFF
--- a/samples/files.js
+++ b/samples/files.js
@@ -116,6 +116,8 @@ async function uploadFile(bucketName, filename) {
   await storage.bucket(bucketName).upload(filename, {
     // Support for HTTP requests made with `Accept-Encoding: gzip`
     gzip: true,
+    // By setting the option `destination`, you can change the name of the
+    // object you are uploading to a bucket.
     metadata: {
       // Enable long-lived HTTP caching headers
       // Use only if the contents of the file will never change


### PR DESCRIPTION
It's often the case that a user wants to change the destination name of an object they're uploading, but it's pretty buried in the docs.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
