### PR TITLE
fix: do not download cached files

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1160,6 +1160,7 @@ class File extends ServiceObject<File> {
 
       const headers = {
         'Accept-Encoding': 'gzip',
+        'Cache-Control': 'no-store'
       } as r.Headers;
 
       if (rangeRequest) {

--- a/test/file.ts
+++ b/test/file.ts
@@ -833,6 +833,7 @@ describe('File', () => {
             uri: '',
             headers: {
               'Accept-Encoding': 'gzip',
+              'Cache-Control': 'no-store',
             },
             qs: {
               alt: 'media',


### PR DESCRIPTION
Fixes #566 

To quickly sum up the issue discovered in #566, this works:

- Save file with contents 'a'
- Download file. Contents === 'a'
- Save file with contents 'b'
- Download file. Contents === 'b' 😄

But as soon as it's a public file, it doesn't work:

- Save file with contents 'a'
- Make file public
- Download file. Contents === 'a'
- Save file with contents 'b'
- Download file. Contents === 'a' 😢

I believe what happens when the file is flipped to a public object, we then have to worry about caching. When you update the file, the upstream API's `generation` property is updated as well for the Object record.

So far, I've found three solutions:

- Ensure the file we download will not be cached (`Cache-Control: no-store`)
- Set `Cache-Control: no-transform` on the file's metadata
- Send the download API request with the latest `generation` in the query

I went with the first, as it seems the least error-prone.