### PR TITLE
fix(ts): improve return types for response metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,9 @@
   "scripts": {
     "predocs": "npm run compile",
     "docs": "jsdoc -c .jsdoc.js",
-    "system-test": "mocha build/system-test --timeout 600000 && npm run conformance-test",
+    "system-test": "mocha build/system-test --timeout 600000",
     "conformance-test": "mocha build/conformance-test",
     "preconformance-test": "npm run compile",
-    "system-test": "mocha build/system-test --timeout 600000",
     "presystem-test": "npm run compile",
     "test": "nyc mocha build/test",
     "pretest": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "pumpify": "^1.5.1",
     "snakeize": "^0.1.0",
     "stream-events": "^1.0.1",
-    "teeny-request": "^3.11.3",
     "through2": "^3.0.0",
     "xdg-basedir": "^3.0.0"
   },
@@ -90,7 +89,6 @@
     "@types/node-fetch": "^2.1.3",
     "@types/proxyquire": "^1.3.28",
     "@types/pumpify": "^1.4.1",
-    "@types/request": "^2.47.1",
     "@types/sinon": "^7.0.10",
     "@types/through2": "^2.0.33",
     "@types/tmp": "0.1.0",

--- a/samples/system-test/test_87aec0b9-4a52-44dc-9ab7-522c4dbf8895.txt
+++ b/samples/system-test/test_87aec0b9-4a52-44dc-9ab7-522c4dbf8895.txt
@@ -1,1 +1,0 @@
-Hello World!

--- a/samples/system-test/test_87aec0b9-4a52-44dc-9ab7-522c4dbf8895.txt
+++ b/samples/system-test/test_87aec0b9-4a52-44dc-9ab7-522c4dbf8895.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {BodyResponseCallback, DecorateRequestOptions} from '@google-cloud/common';
+import {BodyResponseCallback, DecorateRequestOptions, Metadata} from '@google-cloud/common';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
-import * as r from 'request';
 
 export interface AclOptions {
   pathPrefix: string;
@@ -26,10 +25,10 @@ export interface AclOptions {
 }
 
 export type GetAclResponse =
-    [AccessControlObject | AccessControlObject[], r.Response];
+    [AccessControlObject | AccessControlObject[], Metadata];
 export interface GetAclCallback {
   (err: Error|null, acl?: AccessControlObject|AccessControlObject[]|null,
-   apiResponse?: r.Response): void;
+   apiResponse?: Metadata): void;
 }
 export interface GetAclOptions {
   entity: string;
@@ -43,10 +42,10 @@ export interface UpdateAclOptions {
   generation?: number;
   userProject?: string;
 }
-export type UpdateAclResponse = [AccessControlObject, r.Response];
+export type UpdateAclResponse = [AccessControlObject, Metadata];
 export interface UpdateAclCallback {
   (err: Error|null, acl?: AccessControlObject|null,
-   apiResponse?: r.Response): void;
+   apiResponse?: Metadata): void;
 }
 
 export interface AddAclOptions {
@@ -55,14 +54,14 @@ export interface AddAclOptions {
   generation?: number;
   userProject?: string;
 }
-export type AddAclResponse = [AccessControlObject, r.Response];
+export type AddAclResponse = [AccessControlObject, Metadata];
 export interface AddAclCallback {
   (err: Error|null, acl?: AccessControlObject|null,
-   apiResponse?: r.Response): void;
+   apiResponse?: Metadata): void;
 }
