### PR TITLE
docs: update documentation on legacy storage classes

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -2754,8 +2754,8 @@ class Bucket extends ServiceObject {
    *
    * @param {string} storageClass The new storage class. (`standard`,
    *     `nearline`, `coldline`, or `durable_reduced_availability`).
-   *     **Note:** The legacy storage classes `multi_regional` and `regional`
-   *     have been deprecated.
+   *     **Note:** The storage classes `multi_regional` and `regional`
+   *     are now legacy and will be deprecated in the future.
    * @param {object} [options] Configuration options.
    * @param {string} [options.userProject] - The ID of the project which will be
    *     billed for the request.


### PR DESCRIPTION
multi_regional and regional storage classes were marked as deprecated but are actually legacy.