### PR TITLE
build: packageName should be set for release configuration

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,1 +1,2 @@
 releaseType: node
+packageName: '@google-cloud/storage'


### PR DESCRIPTION
we were not updating `samples/package.json`, because we didn't know the correct `packageName`.