### PR TITLE
test: async is still used in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@google-cloud/common": "^1.0.0",
     "@google-cloud/paginator": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
+    "@types/protobufjs": "^6.0.0",
     "arrify": "^2.0.0",
     "compressible": "^2.0.12",
     "concat-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/tmp": "0.1.0",
     "@types/uuid": "^3.4.4",
     "@types/xdg-basedir": "^2.0.0",
+    "async": "^3.0.0",
     "codecov": "^3.0.0",
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^4.0.0",


### PR DESCRIPTION
Tests are currently failing because `async` is used in a few of them.

_update: @types/protobufjs also needed to be updated._