### PR TITLE
fix(ts): fix @types/nock to 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/mime": "^2.0.0",
     "@types/mime-types": "^2.1.0",
     "@types/mocha": "^5.2.3",
-    "@types/nock": "^10.0.0",
+    "@types/nock": "10.0.0",
     "@types/node": "^11.13.4",
     "@types/node-fetch": "^2.1.3",
     "@types/proxyquire": "^1.3.28",

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -93,7 +93,7 @@ import {
   DeleteNotificationCallback,
   Iam,
 } from '../src';
-import * as nock from 'nock';
+import nock from 'nock';
 
 interface ErrorCallbackFunction {
   (err: Error | null): void;


### PR DESCRIPTION
Starting from 10.0.3, @types/nock started using nock as default export,
even though the library uses module export. This broke our typescript
compilation.

Fixing the version of @types/nock to 10.0.0 fixed the problem.

# TODO
- [ ] Report issue at DefinitelyTyped.