### PR TITLE
docs(samples): refactor the quickstart to match the new rubric

### DIFF
--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -15,22 +15,29 @@
 
 'use strict';
 
-// [START storage_quickstart]
-async function quickstart(
-  projectId = 'YOUR_PROJECT_ID', // Your Google Cloud Platform project ID
+function main(
   bucketName = 'my-new-bucket' // The name for the new bucket
 ) {
+  // [START storage_quickstart]
   // Imports the Google Cloud client library
   const {Storage} = require('@google-cloud/storage');
 
   // Creates a client
-  const storage = new Storage({projectId});
+  const storage = new Storage();
 
-  // Creates the new bucket
-  await storage.createBucket(bucketName);
-  console.log(`Bucket ${bucketName} created.`);
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const bucketName = 'bucket-name';
+
+  async function createBucket() {
+    // Creates the new bucket
+    await storage.createBucket(bucketName);
+    console.log(`Bucket ${bucketName} created.`);
+  }
+
+  createBucket();
+  // [END storage_quickstart]
 }
-// [END storage_quickstart]
 
-const args = process.argv.slice(2);
-quickstart(...args).catch(console.error);
+main(...process.argv.slice(2)).catch(console.error);

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -40,4 +40,4 @@ function main(
   // [END storage_quickstart]
 }
 
-main(...process.argv.slice(2)).catch(console.error);
+main(...process.argv.slice(2));

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -21,7 +21,6 @@ const uuid = require('uuid');
 const {Storage} = require('@google-cloud/storage');
 
 const storage = new Storage();
-const projectId = process.env.GCLOUD_PROJECT;
 const bucketName = `nodejs-storage-samples-${uuid.v4()}`;
 
 after(async () => {
@@ -30,8 +29,6 @@ after(async () => {
 });
 
 it('should run the quickstart', async () => {
-  const {stdout} = await execa.shell(
-    `node quickstart ${projectId} ${bucketName}`
-  );
+  const {stdout} = await execa.shell(`node quickstart ${bucketName}`);
   assert.match(stdout, /Bucket .* created./);
 });


### PR DESCRIPTION
This PR updates the quickstart sample to follow the new Node.js sample rubric:
- The projectId isn't explicitly used, so it's reference was dropped
- The region tag was moved inside of the `main` function
- Added a note asking the developer uncomment the bucketName
- Used an inner async function with the actual code

@bcoe this will fix the issue you had where you needed to add the footer thingy to synthtool. 
@jmdobry is the rubric published anywhere?

