### PR TITLE
feat(bucket): add enableLogging method

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1833,9 +1833,7 @@ class Bucket extends ServiceObject {
    *   }
    * });
    *
-   * //-
-   * // Optionally, provide a destination bucket.
-   * //-
+   * @example <caption>Optionally, provide a destination bucket.</caption>
    * const config = {
    *   prefix: 'log',
    *   bucket: 'destination-bucket'
@@ -1843,9 +1841,8 @@ class Bucket extends ServiceObject {
    *
    * bucket.enableLogging(config, function(err, apiResponse) {});
    *
-   * //-
-   * // If the callback is omitted, we'll return a Promise.
-   * //-
+   * @example <caption>If the callback is omitted, we'll return a Promise.
+   *     </caption>
    * bucket.enableLogging(config).then(function(data) {
    *   const apiResponse = data[0];
    * });

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1870,22 +1870,25 @@ class Bucket extends ServiceObject {
     }
 
     (async () => {
+      let setMetadataResponse;
+
       try {
         await this.acl.add({
           entity: 'group-cloud-storage-analytics@google.com',
           role: 'WRITER',
         });
-        const [setMetadataResponse] = await this.setMetadata({
+        [setMetadataResponse] = await this.setMetadata({
           logging: {
             logBucket,
             logObjectPrefix: config.prefix,
           },
         });
-        callback!(null, setMetadataResponse);
       } catch (e) {
         callback!(e);
         return;
       }
+
+      callback!(null, setMetadataResponse);
     })();
   }
 

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1874,8 +1874,8 @@ class Bucket extends ServiceObject {
       try {
         const [policy] = await this.iam.getPolicy();
         policy.bindings.push({
-          members: ['cloud-storage-analytics@google.com'],
-          role: 'roles/storage.objectAdmin',
+          members: ['group:cloud-storage-analytics@google.com'],
+          role: 'roles/storage.objectCreator',
         });
         await this.iam.setPolicy(policy);
         [setMetadataResponse] = await this.setMetadata({

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1841,8 +1841,7 @@ class Bucket extends ServiceObject {
    *
    * bucket.enableLogging(config, function(err, apiResponse) {});
    *
-   * @example <caption>If the callback is omitted, we'll return a Promise.
-   *     </caption>
+   * @example <caption>If the callback is omitted, we'll return a Promise.</caption>
    * bucket.enableLogging(config).then(function(data) {
    *   const apiResponse = data[0];
    * });

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1872,10 +1872,12 @@ class Bucket extends ServiceObject {
       let setMetadataResponse;
 
       try {
-        await this.acl.add({
-          entity: 'group-cloud-storage-analytics@google.com',
-          role: 'WRITER',
+        const [policy] = await this.iam.getPolicy();
+        policy.bindings.push({
+          members: ['cloud-storage-analytics@google.com'],
+          role: 'roles/storage.objectAdmin',
         });
+        await this.iam.setPolicy(policy);
         [setMetadataResponse] = await this.setMetadata({
           logging: {
             logBucket,

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -103,10 +103,6 @@ export interface EnableLoggingOptions {
   bucket?: string | Bucket;
   prefix: string;
 }
-export type EnableLoggingResponse = [];
-export interface EnableLoggingCallback {
-  (err: Error | null): void;
-}
 
 export interface GetFilesOptions {
   autoPaginate?: boolean;
@@ -1801,6 +1797,10 @@ class Bucket extends ServiceObject {
   enableLogging(
     config: EnableLoggingOptions
   ): Promise<SetBucketMetadataResponse>;
+  enableLogging(
+    config: EnableLoggingOptions,
+    callback: SetBucketMetadataCallback
+  ): void;
   /**
    * Configuration object for enabling logging.
    *

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1858,15 +1858,9 @@ class Bucket extends ServiceObject {
       throw new Error('A configuration object with a prefix is required.');
     }
 
-    let logBucket = this.id;
-
-    if (typeof config.bucket !== 'undefined') {
-      if (util.isCustomType(config.bucket, 'Bucket')) {
-        logBucket = (config.bucket as Bucket).id;
-      } else if (typeof config.bucket === 'string') {
-        logBucket = config.bucket;
-      }
-    }
+    const logBucket = config.bucket
+      ? (config.bucket as Bucket).id || config.bucket
+      : this.id;
 
     (async () => {
       let setMetadataResponse;

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -1367,6 +1367,32 @@ describe('storage', () => {
     });
   });
 
+  describe('bucket logging', () => {
+    const PREFIX = 'sys-test';
+
+    it('should enable logging on current bucket by default', async () => {
+      const [metadata] = await bucket.enableLogging({prefix: PREFIX});
+      assert.deepStrictEqual(metadata.logging, {
+        logBucket: bucket.id,
+        logObjectPrefix: PREFIX,
+      });
+    });
+
+    it('should enable logging on another bucket', async () => {
+      const bucketForLogging = storage.bucket(generateName());
+      await bucketForLogging.create();
+
+      const [metadata] = await bucket.enableLogging({
+        bucket: bucketForLogging,
+        prefix: PREFIX,
+      });
+      assert.deepStrictEqual(metadata.logging, {
+        logBucket: bucketForLogging.id,
+        logObjectPrefix: PREFIX,
+      });
+    });
+  });
+
   describe('requester pays', () => {
     const HAS_2ND_PROJECT =
       process.env.GCN_STORAGE_2ND_PROJECT_ID !== undefined;

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -1220,8 +1220,8 @@ describe('Bucket', () => {
           assert.deepStrictEqual(policy_.bindings, [
             policy.bindings[0],
             {
-              members: ['cloud-storage-analytics@google.com'],
-              role: 'roles/storage.objectAdmin',
+              members: ['group:cloud-storage-analytics@google.com'],
+              role: 'roles/storage.objectCreator',
             },
           ]);
           setImmediate(done);

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -1183,7 +1183,6 @@ describe('Bucket', () => {
         setPolicy: () => Promise.resolve(),
       };
       bucket.setMetadata = () => Promise.resolve([]);
-      fakeUtil.isCustomType = util.isCustomType;
     });
 
     it('should throw if a config object is not provided', () => {


### PR DESCRIPTION
Fixes #23 

Hello! This adds the `bucket.enableLogging()` shortcut method as discussed in #23.