### PR TITLE
fix(ts): fix nock @~11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "jsdoc-fresh": "^1.0.1",
     "linkinator": "^1.5.0",
     "mocha": "^6.0.0",
-    "nock": "^11.0.0",
+    "nock": "~11.0.0",
     "node-fetch": "^2.2.0",
     "normalize-newline": "^3.0.0",
     "nyc": "^14.0.0",

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -106,7 +106,7 @@ const RUNNING_IN_VPCSC = !!process.env['GOOGLE_CLOUD_TESTS_IN_VPCSC'];
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
 nock('http://metadata.google.internal')
-  .get((url: any) => true)
+  .get(url => true)
   .replyWithError({code: 'ENOTFOUND'})
   .persist();
 

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -93,7 +93,7 @@ import {
   DeleteNotificationCallback,
   Iam,
 } from '../src';
-const nock = require('nock');
+import * as nock from 'nock';
 
 interface ErrorCallbackFunction {
   (err: Error | null): void;
@@ -106,7 +106,6 @@ const RUNNING_IN_VPCSC = !!process.env['GOOGLE_CLOUD_TESTS_IN_VPCSC'];
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
 nock('http://metadata.google.internal')
-  // tslint:disable-next-line no-any
   .get((url: any) => true)
   .replyWithError({code: 'ENOTFOUND'})
   .persist();

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -93,7 +93,7 @@ import {
   DeleteNotificationCallback,
   Iam,
 } from '../src';
-import * as nock from 'nock';
+const nock = require('nock');
 
 interface ErrorCallbackFunction {
   (err: Error | null): void;
@@ -106,7 +106,8 @@ const RUNNING_IN_VPCSC = !!process.env['GOOGLE_CLOUD_TESTS_IN_VPCSC'];
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
 nock('http://metadata.google.internal')
-  .get(url => true)
+  // tslint:disable-next-line no-any
+  .get((url: any) => true)
   .replyWithError({code: 'ENOTFOUND'})
   .persist();
 


### PR DESCRIPTION
Started to see typescript compilation failed overnight:

```
> @google-cloud/storage@3.1.0 compile /Users/jonathanlui/nodejs-storage
> tsc -p .

system-test/storage.ts:108:1 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof import("/Users/jonathanlui/nodejs-storage/node_modules/nock/types/index")' has no compatible call signatures.

108 nock('http://metadata.google.internal')
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

There hasn't been releases to `@types/nock`, `typescript` or `gts`. So
this is a temporary fix to unblock releasing while we figure out why.

# Update

Turns out starting at nock@11.1.0, they [shipped](https://github.com/nock/nock/releases/tag/v11.1.0%40next) their own typescript definition in the package. The types assumed the downstream library uses `esModuleInterop` so

`import * as nock from 'nock'` failed typescript compilation, while
`import nock from 'nock'` successfully compiled, but failed at runtime.