### PR TITLE
feat: add request timeout configuration to storage object and its methods

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -55,6 +55,11 @@ export interface StorageOptions extends GoogleAuthOptions {
    * Defaults to `www.googleapis.com`.
    */
   apiEndpoint?: string;
+  /**
+   * A number of miliseconds to wait for socket to connect.
+   * Defaults to 60000.
+   */
+  timeout?: number;
 }
 
 export interface BucketOptions {
@@ -219,6 +224,12 @@ export class Storage extends Service {
   acl: typeof Storage.acl;
 
   /**
+   * A number of miliseconds to wait for socket to connect.
+   * Defaults to 60000.
+   */
+  timeout: number;
+
+  /**
    * Get {@link Bucket} objects for all of the buckets in your project as
    * a readable object stream.
    *
@@ -314,6 +325,8 @@ export class Storage extends Service {
     this.acl = Storage.acl;
 
     this.getBucketsStream = paginator.streamify('getBuckets');
+
+    this.timeout = options.timeout!;
   }
 
   /**
@@ -535,6 +548,7 @@ export class Storage extends Service {
         uri: '/b',
         qs: query,
         json: body,
+        timeout: this.timeout,
       },
       (err, resp) => {
         if (err) {
@@ -642,6 +656,7 @@ export class Storage extends Service {
       {
         uri: '/b',
         qs: options,
+        timeout: this.timeout,
       },
       (err, resp) => {
         if (err) {
@@ -732,6 +747,7 @@ export class Storage extends Service {
       {
         uri: `/projects/${this.projectId}/serviceAccount`,
         qs: options,
+        timeout: this.timeout,
       },
       (err, resp) => {
         if (err) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -194,6 +194,31 @@ describe('Storage', () => {
     const METADATA = {a: 'b', c: {d: 'e'}};
     const BUCKET = {name: BUCKET_NAME};
 
+    describe('storage object with timeout set', () => {
+      const requestTimeout = 120000; // 2 minutes
+      
+      beforeEach(() => storage.timeout = requestTimeout);
+      afterEach(() => storage.timeout = undefined);
+
+      it('shoud pass timeout to storage.request', done => {
+        storage.request = (
+          reqOpts: DecorateRequestOptions,
+          callback: Function
+        ) => {
+          assert.strictEqual(reqOpts.method, 'POST');
+          assert.strictEqual(reqOpts.uri, '/b');
+          assert.strictEqual(reqOpts.qs.project, storage.projectId);
+          assert.strictEqual(reqOpts.json.name, BUCKET_NAME);
+          assert.strictEqual(reqOpts.timeout, requestTimeout);
+  
+          callback();
+        };
+        
+        storage.createBucket(BUCKET_NAME, done);
+      });
+    });
+
+
     it('should make correct API request', done => {
       storage.request = (
         reqOpts: DecorateRequestOptions,
@@ -203,6 +228,7 @@ describe('Storage', () => {
         assert.strictEqual(reqOpts.uri, '/b');
         assert.strictEqual(reqOpts.qs.project, storage.projectId);
         assert.strictEqual(reqOpts.json.name, BUCKET_NAME);
+        assert.strictEqual(reqOpts.timeout, undefined);
 
         callback();
       };
@@ -379,10 +405,28 @@ describe('Storage', () => {
   });
 
   describe('getBuckets', () => {
+    describe('storage object with timeout set', () => {
+      const requestTimeout = 120000; // 2 minutes
+      
+      beforeEach(() => storage.timeout = requestTimeout);
+      afterEach(() => storage.timeout = undefined);
+
+      it('shoud pass timeout to storage.request', done => {
+        storage.request = (reqOpts: DecorateRequestOptions) => {
+          assert.strictEqual(reqOpts.uri, '/b');
+          assert.deepStrictEqual(reqOpts.qs, {project: storage.projectId});
+          assert.strictEqual(reqOpts.timeout, requestTimeout);
+          done();
+        };
+        storage.getBuckets(util.noop);
+      });
+    });
+
     it('should get buckets without a query', done => {
       storage.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts.uri, '/b');
         assert.deepStrictEqual(reqOpts.qs, {project: storage.projectId});
+        assert.strictEqual(reqOpts.timeout, undefined);
         done();
       };
       storage.getBuckets(util.noop);
@@ -509,6 +553,28 @@ describe('Storage', () => {
   });
 
   describe('getServiceAccount', () => {
+    describe('storage object with timeout set', () => {
+      const requestTimeout = 120000; // 2 minutes
+      
+      beforeEach(() => storage.timeout = requestTimeout);
+      afterEach(() => storage.timeout = undefined);
+
+      it('shoud pass timeout to storage.request', done => {
+        storage.request = (reqOpts: DecorateRequestOptions) => {
+          assert.strictEqual(
+            reqOpts.uri,
+            `/projects/${storage.projectId}/serviceAccount`
+          );
+          assert.deepStrictEqual(reqOpts.qs, {});
+          assert.strictEqual(reqOpts.timeout, requestTimeout);
+  
+          done();
+        };
+        
+        storage.getServiceAccount(assert.ifError);
+      });
+    });
+
     it('should make the correct request', done => {
       storage.request = (reqOpts: DecorateRequestOptions) => {
         assert.strictEqual(
@@ -516,6 +582,7 @@ describe('Storage', () => {
           `/projects/${storage.projectId}/serviceAccount`
         );
         assert.deepStrictEqual(reqOpts.qs, {});
+        assert.strictEqual(reqOpts.timeout, undefined);
         done();
       };
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -196,9 +196,9 @@ describe('Storage', () => {
 
     describe('storage object with timeout set', () => {
       const requestTimeout = 120000; // 2 minutes
-      
-      beforeEach(() => storage.timeout = requestTimeout);
-      afterEach(() => storage.timeout = undefined);
+
+      beforeEach(() => (storage.timeout = requestTimeout));
+      afterEach(() => (storage.timeout = undefined));
 
       it('shoud pass timeout to storage.request', done => {
         storage.request = (
@@ -210,14 +210,13 @@ describe('Storage', () => {
           assert.strictEqual(reqOpts.qs.project, storage.projectId);
           assert.strictEqual(reqOpts.json.name, BUCKET_NAME);
           assert.strictEqual(reqOpts.timeout, requestTimeout);
-  
+
           callback();
         };
-        
+
         storage.createBucket(BUCKET_NAME, done);
       });
     });
-
 
     it('should make correct API request', done => {
       storage.request = (
@@ -407,9 +406,9 @@ describe('Storage', () => {
   describe('getBuckets', () => {
     describe('storage object with timeout set', () => {
       const requestTimeout = 120000; // 2 minutes
-      
-      beforeEach(() => storage.timeout = requestTimeout);
-      afterEach(() => storage.timeout = undefined);
+
+      beforeEach(() => (storage.timeout = requestTimeout));
+      afterEach(() => (storage.timeout = undefined));
 
       it('shoud pass timeout to storage.request', done => {
         storage.request = (reqOpts: DecorateRequestOptions) => {
@@ -555,9 +554,9 @@ describe('Storage', () => {
   describe('getServiceAccount', () => {
     describe('storage object with timeout set', () => {
       const requestTimeout = 120000; // 2 minutes
-      
-      beforeEach(() => storage.timeout = requestTimeout);
-      afterEach(() => storage.timeout = undefined);
+
+      beforeEach(() => (storage.timeout = requestTimeout));
+      afterEach(() => (storage.timeout = undefined));
 
       it('shoud pass timeout to storage.request', done => {
         storage.request = (reqOpts: DecorateRequestOptions) => {
@@ -567,10 +566,10 @@ describe('Storage', () => {
           );
           assert.deepStrictEqual(reqOpts.qs, {});
           assert.strictEqual(reqOpts.timeout, requestTimeout);
-  
+
           done();
         };
-        
+
         storage.getServiceAccount(assert.ifError);
       });
     });


### PR DESCRIPTION
Towards #733

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

This would be a first step to expose `request.timeout` configuration to storage functions.