### PR TITLE
fix: validate action of getSignedUrl() function

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2319,12 +2319,6 @@ class File extends ServiceObject<File> {
    */
   getSignedUrl(cfg: GetSignedUrlConfig, callback?: GetSignedUrlCallback):
       void|Promise<GetSignedUrlResponse> {
-    const validAction = ['read', 'write', 'delete', 'resumable'];
-
-    if (!cfg.action || !validAction.includes(cfg.action)) {
-      throw new Error('The action is not provided or invalid.');
-    }
-
     const expiresInMSeconds = new Date(cfg.expires).valueOf();
 
     if (isNaN(expiresInMSeconds)) {
@@ -2339,6 +2333,10 @@ class File extends ServiceObject<File> {
         Math.round(expiresInMSeconds / 1000);  // The API expects seconds.
 
     const method = ActionToHTTPMethod[cfg.action];
+
+    if (!method) {
+      throw new Error('The action is not provided or invalid.');
+    }
 
     const name = encodeURIComponent(this.name);
     const resource = `/${this.bucket.name}/${name}`;

--- a/src/file.ts
+++ b/src/file.ts
@@ -2319,6 +2319,12 @@ class File extends ServiceObject<File> {
    */
   getSignedUrl(cfg: GetSignedUrlConfig, callback?: GetSignedUrlCallback):
       void|Promise<GetSignedUrlResponse> {
+    const validAction = ['read', 'write', 'delete', 'resumable'];
+
+    if (!cfg.action || !validAction.includes(cfg.action)) {
+      throw new Error('The action is not provided or invalid.');
+    }
+
     const expiresInMSeconds = new Date(cfg.expires).valueOf();
 
     if (isNaN(expiresInMSeconds)) {

--- a/test/file.ts
+++ b/test/file.ts
@@ -2556,6 +2556,28 @@ describe('File', () => {
       }, /Invalid signed URL version: v42\. Supported versions are 'v2' and 'v4'\./);
     });
 
+    it('should error if action is null', () => {
+      const config = Object.assign({}, CONFIG, {action: null});
+      assert.throws(() => {
+        file.getSignedUrl(config, () => {});
+      }, /The action is not provided or invalid./);
+    });
+
+    it('should error if action is undefined', () => {
+      const config = Object.assign({}, CONFIG);
+      delete config.action;
+      assert.throws(() => {
+        file.getSignedUrl(config, () => {});
+      }, /The action is not provided or invalid./);
+    });
+
+    it('should error for an invalid action', () => {
+      const config = Object.assign({}, CONFIG, {action: 'watch'});
+      assert.throws(() => {
+        file.getSignedUrl(config, () => {});
+      }, /The action is not provided or invalid./);
+    });
+
     describe('v4 signed URL', () => {
       beforeEach(() => {
         CONFIG.version = 'v4';


### PR DESCRIPTION
Fixes #671

- [x] Tests and linter pass
- [x] Code coverage does not decrease

add validation for `action` parameter. 
