### PR TITLE
docs: add a .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "storage",
+  "name_pretty": "Google Cloud Storage",
+  "product_documentation": "https://cloud.google.com/storage",
+  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/",
+  "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
+  "release_level": "ga",
+  "language": "nodejs",
+  "repo": "googleapis/nodejs-storage",
+  "distribution_name": "@google-cloud/storage"
+}


### PR DESCRIPTION
I'm using `nodejs-storage` to test our new `synthtool` README generation, it relies on @busunkim96's meat-information work.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
