### PR TITLE
fix: pass predefined acl as destinationPredefinedAcl to qs

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -323,6 +323,7 @@ interface CopyQuery {
   rewriteToken?: string;
   userProject?: string;
   destinationKmsKeyName?: string;
+  destinationPredefinedAcl?: string;
 }
 
 interface FileQuery {
@@ -832,7 +833,10 @@ class File extends ServiceObject<File> {
     });
   }
 
-  copy(destination: string | Bucket | File): Promise<CopyResponse>;
+  copy(
+    destination: string | Bucket | File,
+    options?: CopyOptions
+  ): Promise<CopyResponse>;
   copy(destination: string | Bucket | File, callback: CopyCallback): void;
   copy(
     destination: string | Bucket | File,
@@ -1029,6 +1033,10 @@ class File extends ServiceObject<File> {
     if (options.userProject !== undefined) {
       query.userProject = options.userProject;
       delete options.userProject;
+    }
+    if (options.predefinedAcl !== undefined) {
+      query.destinationPredefinedAcl = options.predefinedAcl;
+      delete options.predefinedAcl;
     }
 
     newFile = newFile! || destBucket.file(destName);

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2597,6 +2597,16 @@ describe('storage', () => {
       await Promise.all([file.delete, copiedFile.delete()]);
     });
 
+    it('should respect predefined Acl at file#copy', async () => {
+      const opts = {destination: 'CloudLogo'};
+      const [file] = await bucket.upload(FILES.logo.path, opts);
+      const copyOpts = {predefinedAcl: 'publicRead'};
+      const [copiedFile] = await file.copy('CloudLogoCopy', copyOpts);
+      const publicAcl = await isFilePublicAsync(copiedFile);
+      assert.strictEqual(publicAcl, true)
+      await Promise.all([file.delete, copiedFile.delete()]);
+    });
+
     it('should copy a large file', async () => {
       const otherBucket = storage.bucket(generateName());
       const file = bucket.file('Big');

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2603,7 +2603,7 @@ describe('storage', () => {
       const copyOpts = {predefinedAcl: 'publicRead'};
       const [copiedFile] = await file.copy('CloudLogoCopy', copyOpts);
       const publicAcl = await isFilePublicAsync(copiedFile);
-      assert.strictEqual(publicAcl, true)
+      assert.strictEqual(publicAcl, true);
       await Promise.all([file.delete, copiedFile.delete()]);
     });
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -550,6 +550,23 @@ describe('File', () => {
       file.copy(newFile, {destinationKmsKeyName}, assert.ifError);
     });
 
+    it('should accept predefined Acl', done => {
+      const options = {
+        predefinedAcl: 'authenticatedRead',
+      };
+      const newFile = new File(BUCKET, 'new-file');
+      file.request = (reqOpts: DecorateRequestOptions) => {
+        assert.strictEqual(
+          reqOpts.qs.destinationPredefinedAcl,
+          options.predefinedAcl
+        );
+        assert.strictEqual(reqOpts.json.destinationPredefinedAcl, undefined);
+        done();
+      };
+
+      file.copy(newFile, options, assert.ifError);
+    });
+
     it('should favor the option over the File KMS name', done => {
       const newFile = new File(BUCKET, 'new-file');
       newFile.kmsKeyName = 'incorrect-kms-key-name';


### PR DESCRIPTION
- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Currently optional param `predefinedAcl` in [file#copy](https://github.com/googleapis/nodejs-storage/blob/916cede255597ca8d605fa48a079d9c6e1e9b17c/src/file.ts#L864) is not utilized properly.
As per docs API expects `[destinationPredefinedAcl](https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite)` as part of the qs (not Json).
