### PR TITLE
docs: add additional api_id field

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,5 +7,6 @@
   "release_level": "ga",
   "language": "nodejs",
   "repo": "googleapis/nodejs-storage",
-  "distribution_name": "@google-cloud/storage"
+  "distribution_name": "@google-cloud/storage",
+  "api_id": "storage-api.googleapis.com"
 }


### PR DESCRIPTION
we use the `api_id` when allowing folks to enable a given API; this last piece of information seems to get us to the point where we can use `.repo-metadata.json` for generating the project README.md.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