-export type RemoveAclResponse = [r.Response];
+export type RemoveAclResponse = [Metadata];
 export interface RemoveAclCallback {
-  (err: Error|null, apiResponse?: r.Response): void;
+  (err: Error|null, apiResponse?: Metadata): void;
 }
 export interface RemoveAclOptions {
   entity: string;

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -25,8 +25,6 @@ import * as mime from 'mime-types';
 import * as path from 'path';
 
 const snakeize = require('snakeize');
-import * as request from 'request';  // Only for type declarations.
-import {teenyRequest} from 'teeny-request';
 
 import {Acl, AddAclCallback} from './acl';
 import {Channel} from './channel';
@@ -55,7 +53,7 @@ interface BucketOptions {
 
 export interface GetFilesCallback {
   (err: Error|null, files?: File[], nextQuery?: {},
-   apiResponse?: request.Response): void;
+   apiResponse?: Metadata): void;
 }
 
 interface WatchAllOptions {
@@ -96,10 +94,10 @@ export interface CombineOptions {
 }
 
 export interface CombineCallback {
-  (err: Error|null, newFile: File|null, apiResponse: request.Response): void;
+  (err: Error|null, newFile: File|null, apiResponse: Metadata): void;
 }
 
-export type CombineResponse = [File, request.Response];
+export type CombineResponse = [File, Metadata];
 
 export interface CreateChannelConfig extends WatchAllOptions {
   address: string;
@@ -109,10 +107,10 @@ export interface CreateChannelOptions {
   userProject?: string;
 }
 
-export type CreateChannelResponse = [Channel, request.Response];
+export type CreateChannelResponse = [Channel, Metadata];
 
 export interface CreateChannelCallback {
-  (err: Error|null, channel: Channel|null, apiResponse: request.Response): void;
+  (err: Error|null, channel: Channel|null, apiResponse: Metadata): void;
 }
 
 export interface CreateNotificationOptions {
@@ -125,19 +123,19 @@ export interface CreateNotificationOptions {
 
 export interface CreateNotificationCallback {
   (err: Error|null, notification: Notification|null,
-   apiResponse: request.Response): void;
+   apiResponse: Metadata): void;
 }
 
-export type CreateNotificationResponse = [Notification, request.Response];
+export type CreateNotificationResponse = [Notification, Metadata];
 
 export interface DeleteBucketOptions {
   userProject?: string;
 }
 
-export type DeleteBucketResponse = [request.Response];
+export type DeleteBucketResponse = [Metadata];
 
 export interface DeleteBucketCallback extends DeleteCallback {
-  (err: Error|null, apiResponse: request.Response): void;
+  (err: Error|null, apiResponse: Metadata): void;
 }
 
 export interface DeleteFilesOptions extends GetFilesOptions {
@@ -148,20 +146,20 @@ export interface DeleteFilesCallback {
   (err: Error|Error[]|null, apiResponse?: object): void;
 }
 
-export type DeleteLabelsResponse = [request.Response];
+export type DeleteLabelsResponse = [Metadata];
 
 export interface DeleteLabelsCallback extends SetLabelsCallback {}
 
-export type DisableRequesterPaysResponse = [request.Response];
+export type DisableRequesterPaysResponse = [Metadata];
 
 export interface DisableRequesterPaysCallback {
   (err?: Error|null, apiResponse?: object): void;
 }
 
-export type EnableRequesterPaysResponse = [request.Response];
+export type EnableRequesterPaysResponse = [Metadata];
 
 export interface EnableRequesterPaysCallback {
-  (err?: Error|null, apiResponse?: request.Response): void;
+  (err?: Error|null, apiResponse?: Metadata): void;
 }
 
 export interface BucketExistsOptions extends GetConfig {
@@ -176,28 +174,28 @@ export interface GetBucketOptions extends GetConfig {
   userProject?: string;
 }
 
-export type GetBucketResponse = [Bucket, request.Response];
+export type GetBucketResponse = [Bucket, Metadata];
 
 export interface GetBucketCallback {
   (err: ApiError|null, bucket: Bucket|null,
-   apiResponse: request.Response): void;
+   apiResponse: Metadata): void;
 }
 
 export interface GetLabelsOptions {
   userProject?: string;
 }
 
-export type GetLabelsResponse = [request.Response];
+export type GetLabelsResponse = [Metadata];
 
 export interface GetLabelsCallback {
   (err: Error|null, labels: object|null): void;
 }
 
-export type GetBucketMetadataResponse = [Metadata, request.Response];
+export type GetBucketMetadataResponse = [Metadata, Metadata];
 
 export interface GetBucketMetadataCallback {
   (err: ApiError|null, metadata: Metadata|null,
-   apiResponse: request.Response): void;
+   apiResponse: Metadata): void;
 }
 
 export interface GetBucketMetadataOptions {
@@ -210,10 +208,10 @@ export interface GetNotificationsOptions {
 
 export interface GetNotificationsCallback {
   (err: Error|null, notifications: Notification[]|null,
-   apiResponse: request.Response): void;
+   apiResponse: Metadata): void;
 }
 
-export type GetNotificationsResponse = [Notification[], request.Response];
+export type GetNotificationsResponse = [Notification[], Metadata];
 
 export interface MakeBucketPrivateOptions {
   includeFiles?: boolean;
@@ -246,17 +244,17 @@ export interface SetBucketMetadataOptions {
   userProject?: string;
 }
 
-export type SetBucketMetadataResponse = [request.Response];
+export type SetBucketMetadataResponse = [Metadata];
 
 export interface SetBucketMetadataCallback {
   (err?: Error|null, metadata?: Metadata): void;
 }
 
 export interface BucketLockCallback {
-  (err?: Error|null, apiResponse?: request.Response): void;
+  (err?: Error|null, apiResponse?: Metadata): void;
 }
 
-export type BucketLockResponse = [request.Response];
+export type BucketLockResponse = [Metadata];
 
 export type Labels = {
   [key: string]: string;
@@ -266,7 +264,7 @@ export interface SetLabelsOptions {
   userProject?: string;
 }
 
-export type SetLabelsResponse = [request.Response];
+export type SetLabelsResponse = [Metadata];
 
 export interface SetLabelsCallback {
   (err?: Error|null, metadata?: Metadata): void;
@@ -280,10 +278,10 @@ export interface SetBucketStorageClassCallback {
   (err?: Error|null): void;
 }
 
-export type UploadResponse = [File, request.Response];
+export type UploadResponse = [File, Metadata];
 
 export interface UploadCallback {
-  (err: Error|null, file?: File|null, apiResponse?: request.Response): void;
+  (err: Error|null, file?: File|null, apiResponse?: Metadata): void;
 }
 
 export interface UploadOptions extends CreateResumableUploadOptions,
@@ -2518,7 +2516,7 @@ class Bucket extends ServiceObject {
   }
 
   request(reqOpts: DecorateRequestOptions):
-      Promise<[ResponseBody, request.Response]>;
+      Promise<[ResponseBody, Metadata]>;
   request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
       void;
   /**
@@ -2530,7 +2528,7 @@ class Bucket extends ServiceObject {
    * @param {function} callback - The callback function.
    */
   request(reqOpts: DecorateRequestOptions, callback?: BodyResponseCallback):
-      void|Promise<[ResponseBody, request.Response]> {
+      void|Promise<[ResponseBody, Metadata]> {
     if (this.userProject && (!reqOpts.qs || !reqOpts.qs.userProject)) {
       reqOpts.qs = extend(reqOpts.qs, {userProject: this.userProject});
     }

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -177,8 +177,7 @@ export interface GetBucketOptions extends GetConfig {
 export type GetBucketResponse = [Bucket, Metadata];
 
 export interface GetBucketCallback {
-  (err: ApiError|null, bucket: Bucket|null,
-   apiResponse: Metadata): void;
+  (err: ApiError|null, bucket: Bucket|null, apiResponse: Metadata): void;
 }
 
 export interface GetLabelsOptions {
@@ -194,8 +193,7 @@ export interface GetLabelsCallback {
 export type GetBucketMetadataResponse = [Metadata, Metadata];
 
 export interface GetBucketMetadataCallback {
-  (err: ApiError|null, metadata: Metadata|null,
-   apiResponse: Metadata): void;
+  (err: ApiError|null, metadata: Metadata|null, apiResponse: Metadata): void;
 }
 
 export interface GetBucketMetadataOptions {
@@ -2515,8 +2513,7 @@ class Bucket extends ServiceObject {
         callback!);
   }
 
-  request(reqOpts: DecorateRequestOptions):
-      Promise<[ResponseBody, Metadata]>;
+  request(reqOpts: DecorateRequestOptions): Promise<[ResponseBody, Metadata]>;
   request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
       void;
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-import {ServiceObject, util} from '@google-cloud/common';
+import {ServiceObject, util, Metadata} from '@google-cloud/common';
 import {promisifyAll} from '@google-cloud/promisify';
-import * as request from 'request';  // Only for type declarations.
-import {Response} from 'request';
-import {teenyRequest} from 'teeny-request';
 
 import {Storage} from './storage';
 
 export interface StopCallback {
-  (err: Error|null, apiResponse?: request.Response): void;
+  (err: Error|null, apiResponse?: Metadata): void;
 }
 
 
@@ -67,7 +64,7 @@ class Channel extends ServiceObject {
     metadata.resourceId = resourceId;
   }
 
-  stop(): Promise<Response>;
+  stop(): Promise<Metadata>;
   stop(callback: StopCallback): void;
   /**
    * @typedef {array} StopResponse
@@ -101,7 +98,7 @@ class Channel extends ServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  stop(callback?: StopCallback): Promise<Response>|void {
+  stop(callback?: StopCallback): Promise<Metadata>|void {
     callback = callback || util.noop;
     this.request(
         {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ServiceObject, util, Metadata} from '@google-cloud/common';
+import {Metadata, ServiceObject, util} from '@google-cloud/common';
 import {promisifyAll} from '@google-cloud/promisify';
 
 import {Storage} from './storage';

--- a/src/file.ts
+++ b/src/file.ts
@@ -37,7 +37,6 @@ import * as querystring from 'querystring';
 import * as zlib from 'zlib';
 import * as url from 'url';
 import * as http from 'http';
-import * as r from 'request';  // Only for type declarations.
 
 import {Storage} from './storage';
 import {Bucket} from './bucket';
@@ -45,10 +44,11 @@ import {Acl} from './acl';
 import {ResponseBody, ApiError, Duplexify, DuplexifyConstructor} from '@google-cloud/common/build/src/util';
 const duplexify: DuplexifyConstructor = require('duplexify');
 import {normalize, objectEntries} from './util';
+import { Headers } from 'gaxios';
 
 export type GetExpirationDateResponse = [Date];
 export interface GetExpirationDateCallback {
-  (err: Error|null, expirationDate?: Date|null, apiResponse?: r.Response): void;
+  (err: Error|null, expirationDate?: Date|null, apiResponse?: Metadata): void;
 }
 
 export interface GetSignedUrlConfig {
@@ -117,20 +117,20 @@ export interface GetFileMetadataOptions {
   userProject?: string;
 }
 
-export type GetFileMetadataResponse = [Metadata, r.Response];
+export type GetFileMetadataResponse = [Metadata, Metadata];
 
 export interface GetFileMetadataCallback {
-  (err: Error|null, metadata?: Metadata, apiResponse?: r.Response): void;
+  (err: Error|null, metadata?: Metadata, apiResponse?: Metadata): void;
 }
 
 export interface GetFileOptions extends GetConfig {
   userProject?: string;
 }
 
-export type GetFileResponse = [File, r.Response];
+export type GetFileResponse = [File, Metadata];
 
 export interface GetFileCallback {
-  (err: Error|null, file?: File, apiResponse?: r.Response): void;
+  (err: Error|null, file?: File, apiResponse?: Metadata): void;
 }
 
 export interface FileExistsOptions {
@@ -147,10 +147,10 @@ export interface DeleteFileOptions {
   userProject?: string;
 }
 
-export type DeleteFileResponse = [r.Response];
+export type DeleteFileResponse = [Metadata];
 
 export interface DeleteFileCallback {
-  (err: Error|null, apiResponse?: r.Response): void;
+  (err: Error|null, apiResponse?: Metadata): void;
 }
 
 export type PredefinedAcl = 'authenticatedRead'|'bucketOwnerFullControl'|
@@ -185,21 +185,21 @@ export interface MakeFilePrivateOptions {
   userProject?: string;
 }
 
-export type MakeFilePrivateResponse = [r.Response];
+export type MakeFilePrivateResponse = [Metadata];
 
 export interface MakeFilePrivateCallback extends SetFileMetadataCallback {}
 
-export type MakeFilePublicResponse = [r.Response];
+export type MakeFilePublicResponse = [Metadata];
 
 export interface MakeFilePublicCallback {
-  (err?: Error|null, apiResponse?: r.Response): void;
+  (err?: Error|null, apiResponse?: Metadata): void;
 }
 
-export type MoveResponse = [r.Response];
+export type MoveResponse = [Metadata];
 
 export interface MoveCallback {
   (err: Error|null, destinationFile?: File|null,
-   apiResponse?: r.Response): void;
+   apiResponse?: Metadata): void;
 }
 
 export interface MoveOptions {
@@ -269,10 +269,10 @@ export interface CopyOptions {
   userProject?: string;
 }
 
-export type CopyResponse = [File, r.Response];
+export type CopyResponse = [File, Metadata];
 
 export interface CopyCallback {
-  (err: Error|null, file?: File|null, apiResponse?: r.Response): void;
+  (err: Error|null, file?: File|null, apiResponse?: Metadata): void;
 }
 
 export type DownloadResponse = [Buffer];
@@ -339,12 +339,12 @@ export interface SetFileMetadataOptions {
 }
 
 export interface SetFileMetadataCallback {
-  (err?: Error|null, apiResponse?: r.Response): void;
+  (err?: Error|null, apiResponse?: Metadata): void;
 }
 
-export type SetFileMetadataResponse = [r.Response];
+export type SetFileMetadataResponse = [Metadata];
 
-export type SetStorageClassResponse = [r.Response];
+export type SetStorageClassResponse = [Metadata];
 
 export interface SetStorageClassOptions {
   userProject?: string;
@@ -355,7 +355,7 @@ interface SetStorageClassRequest extends SetStorageClassOptions {
 }
 
 export interface SetStorageClassCallback {
-  (err?: Error|null, apiResponse?: r.Response): void;
+  (err?: Error|null, apiResponse?: Metadata): void;
 }
 
 class RequestError extends Error {
@@ -1196,7 +1196,7 @@ class File extends ServiceObject<File> {
       const headers = {
         'Accept-Encoding': 'gzip',
         'Cache-Control': 'no-store'
-      } as r.Headers;
+      } as Headers;
 
       if (rangeRequest) {
         const start = typeof options.start === 'number' ? options.start : '0';
@@ -1237,7 +1237,7 @@ class File extends ServiceObject<File> {
       //      applicable, to the user.
       const onResponse =
           (err: Error|null, body: ResponseBody,
-           rawResponseStream: r.Response) => {
+           rawResponseStream: Metadata) => {
             if (err) {
               // Get error message from the body.
               rawResponseStream.pipe(concat(body => {
@@ -1974,7 +1974,7 @@ class File extends ServiceObject<File> {
   getExpirationDate(callback?: GetExpirationDateCallback):
       void|Promise<GetExpirationDateResponse> {
     this.getMetadata(
-        (err: ApiError|null, metadata: Metadata, apiResponse: r.Response) => {
+        (err: ApiError|null, metadata: Metadata, apiResponse: Metadata) => {
           if (err) {
             callback!(err, null, apiResponse);
             return;
@@ -2804,7 +2804,7 @@ class File extends ServiceObject<File> {
     });
   }
 
-  request(reqOpts: DecorateRequestOptions): Promise<[ResponseBody, r.Response]>;
+  request(reqOpts: DecorateRequestOptions): Promise<[ResponseBody, Metadata]>;
   request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
       void;
   /**
@@ -2816,7 +2816,7 @@ class File extends ServiceObject<File> {
    * @param {function} callback - The callback function.
    */
   request(reqOpts: DecorateRequestOptions, callback?: BodyResponseCallback):
-      void|Promise<[ResponseBody, r.Response]> {
+      void|Promise<[ResponseBody, Metadata]> {
     return this.parent.request.call(this, reqOpts, callback!);
   }
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -44,7 +44,7 @@ import {Acl} from './acl';
 import {ResponseBody, ApiError, Duplexify, DuplexifyConstructor} from '@google-cloud/common/build/src/util';
 const duplexify: DuplexifyConstructor = require('duplexify');
 import {normalize, objectEntries} from './util';
-import { Headers } from 'gaxios';
+import {Headers} from 'gaxios';
 
 export type GetExpirationDateResponse = [Date];
 export interface GetExpirationDateCallback {
@@ -198,8 +198,7 @@ export interface MakeFilePublicCallback {
 export type MoveResponse = [Metadata];
 
 export interface MoveCallback {
-  (err: Error|null, destinationFile?: File|null,
-   apiResponse?: Metadata): void;
+  (err: Error|null, destinationFile?: File|null, apiResponse?: Metadata): void;
 }
 
 export interface MoveOptions {

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {BodyResponseCallback, DecorateRequestOptions} from '@google-cloud/common';
+import {BodyResponseCallback, DecorateRequestOptions, Metadata} from '@google-cloud/common';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
-import * as r from 'request';
 
 import {Bucket} from './bucket';
 import {normalize} from './util';
@@ -36,7 +35,7 @@ export interface GetPolicyOptions {
  * @property {object} 0 The policy.
  * @property {object} 1 The full API response.
  */
-export type GetPolicyResponse = [Policy, r.Response];
+export type GetPolicyResponse = [Policy, Metadata];
 
 /**
  * @callback GetPolicyCallback
@@ -45,7 +44,7 @@ export type GetPolicyResponse = [Policy, r.Response];
  * @param {object} apiResponse The full API response.
  */
 export interface GetPolicyCallback {
-  (err?: Error|null, acl?: Policy, apiResponse?: r.Response): void;
+  (err?: Error|null, acl?: Policy, apiResponse?: Metadata): void;
 }
 
 /**
@@ -62,7 +61,7 @@ export interface SetPolicyOptions {
  * @property {object} 0 The policy.
  * @property {object} 1 The full API response.
  */
-export type SetPolicyResponse = [Policy, r.Response];
+export type SetPolicyResponse = [Policy, Metadata];
 
 /**
  * @callback SetPolicyCallback
@@ -94,7 +93,7 @@ export interface PolicyBinding {
  * @property {object} 0 A subset of permissions that the caller is allowed.
  * @property {object} 1 The full API response.
  */
-export type TestIamPermissionsResponse = [{[key: string]: boolean}, r.Response];
+export type TestIamPermissionsResponse = [{[key: string]: boolean}, Metadata];
 
 /**
  * @callback TestIamPermissionsCallback
@@ -104,7 +103,7 @@ export type TestIamPermissionsResponse = [{[key: string]: boolean}, r.Response];
  */
 export interface TestIamPermissionsCallback {
   (err?: Error|null, acl?: {[key: string]: boolean}|null,
-   apiResponse?: r.Response): void;
+   apiResponse?: Metadata): void;
 }
 
 /**

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ApiError, MetadataCallback, ServiceObject, util, Metadata} from '@google-cloud/common';
+import {ApiError, Metadata, MetadataCallback, ServiceObject, util} from '@google-cloud/common';
 import {ResponseBody} from '@google-cloud/common/build/src/util';
 import {promisifyAll} from '@google-cloud/promisify';
 
@@ -42,8 +42,7 @@ export type GetNotificationMetadataResponse = [ResponseBody, Metadata];
  * @param {object} apiResponse The full API response.
  */
 export interface GetNotificationMetadataCallback {
-  (err: Error|null, metadata?: ResponseBody,
-   apiResponse?: Metadata): void;
+  (err: Error|null, metadata?: ResponseBody, apiResponse?: Metadata): void;
 }
 
 /**

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import {ApiError, MetadataCallback, ServiceObject, util} from '@google-cloud/common';
+import {ApiError, MetadataCallback, ServiceObject, util, Metadata} from '@google-cloud/common';
 import {ResponseBody} from '@google-cloud/common/build/src/util';
 import {promisifyAll} from '@google-cloud/promisify';
-import * as request from 'request';  // Only for type declarations.
-import {teenyRequest} from 'teeny-request';
 
 import {Bucket} from './bucket';
 
@@ -35,7 +33,7 @@ export interface GetNotificationMetadataOptions {
  * @property {object} 0 The notification metadata.
  * @property {object} 1 The full API response.
  */
-export type GetNotificationMetadataResponse = [ResponseBody, request.Response];
+export type GetNotificationMetadataResponse = [ResponseBody, Metadata];
 
 /**
  * @callback GetNotificationMetadataCallback
@@ -45,7 +43,7 @@ export type GetNotificationMetadataResponse = [ResponseBody, request.Response];
  */
 export interface GetNotificationMetadataCallback {
   (err: Error|null, metadata?: ResponseBody,
-   apiResponse?: request.Response): void;
+   apiResponse?: Metadata): void;
 }
 
 /**
@@ -53,7 +51,7 @@ export interface GetNotificationMetadataCallback {
  * @property {Notification} 0 The {@link Notification}
  * @property {object} 1 The full API response.
  */
-export type GetNotificationResponse = [Notification, request.Response];
+export type GetNotificationResponse = [Notification, Metadata];
 
 export interface GetNotificationOptions {
   /**
@@ -75,7 +73,7 @@ export interface GetNotificationOptions {
  */
 export interface GetNotificationCallback {
   (err: Error|null, notification?: Notification|null,
-   apiResponse?: request.Response): void;
+   apiResponse?: Metadata): void;
 }
 
 /**
@@ -84,7 +82,7 @@ export interface GetNotificationCallback {
  * @param {object} apiResponse The full API response.
  */
 export interface DeleteNotificationCallback {
-  (err: Error|null, apiResponse?: request.Response): void;
+  (err: Error|null, apiResponse?: Metadata): void;
 }
 
 
@@ -196,7 +194,7 @@ class Notification extends ServiceObject {
     });
   }
 
-  delete(options?: DeleteNotificationOptions): Promise<[request.Response]>;
+  delete(options?: DeleteNotificationOptions): Promise<[Metadata]>;
   delete(
       options: DeleteNotificationOptions,
       callback: DeleteNotificationCallback): void;
@@ -237,7 +235,7 @@ class Notification extends ServiceObject {
    */
   delete(
       optionsOrCallback?: DeleteNotificationOptions|DeleteNotificationCallback,
-      callback?: DeleteNotificationCallback): void|Promise<[request.Response]> {
+      callback?: DeleteNotificationCallback): void|Promise<[Metadata]> {
     const options =
         typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
     callback =
@@ -299,7 +297,7 @@ class Notification extends ServiceObject {
 
     const onCreate =
         (err: ApiError|null, notification: Notification,
-         apiResponse: request.Response) => {
+         apiResponse: Metadata) => {
           if (err) {
             if (err.code === 409) {
               this.get(options, callback!);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-import {GoogleAuthOptions, Service} from '@google-cloud/common';
+import {GoogleAuthOptions, Service, Metadata} from '@google-cloud/common';
 import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
-import * as r from 'request';  // Only for type declarations.
 import {Readable} from 'stream';
-import {teenyRequest} from 'teeny-request';
 
 import {Bucket} from './bucket';
 import {Channel} from './channel';
@@ -33,10 +31,10 @@ export interface GetServiceAccountOptions {
 export interface ServiceAccount {
   emailAddress?: string;
 }
-export type GetServiceAccountResponse = [ServiceAccount, r.Response];
+export type GetServiceAccountResponse = [ServiceAccount, Metadata];
 export interface GetServiceAccountCallback {
   (err: Error|null, serviceAccount?: ServiceAccount,
-   apiResponse?: r.Response): void;
+   apiResponse?: Metadata): void;
 }
 
 export interface CreateBucketQuery {
@@ -67,10 +65,10 @@ export interface CreateBucketRequest {
   location?: string;
 }
 
-export type CreateBucketResponse = [Bucket, r.Response];
+export type CreateBucketResponse = [Bucket, Metadata];
 
 export interface BucketCallback {
-  (err: Error|null, bucket?: Bucket|null, apiResponse?: r.Response): void;
+  (err: Error|null, bucket?: Bucket|null, apiResponse?: Metadata): void;
 }
 
 export type GetBucketsResponse = [Bucket[]];

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import {GoogleAuthOptions, Service, Metadata} from '@google-cloud/common';
+import {GoogleAuthOptions, Metadata, Service} from '@google-cloud/common';
 import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
+
 import arrify = require('arrify');
 import {Readable} from 'stream';
 

--- a/test/acl.ts
+++ b/test/acl.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import {DecorateRequestOptions, util} from '@google-cloud/common';
+import {DecorateRequestOptions, util, Metadata} from '@google-cloud/common';
 import * as assert from 'assert';
 import * as async from 'async';
 import * as proxyquire from 'proxyquire';
-import * as r from 'request';
 
 // tslint:disable-next-line:variable-name no-any
 let Acl: any;
@@ -88,7 +87,7 @@ describe('storage/acl', () => {
         generation: 8,
       };
 
-      acl.request = (reqOpts: r.Options) => {
+      acl.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts.qs.generation, options.generation);
         done();
       };
@@ -103,7 +102,7 @@ describe('storage/acl', () => {
         userProject: 'grape-spaceship-123',
       };
 
-      acl.request = (reqOpts: r.Options) => {
+      acl.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -151,7 +150,7 @@ describe('storage/acl', () => {
 
       acl.add(
           {entity: ENTITY, role: ROLE},
-          (err: Error, acls: {}, apiResponse: r.Response) => {
+          (err: Error, acls: {}, apiResponse: Metadata) => {
             assert.deepStrictEqual(resp, apiResponse);
             done();
           });
@@ -176,7 +175,7 @@ describe('storage/acl', () => {
         generation: 8,
       };
 
-      acl.request = (reqOpts: r.Options) => {
+      acl.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts.qs.generation, options.generation);
         done();
       };
@@ -191,7 +190,7 @@ describe('storage/acl', () => {
         userProject: 'grape-spaceship-123',
       };
 
-      acl.request = (reqOpts: r.Options) => {
+      acl.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -217,7 +216,7 @@ describe('storage/acl', () => {
         callback(null, resp);
       };
 
-      acl.delete({entity: ENTITY}, (err: Error, apiResponse: r.Response) => {
+      acl.delete({entity: ENTITY}, (err: Error, apiResponse: Metadata) => {
         assert.deepStrictEqual(resp, apiResponse);
         done();
       });
@@ -239,7 +238,7 @@ describe('storage/acl', () => {
       it('should accept a configuration object', done => {
         const generation = 1;
 
-        acl.request = (reqOpts: r.Options) => {
+        acl.request = (reqOpts: DecorateRequestOptions) => {
           assert.strictEqual(reqOpts.qs.generation, generation);
 
           done();
@@ -293,7 +292,7 @@ describe('storage/acl', () => {
       it('should accept a configuration object', done => {
         const generation = 1;
 
-        acl.request = (reqOpts: r.Options) => {
+        acl.request = (reqOpts: DecorateRequestOptions) => {
           assert.strictEqual(reqOpts.qs.generation, generation);
 
           done();
@@ -308,7 +307,7 @@ describe('storage/acl', () => {
           userProject: 'grape-spaceship-123',
         };
 
-        acl.request = (reqOpts: r.Options) => {
+        acl.request = (reqOpts: DecorateRequestOptions) => {
           assert.strictEqual(reqOpts.qs.userProject, options.userProject);
           done();
         };
@@ -354,7 +353,7 @@ describe('storage/acl', () => {
         callback(null, resp);
       };
 
-      acl.get((err: Error, acls: Array<{}>, apiResponse: r.Response) => {
+      acl.get((err: Error, acls: Array<{}>, apiResponse: Metadata) => {
         assert.deepStrictEqual(resp, apiResponse);
         done();
       });
@@ -381,7 +380,7 @@ describe('storage/acl', () => {
         generation: 8,
       };
 
-      acl.request = (reqOpts: r.Options) => {
+      acl.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts.qs.generation, options.generation);
         done();
       };
@@ -396,7 +395,7 @@ describe('storage/acl', () => {
         userProject: 'grape-spaceship-123',
       };
 
-      acl.request = (reqOpts: r.Options) => {
+      acl.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts.qs.userProject, options.userProject);
         done();
       };
@@ -443,7 +442,7 @@ describe('storage/acl', () => {
 
       const config = {entity: ENTITY, role: ROLE};
       acl.update(
-          config, (err: Error, acls: Array<{}>, apiResponse: r.Response) => {
+          config, (err: Error, acls: Array<{}>, apiResponse: Metadata) => {
             assert.deepStrictEqual(resp, apiResponse);
             done();
           });

--- a/test/acl.ts
+++ b/test/acl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {DecorateRequestOptions, util, Metadata} from '@google-cloud/common';
+import {DecorateRequestOptions, Metadata, util} from '@google-cloud/common';
 import * as assert from 'assert';
 import * as async from 'async';
 import * as proxyquire from 'proxyquire';

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -28,7 +28,6 @@ import * as through from 'through2';
 import {Bucket, Channel, Notification} from '../src';
 import {CreateWriteStreamOptions, File, SetFileMetadataOptions, FileOptions} from '../src/file';
 import {PromisifyAllOptions} from '@google-cloud/promisify';
-import * as r from 'request';
 import {GetBucketMetadataCallback, GetFilesOptions, MakeAllFilesPublicPrivateOptions, SetBucketMetadataCallback} from '../src/bucket';
 import {AddAclOptions} from '../src/acl';
 
@@ -203,7 +202,7 @@ describe('Bucket', () => {
     });
 
     describe('ACL objects', () => {
-      let _request: typeof r;
+      let _request: Function;
 
       before(() => {
         _request = Bucket.prototype.request;
@@ -299,7 +298,7 @@ describe('Bucket', () => {
   describe('addLifecycleRule', () => {
     beforeEach(() => {
       bucket.getMetadata = (callback: GetBucketMetadataCallback) => {
-        callback(null, {}, {} as r.Response);
+        callback(null, {}, {});
       };
     });
 
@@ -425,7 +424,7 @@ describe('Bucket', () => {
       };
 
       bucket.getMetadata = (callback: GetBucketMetadataCallback) => {
-        callback(null, {lifecycle: {rule: [existingRule]}}, {} as r.Response);
+        callback(null, {lifecycle: {rule: [existingRule]}}, {});
       };
 
       bucket.setMetadata = (metadata: Metadata) => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import {DecorateRequestOptions, Service, ServiceConfig, util} from '@google-cloud/common';
+import {DecorateRequestOptions, Service, ServiceConfig, util, Metadata} from '@google-cloud/common';
 import {PromisifyAllOptions} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
 import * as assert from 'assert';
 import * as proxyquire from 'proxyquire';
-import * as r from 'request';
 
 import {Bucket} from '../src';
 import {GetFilesOptions} from '../src/bucket';
@@ -266,7 +265,7 @@ describe('Storage', () => {
           };
       storage.createBucket(
           BUCKET_NAME,
-          (err: Error, bucket: Bucket, apiResponse: r.Response) => {
+          (err: Error, bucket: Bucket, apiResponse: Metadata) => {
             assert.strictEqual(resp, apiResponse);
             done();
           });
@@ -373,7 +372,7 @@ describe('Storage', () => {
 
       storage.getBuckets(
           {},
-          (err: Error, buckets: Bucket[], nextQuery: {}, resp: r.Response) => {
+          (err: Error, buckets: Bucket[], nextQuery: {}, resp: Metadata) => {
             assert.strictEqual(err, error);
             assert.strictEqual(buckets, null);
             assert.strictEqual(nextQuery, null);
@@ -488,7 +487,7 @@ describe('Storage', () => {
 
       it('should return the error and apiResponse', done => {
         storage.getServiceAccount(
-            (err: Error, serviceAccount: {}, apiResponse: r.Response) => {
+            (err: Error, serviceAccount: {}, apiResponse: Metadata) => {
               assert.strictEqual(err, ERROR);
               assert.strictEqual(serviceAccount, null);
               assert.strictEqual(apiResponse, API_RESPONSE);

--- a/test/index.ts
+++ b/test/index.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {DecorateRequestOptions, Service, ServiceConfig, util, Metadata} from '@google-cloud/common';
+import {DecorateRequestOptions, Metadata, Service, ServiceConfig, util} from '@google-cloud/common';
 import {PromisifyAllOptions} from '@google-cloud/promisify';
+
 import arrify = require('arrify');
 import * as assert from 'assert';
 import * as proxyquire from 'proxyquire';
@@ -264,8 +265,7 @@ describe('Storage', () => {
             callback(null, resp);
           };
       storage.createBucket(
-          BUCKET_NAME,
-          (err: Error, bucket: Bucket, apiResponse: Metadata) => {
+          BUCKET_NAME, (err: Error, bucket: Bucket, apiResponse: Metadata) => {
             assert.strictEqual(resp, apiResponse);
             done();
           });


### PR DESCRIPTION
As a bonus, drops dependencies on `teeny-request` and `@types/request`