### PR TITLE
fix: file#move do not delete origin file if same as destination

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -3028,9 +3028,12 @@ class File extends ServiceObject<File> {
         return;
       }
 
-      this.delete(options, (err, apiResponse) => {
-        callback!(err, destinationFile, apiResponse);
-      });
+      if (this.name !== destinationFile!.name || this.bucket.name !== destinationFile!.bucket.name) {
+        this.delete(options, (err, apiResponse) => {
+          callback!(err, destinationFile, apiResponse);
+        });
+      }
+      callback!(null, destinationFile, apiResponse);
     });
   }
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -3028,7 +3028,10 @@ class File extends ServiceObject<File> {
         return;
       }
 
-      if (this.name !== destinationFile!.name || this.bucket.name !== destinationFile!.bucket.name) {
+      if (
+        this.name !== destinationFile!.name ||
+        this.bucket.name !== destinationFile!.bucket.name
+      ) {
         this.delete(options, (err, apiResponse) => {
           callback!(err, destinationFile, apiResponse);
         });

--- a/src/file.ts
+++ b/src/file.ts
@@ -3041,8 +3041,9 @@ class File extends ServiceObject<File> {
         this.delete(options, (err, apiResponse) => {
           callback!(err, destinationFile, apiResponse);
         });
+      } else {
+        callback!(null, destinationFile, apiResponse);
       }
-      callback!(null, destinationFile, apiResponse);
     });
   }
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -3461,15 +3461,9 @@ describe('File', () => {
       });
 
       it('should not delete the destination is same as origin', done => {
-        // sinon.stub(file, 'request').callsFake((callback: Function) => {
-        //   callback(null, null);
-        // })
         file.request = (config: {}, callback: Function) => {
           callback(null, {});
         };
-        // file.copy = (destination: {}, options: {}, callback: Function) => {
-        //   callback(null);
-        // };
         const stub = sinon.stub(file, 'delete');
         // destination is same bucket as object
         file.move(BUCKET, (err: Error) => {

--- a/test/file.ts
+++ b/test/file.ts
@@ -3455,7 +3455,7 @@ describe('File', () => {
         // })
         file.request = (config: {}, callback: Function) => {
           callback(null, {});
-        }
+        };
         // file.copy = (destination: {}, options: {}, callback: Function) => {
         //   callback(null);
         // };
@@ -3472,10 +3472,10 @@ describe('File', () => {
               assert.ok(stub.notCalled);
               stub.reset();
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
       it('should pass options to delete', done => {
         const options = {};

--- a/test/file.ts
+++ b/test/file.ts
@@ -3422,8 +3422,9 @@ describe('File', () => {
 
     describe('delete original file', () => {
       it('should delete if copy is successful', done => {
+        const destinationFile = {bucket: {}};
         file.copy = (destination: {}, options: {}, callback: Function) => {
-          callback(null);
+          callback(null, destinationFile);
         };
         Object.assign(file, {
           delete() {
@@ -3448,11 +3449,40 @@ describe('File', () => {
         });
       });
 
+      it('should not delete the destination is same as origin', done => {
+        // sinon.stub(file, 'request').callsFake((callback: Function) => {
+        //   callback(null, null);
+        // })
+        file.request = (config: {}, callback: Function) => {
+          callback(null, {});
+        }
+        // file.copy = (destination: {}, options: {}, callback: Function) => {
+        //   callback(null);
+        // };
+        const stub = sinon.stub(file, 'delete');
+        // destination is same bucket as object
+        file.move(BUCKET, (err: Error) => {
+          assert.ifError(err);
+          // destination is same file as object
+          file.move(file, (err: Error) => {
+            assert.ifError(err);
+            // destination is same file name as string
+            file.move(file.name, (err: Error) => {
+              assert.ifError(err);
+              assert.ok(stub.notCalled);
+              stub.reset();
+              done();
+            })
+          })
+        })
+      })
+
       it('should pass options to delete', done => {
         const options = {};
+        const destinationFile = {bucket: {}};
 
         file.copy = (destination: {}, options: {}, callback: Function) => {
-          callback();
+          callback(null, destinationFile);
         };
 
         file.delete = (options_: {}) => {
@@ -3465,8 +3495,9 @@ describe('File', () => {
 
       it('should fail if delete fails', done => {
         const error = new Error('Error.');
+        const destinationFile = {bucket: {}};
         file.copy = (destination: {}, options: {}, callback: Function) => {
-          callback();
+          callback(null, destinationFile);
         };
         file.delete = (options: {}, callback: Function) => {
           callback(error);


### PR DESCRIPTION
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Currently if user passes same `bucket` object, `file`object, or `fileName` string as the original file, the client will attempt to "copy" (essentially leaving the file in place) and subsequently delete the origin/destination file.  


