### PR TITLE
chore(deps): upgrade to newest version of @google-cloud/common

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.31.0",
+    "@google-cloud/common": "^0.32.0",
     "@google-cloud/paginator": "^0.2.0",
     "@google-cloud/promisify": "^0.4.0",
     "arrify": "^1.0.0",
@@ -83,6 +83,7 @@
     "@types/mime-types": "^2.1.0",
     "@types/mocha": "^5.2.3",
     "@types/nock": "^9.3.0",
+    "@types/node": "11.12.4",
     "@types/node-fetch": "^2.1.3",
     "@types/once": "^1.4.0",
     "@types/proxyquire": "^1.3.28",
@@ -101,6 +102,7 @@
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.5.4",
     "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
+    "linkinator": "^1.1.2",
     "mocha": "^6.0.0",
     "nock": "^10.0.1",
     "node-fetch": "^2.2.0",
@@ -112,7 +114,6 @@
     "source-map-support": "^0.5.6",
     "tmp": "^0.1.0",
     "typescript": "~3.4.0",
-    "uuid": "^3.1.0",
-    "linkinator": "^1.1.2"
+    "uuid": "^3.1.0"
   }
 }

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -847,8 +847,7 @@ class Bucket extends ServiceObject {
       baseUrl: '/b',
       id: name,
       createMethod: storage.createBucket.bind(storage),
-      methods,
-      requestModule: teenyRequest as typeof request,
+      methods
     });
 
     this.name = name;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -55,8 +55,7 @@ class Channel extends ServiceObject {
 
       methods: {
           // Only need `request`.
-      },
-      requestModule: teenyRequest as typeof request,
+      }
     };
 
     super(config);

--- a/src/file.ts
+++ b/src/file.ts
@@ -20,7 +20,6 @@ import {promisifyAll} from '@google-cloud/promisify';
 import compressible = require('compressible');
 import concat = require('concat-stream');
 import * as crypto from 'crypto';
-import * as duplexify from 'duplexify';
 import * as extend from 'extend';
 import * as fs from 'fs';
 const hashStreamValidation = require('hash-stream-validation');
@@ -42,7 +41,8 @@ import {teenyRequest} from 'teeny-request';
 import {Storage} from './storage';
 import {Bucket} from './bucket';
 import {Acl} from './acl';
-import {ResponseBody, ApiError} from '@google-cloud/common/build/src/util';
+import {ResponseBody, ApiError, Duplexify, DuplexifyConstructor} from '@google-cloud/common/build/src/util';
+const duplexify: DuplexifyConstructor = require('duplexify');
 import {normalize} from './util';
 
 export type GetExpirationDateResponse = [Date];
@@ -728,7 +728,6 @@ class File extends ServiceObject<File> {
       parent: bucket,
       baseUrl: '/o',
       id: encodeURIComponent(name),
-      requestModule: teenyRequest as typeof r,
       methods,
     });
 
@@ -2917,7 +2916,7 @@ class File extends ServiceObject<File> {
    * @private
    */
   startResumableUpload_(
-      dup: duplexify.Duplexify, options: CreateResumableUploadOptions): void {
+      dup: Duplexify, options: CreateResumableUploadOptions): void {
     options = Object.assign(
         {
           metadata: {},
@@ -2967,7 +2966,7 @@ class File extends ServiceObject<File> {
    * @private
    */
   startSimpleUpload_(
-      dup: duplexify.Duplexify, options?: CreateResumableUploadOptions): void {
+      dup: Duplexify, options?: CreateResumableUploadOptions): void {
     options = Object.assign(
         {
           metadata: {},
@@ -3002,7 +3001,7 @@ class File extends ServiceObject<File> {
     }
 
     util.makeWritableStream(dup, {
-      makeAuthenticatedRequest: reqOpts => {
+      makeAuthenticatedRequest: (reqOpts: object) => {
         this.request(reqOpts as DecorateRequestOptions, (err, body, resp) => {
           if (err) {
             dup.destroy(err);
@@ -3015,8 +3014,7 @@ class File extends ServiceObject<File> {
         });
       },
       metadata: options.metadata,
-      request: reqOpts,
-      requestModule: teenyRequest as typeof r,
+      request: reqOpts
     });
   }
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -2915,8 +2915,8 @@ class File extends ServiceObject<File> {
    *
    * @private
    */
-  startResumableUpload_(
-      dup: Duplexify, options: CreateResumableUploadOptions): void {
+  startResumableUpload_(dup: Duplexify, options: CreateResumableUploadOptions):
+      void {
     options = Object.assign(
         {
           metadata: {},
@@ -2965,8 +2965,8 @@ class File extends ServiceObject<File> {
    *
    * @private
    */
-  startSimpleUpload_(
-      dup: Duplexify, options?: CreateResumableUploadOptions): void {
+  startSimpleUpload_(dup: Duplexify, options?: CreateResumableUploadOptions):
+      void {
     options = Object.assign(
         {
           metadata: {},

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -192,8 +192,7 @@ class Notification extends ServiceObject {
       baseUrl: '/notificationConfigs',
       id: id.toString(),
       createMethod: bucket.createNotification.bind(bucket),
-      methods,
-      requestModule: teenyRequest as typeof request,
+      methods
     });
   }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -287,8 +287,7 @@ export class Storage extends Service {
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/devstorage.full_control',
       ],
-      packageJson: require('../../package.json'),
-      requestModule: teenyRequest as typeof r,
+      packageJson: require('../../package.json')
     };
 
     super(config, options);


### PR DESCRIPTION
With the goal of getting master passing, pulls in `@types/node@11.12.4`, as `11.13.0` is currently breaking the build.

This PR brings in this [breaking change](https://github.com/googleapis/nodejs-common/pull/394) which retires the configurable request object (unfortunately this didn't address the error on `master`, because other dependencies brought in `@types/node@11.13.0`.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
