### PR TITLE
fix(deps): upgrade @google-cloud/common version to show original error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "benchwrapper": "node bin/benchwrapper.js"
   },
   "dependencies": {
-    "@google-cloud/common": "^2.0.5",
+    "@google-cloud/common": "^2.1.0",
     "@google-cloud/paginator": "^2.0.0",
     "@google-cloud/promisify": "^1.0.0",
     "arrify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "benchwrapper": "node bin/benchwrapper.js"
   },
   "dependencies": {
-    "@google-cloud/common": "^2.0.0",
+    "@google-cloud/common": "^2.0.5",
     "@google-cloud/paginator": "^2.0.0",
     "@google-cloud/promisify": "^1.0.0",
     "arrify": "^2.0.0",

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2008,6 +2008,34 @@ describe('storage', () => {
         });
     });
 
+    it('should thow orignal error message on non JSON response on large metadata', async () => {
+      const largeCustomMeta = (size: number) => {
+        let str = '';
+        for (let i = 0; i < size; i++) {
+          str += 'a';
+        }
+        return str;
+      };
+
+      const file = bucket.file('large-metadata-error-test');
+      // Save file with metadata size more then 2MB.
+      await assert.rejects(
+        async () => {
+          await file.save('test', {
+            resumable: false,
+            metadata: {
+              metadata: {
+                custom: largeCustomMeta(2.1e6),
+              },
+            },
+          });
+        },
+        {
+          message: 'Cannot parse response as JSON: Metadata part is too large.',
+        }
+      );
+    });
+
     it('should read a byte range from a file', done => {
       bucket.upload(FILES.big.path, (err: Error | null, file?: File | null) => {
         assert.ifError(err);


### PR DESCRIPTION
Upgraded `@google-cloud/common` has added original error message with of JSON parsing failure. 

- To check original message is propagating to api response, added system test case for non JSON response body. ( metadata size is too large)

Fixes #170 

- [x] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)