### PR TITLE
fix: use storage.googleapis.com for api endpoint

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -278,7 +278,7 @@ const STORAGE_DOWNLOAD_BASE_URL = 'https://storage.googleapis.com';
  * @private
  */
 const STORAGE_UPLOAD_BASE_URL =
-  'https://www.googleapis.com/upload/storage/v1/b';
+  'https://storage.googleapis.com/upload/storage/v1/b';
 
 /**
  * @const {RegExp}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -53,7 +53,7 @@ export interface StorageOptions extends GoogleAuthOptions {
   promise?: typeof Promise;
   /**
    * The API endpoint of the service used to make requests.
-   * Defaults to `www.googleapis.com`.
+   * Defaults to `storage.googleapis.com`.
    */
   apiEndpoint?: string;
 }
@@ -373,7 +373,7 @@ export class Storage extends Service {
    * @param {StorageOptions} [options] Configuration options.
    */
   constructor(options: StorageOptions = {}) {
-    options.apiEndpoint = options.apiEndpoint || 'www.googleapis.com';
+    options.apiEndpoint = options.apiEndpoint || 'storage.googleapis.com';
     const url =
       process.env.STORAGE_EMULATOR_HOST ||
       `https://${options.apiEndpoint}/storage/v1`;

--- a/test/file.ts
+++ b/test/file.ts
@@ -4021,7 +4021,7 @@ describe('File', () => {
             predefinedAcl: options.predefinedAcl,
           },
           uri:
-            'https://www.googleapis.com/upload/storage/v1/b/' +
+            'https://storage.googleapis.com/upload/storage/v1/b/' +
             file.bucket.name +
             '/o',
         });

--- a/test/index.ts
+++ b/test/index.ts
@@ -128,7 +128,7 @@ describe('Storage', () => {
 
       const calledWith = storage.calledWith_[0];
 
-      const baseUrl = 'https://www.googleapis.com/storage/v1';
+      const baseUrl = 'https://storage.googleapis.com/storage/v1';
       assert.strictEqual(calledWith.baseUrl, baseUrl);
       assert.strictEqual(calledWith.projectIdRequired, false);
       assert.deepStrictEqual(calledWith.scopes, [


### PR DESCRIPTION
Reverts googleapis/nodejs-storage#893

Turns out we want to no fix this and I'm reverting my revert based on discussion with @broady and @crwilcox.