### PR TITLE
test(v2-sign): add multi-valued headers system-test

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2196,6 +2196,11 @@ class File extends ServiceObject<File> {
    *     for the requirements of this feature, most notably:
    *       - The header name must be prefixed with `x-goog-`
    *       - The header name must be all lowercase
+   *     Note: Multi-valued header passed as an array in the extensionHeaders
+   *           object is converted into a string, delimited by `,` with
+   *           no space. Requests made using the signed URL will need to
+   *           delimit multi-valued headers using a single `,` as well, or
+   *           else the server will report a mismatched signature.
    * @param {string} [config.promptSaveAs] The filename to prompt the user to
    *     save the file as when the signed url is accessed. This is ignored if
    *     `config.responseDisposition` is set.

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2842,6 +2842,23 @@ describe('storage', () => {
                 .catch(error => assert.ifError(error));
           });
     });
+
+    it('should work with multi-valued extension headers', async () => {
+      const HEADERS = {
+        'x-goog-custom-header': ['value1', 'value2'],
+      };
+      const [signedReadUrl] = await file.getSignedUrl({
+        action: 'read',
+        expires: Date.now() + 5000,
+        extensionHeaders: HEADERS,
+      });
+
+      const res = await fetch(signedReadUrl, {
+        headers: { 'x-goog-custom-header': 'value1,value2' },
+      });
+      const body = await res.text();
+      assert.strictEqual(body, localFile.toString());
+    })
   });
 
   describe('sign policy', () => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2854,11 +2854,11 @@ describe('storage', () => {
       });
 
       const res = await fetch(signedReadUrl, {
-        headers: { 'x-goog-custom-header': 'value1,value2' },
+        headers: {'x-goog-custom-header': 'value1,value2'},
       });
       const body = await res.text();
       assert.strictEqual(body, localFile.toString());
-    })
+    });
   });
 
   describe('sign policy', () => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2798,7 +2798,7 @@ describe('storage', () => {
     const localFile = fs.readFileSync(FILES.logo.path);
     let file: File;
 
-    before(done => {
+    beforeEach(done => {
       file = bucket.file('LogoToSign.jpg');
       fs.createReadStream(FILES.logo.path)
           .pipe(file.createWriteStream())


### PR DESCRIPTION
As discussed, we have been supporting multi-valued headers for v2 signing.

This PR added a system-test to verify the request header is signed assuming header values will be delimited by a single `,` with no spaces between values.

Also added a note in the jsdoc to inform users a request using the signed url must use the same delimiting scheme.