### PR TITLE
docs: new synthtool generated README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ google-cloud-logging-winston-*.tgz
 google-cloud-logging-bunyan-*.tgz
 .vscode
 package-lock.json
+__pycache__

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -1,0 +1,8 @@
+introduction: |-
+    > Node.js idiomatic client for [Cloud Storage][product-docs].
+
+    [Cloud Storage](https://cloud.google.com/storage/docs) allows world-wide
+    storage and retrieval of any amount of data at any time. You can use Google
+    Cloud Storage for a range of scenarios including serving website content,
+    storing data for archival and disaster recovery, or distributing large data
+    objects to users via direct download.

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -6,3 +6,9 @@ introduction: |-
     Cloud Storage for a range of scenarios including serving website content,
     storing data for archival and disaster recovery, or distributing large data
     objects to users via direct download.
+quickstart_footer:
+    // process.env.GOOGLE_APPLICATION_CREDENTIALS points to service account JSON.
+
+    // process.env.GOOGLE_CLOUD_PROJECT points to your project in GCP.
+
+    quickstart(process.env.GOOGLE_CLOUD_PROJECT, "my-bucket")

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -11,4 +11,4 @@ quickstart_footer:
 
     // process.env.GOOGLE_CLOUD_PROJECT points to your project in GCP.
 
-    quickstart(process.env.GOOGLE_CLOUD_PROJECT, "my-bucket")
+    quickstart(process.env.GOOGLE_CLOUD_PROJECT)

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -6,9 +6,3 @@ introduction: |-
     Cloud Storage for a range of scenarios including serving website content,
     storing data for archival and disaster recovery, or distributing large data
     objects to users via direct download.
-quickstart_footer:
-    // process.env.GOOGLE_APPLICATION_CREDENTIALS points to service account JSON.
-
-    // process.env.GOOGLE_CLOUD_PROJECT points to your project in GCP.
-
-    quickstart(process.env.GOOGLE_CLOUD_PROJECT)

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "name": "storage",
   "name_pretty": "Google Cloud Storage",
   "product_documentation": "https://cloud.google.com/storage",
-  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/",
+  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/storage/latest/",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
   "release_level": "ga",
   "language": "nodejs",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@
 
 <<<<<<< HEAD
 
+<<<<<<< HEAD
 Cloud Storage Client Library for Node.js
+=======
+> Node.js idiomatic client for [Cloud Storage][product-docs].
+
+[Cloud Storage](https://cloud.google.com/storage/docs) allows world-wide
+storage and retrieval of any amount of data at any time. You can use Google
+Cloud Storage for a range of scenarios including serving website content,
+storing data for archival and disaster recovery, or distributing large data
+objects to users via direct download.
+>>>>>>> docs: playing with header
 
 
 =======

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ async function quickstart(
 
 // process.env.GOOGLE_APPLICATION_CREDENTIALS points to service account JSON.
 // process.env.GOOGLE_CLOUD_PROJECT points to your project in GCP.
-quickstart(process.env.GOOGLE_CLOUD_PROJECT, "my-bucket")
+quickstart(process.env.GOOGLE_CLOUD_PROJECT)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@
 [![npm version](https://img.shields.io/npm/v/@google-cloud/storage.svg)](https://www.npmjs.org/package/@google-cloud/storage)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-storage/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-storage)
 
+<<<<<<< HEAD
 
 Cloud Storage Client Library for Node.js
 
 
+=======
+Cloud Storage Client Library for Node.js
+
+>>>>>>> docs: new synthtool generated README
 * [Using the client library](#using-the-client-library)
 * [Samples](#samples)
 * [Versioning](#versioning)
@@ -104,6 +109,7 @@ Apache Version 2.0
 See [LICENSE](https://github.com/googleapis/nodejs-storage/blob/master/LICENSE)
 
 ## What's Next
+<<<<<<< HEAD
 
 * [Google Cloud Storage Documentation][product-docs]
 * [Google Cloud Storage Node.js Client API Reference][client-docs]
@@ -114,6 +120,18 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 [explained]: https://cloud.google.com/apis/docs/client-libraries-explained
 
+=======
+
+* [Google Cloud Storage Documentation][product-docs]
+* [Google Cloud Storage Node.js Client API Reference][client-docs]
+* [github.com/googleapis/nodejs-storage](https://github.com/googleapis/nodejs-storage)
+
+Read more about the client libraries for Cloud APIs, including the older
+Google APIs Client Libraries, in [Client Libraries Explained][explained].
+
+[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
+
+>>>>>>> docs: new synthtool generated README
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/
 [product-docs]: https://cloud.google.com/storage
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png

--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@
 <<<<<<< HEAD
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 Cloud Storage Client Library for Node.js
 =======
+=======
+
+
+>>>>>>> chore: some additional tweaks to README generation
 > Node.js idiomatic client for [Cloud Storage][product-docs].
 
 [Cloud Storage](https://cloud.google.com/storage/docs) allows world-wide
@@ -23,17 +28,38 @@ objects to users via direct download.
 >>>>>>> docs: playing with header
 
 
+<<<<<<< HEAD
 =======
 Cloud Storage Client Library for Node.js
 
 >>>>>>> docs: new synthtool generated README
 * [Using the client library](#using-the-client-library)
+=======
+* [Google Cloud Storage Node.js Client API Reference][client-docs]
+* [Google Cloud Storage Documentation][product-docs]
+* [github.com/googleapis/nodejs-storage](https://github.com/googleapis/nodejs-storage)
+
+Read more about the client libraries for Cloud APIs, including the older
+Google APIs Client Libraries, in [Client Libraries Explained][explained].
+
+[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
+
+**Table of contents:**
+
+
+* [Quickstart](#quickstart)
+  * [Before you begin](#before-you-begin)
+  * [Installing the client library](#installing-the-client-library)
+  * [Using the client library](#using-the-client-library)
+>>>>>>> chore: some additional tweaks to README generation
 * [Samples](#samples)
 * [Versioning](#versioning)
 * [Contributing](#contributing)
 * [License](#license)
 
-## Using the client library
+## Quickstart
+
+### Before you begin
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
@@ -41,12 +67,14 @@ Cloud Storage Client Library for Node.js
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
 
-1. Install the client library:
+### Installing the client library
 
-        npm install @google-cloud/storage
+```bash
+npm install @google-cloud/storage
+```
 
 
-1. Try an example:
+### Using the client library
 
 ```javascript
 async function quickstart(
@@ -64,6 +92,9 @@ async function quickstart(
   console.log(`Bucket ${bucketName} created.`);
 }
 
+// process.env.GOOGLE_APPLICATION_CREDENTIALS points to service account JSON.
+// process.env.GOOGLE_CLOUD_PROJECT points to your project in GCP.
+quickstart(process.env.GOOGLE_CLOUD_PROJECT, "my-bucket")
 ```
 
 
@@ -118,6 +149,7 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/nodejs-storage/blob/master/LICENSE)
 
+<<<<<<< HEAD
 ## What's Next
 <<<<<<< HEAD
 
@@ -143,6 +175,9 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 >>>>>>> docs: new synthtool generated README
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/
+=======
+[client-docs]: https://cloud.google.com/nodejs/docs/reference/storage/latest/
+>>>>>>> chore: some additional tweaks to README generation
 [product-docs]: https://cloud.google.com/storage
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project

--- a/README.md
+++ b/README.md
@@ -8,16 +8,9 @@
 [![npm version](https://img.shields.io/npm/v/@google-cloud/storage.svg)](https://www.npmjs.org/package/@google-cloud/storage)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-storage/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-storage)
 
-<<<<<<< HEAD
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-Cloud Storage Client Library for Node.js
-=======
-=======
 
 
->>>>>>> chore: some additional tweaks to README generation
+
 > Node.js idiomatic client for [Cloud Storage][product-docs].
 
 [Cloud Storage](https://cloud.google.com/storage/docs) allows world-wide
@@ -25,16 +18,8 @@ storage and retrieval of any amount of data at any time. You can use Google
 Cloud Storage for a range of scenarios including serving website content,
 storing data for archival and disaster recovery, or distributing large data
 objects to users via direct download.
->>>>>>> docs: playing with header
 
 
-<<<<<<< HEAD
-=======
-Cloud Storage Client Library for Node.js
-
->>>>>>> docs: new synthtool generated README
-* [Using the client library](#using-the-client-library)
-=======
 * [Google Cloud Storage Node.js Client API Reference][client-docs]
 * [Google Cloud Storage Documentation][product-docs]
 * [github.com/googleapis/nodejs-storage](https://github.com/googleapis/nodejs-storage)
@@ -51,7 +36,6 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
   * [Before you begin](#before-you-begin)
   * [Installing the client library](#installing-the-client-library)
   * [Using the client library](#using-the-client-library)
->>>>>>> chore: some additional tweaks to README generation
 * [Samples](#samples)
 * [Versioning](#versioning)
 * [Contributing](#contributing)
@@ -77,24 +61,25 @@ npm install @google-cloud/storage
 ### Using the client library
 
 ```javascript
-async function quickstart(
-  projectId = 'YOUR_PROJECT_ID', // Your Google Cloud Platform project ID
-  bucketName = 'my-new-bucket' // The name for the new bucket
-) {
   // Imports the Google Cloud client library
   const {Storage} = require('@google-cloud/storage');
 
   // Creates a client
-  const storage = new Storage({projectId});
+  const storage = new Storage();
 
-  // Creates the new bucket
-  await storage.createBucket(bucketName);
-  console.log(`Bucket ${bucketName} created.`);
-}
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const bucketName = 'bucket-name';
 
-// process.env.GOOGLE_APPLICATION_CREDENTIALS points to service account JSON.
-// process.env.GOOGLE_CLOUD_PROJECT points to your project in GCP.
-quickstart(process.env.GOOGLE_CLOUD_PROJECT)
+  async function createBucket() {
+    // Creates the new bucket
+    await storage.createBucket(bucketName);
+    console.log(`Bucket ${bucketName} created.`);
+  }
+
+  createBucket();
+
 ```
 
 
@@ -149,35 +134,7 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/nodejs-storage/blob/master/LICENSE)
 
-<<<<<<< HEAD
-## What's Next
-<<<<<<< HEAD
-
-* [Google Cloud Storage Documentation][product-docs]
-* [Google Cloud Storage Node.js Client API Reference][client-docs]
-* [github.com/googleapis/nodejs-storage](https://github.com/googleapis/nodejs-storage)
-
-Read more about the client libraries for Cloud APIs, including the older
-Google APIs Client Libraries, in [Client Libraries Explained][explained].
-
-[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
-
-=======
-
-* [Google Cloud Storage Documentation][product-docs]
-* [Google Cloud Storage Node.js Client API Reference][client-docs]
-* [github.com/googleapis/nodejs-storage](https://github.com/googleapis/nodejs-storage)
-
-Read more about the client libraries for Cloud APIs, including the older
-Google APIs Client Libraries, in [Client Libraries Explained][explained].
-
-[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
-
->>>>>>> docs: new synthtool generated README
-[client-docs]: https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/
-=======
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/storage/latest/
->>>>>>> chore: some additional tweaks to README generation
 [product-docs]: https://cloud.google.com/storage
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,9 @@
 {
+<<<<<<< HEAD
   "updateTime": "2019-03-27T11:27:46.413216Z",
+=======
+  "updateTime": "2019-03-26T20:24:16.137716Z",
+>>>>>>> docs: new synthtool generated README
   "sources": [
     {
       "template": {

--- a/synth.metadata
+++ b/synth.metadata
@@ -2,6 +2,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   "updateTime": "2019-03-27T11:27:46.413216Z",
 =======
   "updateTime": "2019-03-26T20:24:16.137716Z",
@@ -12,6 +13,9 @@
 =======
   "updateTime": "2019-03-27T00:59:47.165103Z",
 >>>>>>> chore: some additional tweaks to README generation
+=======
+  "updateTime": "2019-03-27T01:08:58.048137Z",
+>>>>>>> chore: slight tweak to make bucket name less confusing
   "sources": [
     {
       "template": {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,21 +1,5 @@
 {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-  "updateTime": "2019-03-27T11:27:46.413216Z",
-=======
-  "updateTime": "2019-03-26T20:24:16.137716Z",
->>>>>>> docs: new synthtool generated README
-=======
-  "updateTime": "2019-03-27T00:03:36.931729Z",
->>>>>>> docs: playing with header
-=======
-  "updateTime": "2019-03-27T00:59:47.165103Z",
->>>>>>> chore: some additional tweaks to README generation
-=======
-  "updateTime": "2019-03-27T01:08:58.048137Z",
->>>>>>> chore: slight tweak to make bucket name less confusing
+  "updateTime": "2019-03-27T23:29:22.642318Z",
   "sources": [
     {
       "template": {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,6 +1,7 @@
 {
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   "updateTime": "2019-03-27T11:27:46.413216Z",
 =======
   "updateTime": "2019-03-26T20:24:16.137716Z",
@@ -8,6 +9,9 @@
 =======
   "updateTime": "2019-03-27T00:03:36.931729Z",
 >>>>>>> docs: playing with header
+=======
+  "updateTime": "2019-03-27T00:59:47.165103Z",
+>>>>>>> chore: some additional tweaks to README generation
   "sources": [
     {
       "template": {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,9 +1,13 @@
 {
 <<<<<<< HEAD
+<<<<<<< HEAD
   "updateTime": "2019-03-27T11:27:46.413216Z",
 =======
   "updateTime": "2019-03-26T20:24:16.137716Z",
 >>>>>>> docs: new synthtool generated README
+=======
+  "updateTime": "2019-03-27T00:03:36.931729Z",
+>>>>>>> docs: playing with header
   "sources": [
     {
       "template": {


### PR DESCRIPTION
refs: https://github.com/googleapis/google-cloud-node/issues/2868 this PR regenerates our README using `synthtool` rather than node-repo-tools.

It seems to be most of the way there, one thing that does jump out at me is the description isn't nearly as fleshed out ... I wonder if this grew organically over time; any thoughts about how to auto-generate the README with up-to-date samples, while maintaining a more useful description?

@busunkim96 thanks for all your help on this!

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
