### PR TITLE
test: add benchmarking wrapper

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,13 @@
+# benchwrapper
+
+benchwrapper is a lightweight gRPC server that wraps the storage library for
+bencharmking purposes.
+
+## Running
+
+```
+cd nodejs-storage
+npm install
+export STORAGE_EMULATOR_HOST=localhost:8080
+npm run benchwrapper -- --port 50051
+```

--- a/bin/benchwrapper.js
+++ b/bin/benchwrapper.js
@@ -1,0 +1,55 @@
+const grpc = require('grpc');
+const protoLoader = require('@grpc/proto-loader');
+const {Storage} = require('../build/src');
+
+const argv = require('yargs')
+  .option('port', {
+    description: 'The port that the Node.js benchwrapper should run on.',
+    type: 'number',
+    demand: true,
+  })
+  .parse();
+
+const PROTO_PATH = __dirname + '/storage.proto';
+// Suggested options for similarity to existing grpc.load behavior.
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+const protoDescriptor = grpc.loadPackageDefinition(packageDefinition);
+const storageBenchWrapper = protoDescriptor.storage_bench;
+
+const storageClient = new Storage();
+
+function read(call, callback) {
+  const bucketName = call.request.bucketName;
+  const objectName = call.request.objectName;
+
+  storageClient
+    .bucket(bucketName)
+    .file(objectName)
+    .download({validation: false})
+    .then(function(data) {
+      // Do nothing with contents.
+    });
+
+  callback(null, null);
+}
+
+function write(call, callback) {
+  // TODO(deklerk)
+  callback(null, null);
+}
+
+const server = new grpc.Server();
+
+server.addService(storageBenchWrapper['StorageBenchWrapper']['service'], {
+  read: read,
+  write: write,
+});
+console.log('starting on localhost:' + argv.port);
+server.bind('0.0.0.0:' + argv.port, grpc.ServerCredentials.createInsecure());
+server.start();

--- a/bin/storage.proto
+++ b/bin/storage.proto
@@ -1,0 +1,45 @@
+// Copyright 2016 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicwable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package storage_bench;
+option java_multiple_files = true;
+option java_package = "com.benchwrapper";
+
+message ObjectRead{
+  // The bucket string identifier.
+  string bucketName = 1;
+  // The object/blob string identifier.
+  string objectName = 2;
+}
+
+message ObjectWrite{
+   // The bucket string identifier.
+  string bucketName = 1;
+  // The object/blob string identifiers.
+  string objectName = 2;
+  // The string containing the upload file path.
+  string destination = 3;
+}
+
+message EmptyResponse{
+}
+
+service StorageBenchWrapper{
+  // Performs an upload from a specific object.
+  rpc Write(ObjectWrite) returns (EmptyResponse) {}
+  // Read a specific object.
+  rpc Read(ObjectRead) returns (EmptyResponse){}
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "fix": "gts fix && eslint --fix '**/*.js'",
     "prepare": "npm run compile",
     "docs-test": "linkinator docs",
-    "predocs-test": "npm run docs"
+    "predocs-test": "npm run docs",
+    "benchwrapper": "node bin/benchwrapper.js"
   },
   "dependencies": {
     "@google-cloud/common": "^2.0.0",
@@ -74,6 +75,7 @@
   },
   "devDependencies": {
     "@google-cloud/pubsub": "^0.30.0",
+    "@grpc/proto-loader": "^0.5.1",
     "@types/compressible": "^2.0.0",
     "@types/concat-stream": "^1.6.0",
     "@types/configstore": "^4.0.0",
@@ -97,6 +99,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-node": "^9.0.0",
     "eslint-plugin-prettier": "^3.0.0",
+    "grpc": "^1.22.2",
     "gts": "^1.0.0",
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.6.2",
@@ -114,6 +117,7 @@
     "source-map-support": "^0.5.6",
     "tmp": "^0.1.0",
     "typescript": "~3.5.0",
-    "uuid": "^3.1.0"
+    "uuid": "^3.1.0",
+    "yargs": "^13.3.0"
   }
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -291,9 +291,12 @@ export class Storage extends Service {
    */
   constructor(options: StorageOptions = {}) {
     options.apiEndpoint = options.apiEndpoint || 'www.googleapis.com';
+    const url =
+      process.env.STORAGE_EMULATOR_HOST ||
+      `https://${options.apiEndpoint}/storage/v1`;
     const config = {
       apiEndpoint: options.apiEndpoint,
-      baseUrl: `https://${options.apiEndpoint}/storage/v1`,
+      baseUrl: url,
       projectIdRequired: false,
       scopes: [
         'https://www.googleapis.com/auth/iam',


### PR DESCRIPTION
This PR adds a gRPC server which wraps the storage client library. The methods specified in the proto are read and write, though the only implemented method in this PR is read.

The PR also:

- Adds an `apiScheme?` to `StorageOptions` (alongside `apiEndpoint?`)
- Causes validation: false to actually not do validation, instead of the current behavior in which validation: false always returns a validation error 