### PR TITLE
fix(signed-url): replace encodeURIComponent with custom encoding function

### DIFF
--- a/conformance-test/test-data/v4SignedUrl.json
+++ b/conformance-test/test-data/v4SignedUrl.json
@@ -53,6 +53,19 @@
     },
 
     {
+        "description": "Slashes in object name should not be URL encoded",
+        "bucket": "test-bucket",
+        "object": "path/with/slashes/under_score/amper&sand/file.ext",
+        "headers": {
+          "header/name/with/slash": "should-be-encoded"
+        },
+        "method": "GET",
+        "expiration": "10",
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/path/with/slashes/under_score/amper%26sand/file.ext?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=header%2Fname%2Fwith%2Fslash%3Bhost&X-Goog-Signature=2a9a82e84e39f5d2c0d980514db17f8c3dece473c9a5743d54e8453f9811927b1b99ce548c534cababd8fa339183e75b410e12e32a4c72f5ff176e95651fabed0072e59e7e236eb7e26f52c0ce599db1c47ae07af1a98d20872b6fde23432c0a5fcf4fb2dda735169198c80cd5cc51be9904f7e5eef2cc489ff44ac5697c529e4b34ac08709a7d2e425619377212c64561ed8b4d2fcb70a26e4f9236f995ab4658d240ac85c7a353bae6b2d39d5fc0716afa435a1f6e100db5504612b5e610db370623ab4b8eba3c03c98f23dcb4b9ffd518f2212abb2f93649d25385d71603d470cff0b7631adb9d0849d38609dedb3097761c8f47ec0d57777bb063611c05b"
+    },
+
+    {
         "description": "Simple headers",
         "bucket": "test-bucket",
         "object": "test-object",

--- a/src/file.ts
+++ b/src/file.ts
@@ -2629,7 +2629,7 @@ class File extends ServiceObject<File> {
         'X-Goog-Credential': credential,
         'X-Goog-Date': dateISO,
         'X-Goog-Expires': expiresPeriodInSeconds,
-        'X-Goog-SignedHeaders': signedHeaders
+        'X-Goog-SignedHeaders': signedHeaders,
       };
 
       // tslint:disable-next-line:no-any

--- a/src/file.ts
+++ b/src/file.ts
@@ -41,7 +41,6 @@ import {Duplex, Writable, Readable} from 'stream';
 import * as streamEvents from 'stream-events';
 import * as through from 'through2';
 import * as xdgBasedir from 'xdg-basedir';
-import * as querystring from 'querystring';
 import * as zlib from 'zlib';
 import * as url from 'url';
 import * as http from 'http';
@@ -56,7 +55,7 @@ import {
   DuplexifyConstructor,
 } from '@google-cloud/common/build/src/util';
 const duplexify: DuplexifyConstructor = require('duplexify');
-import {normalize, objectEntries} from './util';
+import {normalize, objectEntries, encodeURI, qsStringify} from './util';
 import {GaxiosError, Headers, request as gaxiosRequest} from 'gaxios';
 
 export type GetExpirationDateResponse = [Date];
@@ -2490,7 +2489,7 @@ class File extends ServiceObject<File> {
       throw new Error('The action is not provided or invalid.');
     }
 
-    const name = encodeURIComponent(this.name);
+    const name = encodeURI(this.name, false);
     const resource = `/${this.bucket.name}/${name}`;
 
     const version = cfg.version || DEFAULT_SIGNING_VERSION;
@@ -2533,7 +2532,7 @@ class File extends ServiceObject<File> {
       const signedUrl = new url.URL(config.cname || STORAGE_DOWNLOAD_BASE_URL);
       signedUrl.pathname = config.cname ? name : `${this.bucket.name}/${name}`;
       // tslint:disable-next-line:no-any
-      signedUrl.search = querystring.stringify(query as any);
+      signedUrl.search = qsStringify(query as any);
 
       callback!(null, signedUrl.href);
     }, callback!);
@@ -2630,11 +2629,11 @@ class File extends ServiceObject<File> {
         'X-Goog-Credential': credential,
         'X-Goog-Date': dateISO,
         'X-Goog-Expires': expiresPeriodInSeconds,
-        'X-Goog-SignedHeaders': signedHeaders,
+        'X-Goog-SignedHeaders': signedHeaders
       };
 
       // tslint:disable-next-line:no-any
-      const canonicalQueryParams = querystring.stringify(queryParams as any);
+      const canonicalQueryParams = qsStringify(queryParams as any);
 
       const canonicalRequest = [
         config.method,

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,6 @@
  */
 
 import * as querystring from 'querystring';
-import {encode} from 'punycode';
 
 export function normalize<T = {}, U = Function>(
   optionsOrCallback?: T | U,

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,6 +15,7 @@
  */
 
 import * as querystring from 'querystring';
+import { encode } from 'punycode';
 
 export function normalize<T = {}, U = Function>(
   optionsOrCallback?: T | U,
@@ -58,11 +59,11 @@ export function encodeURI(uri: string, encodeSlash: boolean): string {
 
   // Encode additional characters not encoded by encodeURIComponent.
   return encoded
-    .replace('!', '%21')
-    .replace('*', '%2A')
-    .replace("'", '%27')
-    .replace('(', '%28')
-    .replace(')', '%29');
+    .replace(/!/g, '%21')
+    .replace(/\*/g, '%2A')
+    .replace(/'/g, '%27')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29');
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@
  */
 
 import * as querystring from 'querystring';
-import { encode } from 'punycode';
+import {encode} from 'punycode';
 
 export function normalize<T = {}, U = Function>(
   optionsOrCallback?: T | U,

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,7 +43,7 @@ export function objectEntries<T>(obj: {[key: string]: T}): Array<[string, T]> {
  * Encode every byte except `A-Z a-Z 0-9 ~ - . _`.
  *
  * encodeURI patches encodeURIComponent() by:
- *  - additionally encoding `! * ' ( )` characters;
+ *  - additionally encoding `! * ' ( )` characters (@see [MDN: fixedEncodeURIComponent]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent}
  *  - conditionally encoding `/` if encodeSlash is `true`.
  * @param {string} uri The URI to encode.
  * @param [boolean=false] encodeSlash If `true`, the "/" character is not encoded.
@@ -60,7 +60,13 @@ export function encodeURI(uri: string, encodeSlash: boolean): string {
   // Encode additional characters not encoded by encodeURIComponent.
   return encoded.replace(
     /[!'()*]/g,
-    (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    c =>
+      '%' +
+      c
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase()
+  );
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -58,12 +58,9 @@ export function encodeURI(uri: string, encodeSlash: boolean): string {
     .join(encodeSlash ? '%2F' : '/');
 
   // Encode additional characters not encoded by encodeURIComponent.
-  return encoded
-    .replace(/!/g, '%21')
-    .replace(/\*/g, '%2A')
-    .replace(/'/g, '%27')
-    .replace(/\(/g, '%28')
-    .replace(/\)/g, '%29');
+  return encoded.replace(
+    /[!'()*]/g,
+    (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as querystring from 'querystring';
+
 export function normalize<T = {}, U = Function>(
   optionsOrCallback?: T | U,
   cb?: U
@@ -34,4 +36,43 @@ export function normalize<T = {}, U = Function>(
  */
 export function objectEntries<T>(obj: {[key: string]: T}): Array<[string, T]> {
   return Object.keys(obj).map(key => [key, obj[key]] as [string, T]);
+}
+
+/**
+ * URI encode the given string for generating signed URLs.
+ *
+ * This implementation differs from encodeURIComponent() in these ways:
+ *  - `! * ' ( )` characters are encoded;
+ *  - `/` is not encoded if encodeSlash is true.
+ * @param {string} uri The URI to encode.
+ * @param {boolean=false} encodeSlash If `true`, the "/" character is not encoded.
+ * @return {string} The encoded string.
+ */
+export function encodeURI(uri: string, encodeSlash: boolean): string {
+  // Encode using JavaScript's encodeURIComponent, excluding "/" if encodeSlash is
+  // `true`.
+  let encoded = uri.split('/')
+    .map(encodeURIComponent)
+    .join(encodeSlash ? '%2F' : '/')
+
+  // Encode additional characters not encoded by encodeURIComponent.
+  return encoded
+    .replace('!', '%21')
+    .replace('*', '%2A')
+    .replace('\'', '%27')
+    .replace('(', '%28')
+    .replace(')', '%29');
+}
+
+/**
+ * Serialize an object to a URL query string using util.encodeURI(uri, true).
+ * @param {string} url The object to serialize.
+ * @return {string} Serialized string.
+ */
+export function qsStringify(qs: querystring.ParsedUrlQueryInput): string {
+  return querystring.stringify(qs, '&', '=', {
+    encodeURIComponent:
+      (component: string) =>
+        encodeURI(component, true),
+  });
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,7 +45,7 @@ export function objectEntries<T>(obj: {[key: string]: T}): Array<[string, T]> {
  *  - `! * ' ( )` characters are encoded;
  *  - `/` is not encoded if encodeSlash is true.
  * @param {string} uri The URI to encode.
- * @param {boolean=false} encodeSlash If `true`, the "/" character is not encoded.
+ * @param [boolean=false] encodeSlash If `true`, the "/" character is not encoded.
  * @return {string} The encoded string.
  */
 export function encodeURI(uri: string, encodeSlash: boolean): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,15 +51,16 @@ export function objectEntries<T>(obj: {[key: string]: T}): Array<[string, T]> {
 export function encodeURI(uri: string, encodeSlash: boolean): string {
   // Encode using JavaScript's encodeURIComponent, excluding "/" if encodeSlash is
   // `true`.
-  let encoded = uri.split('/')
+  const encoded = uri
+    .split('/')
     .map(encodeURIComponent)
-    .join(encodeSlash ? '%2F' : '/')
+    .join(encodeSlash ? '%2F' : '/');
 
   // Encode additional characters not encoded by encodeURIComponent.
   return encoded
     .replace('!', '%21')
     .replace('*', '%2A')
-    .replace('\'', '%27')
+    .replace("'", '%27')
     .replace('(', '%28')
     .replace(')', '%29');
 }
@@ -71,8 +72,6 @@ export function encodeURI(uri: string, encodeSlash: boolean): string {
  */
 export function qsStringify(qs: querystring.ParsedUrlQueryInput): string {
   return querystring.stringify(qs, '&', '=', {
-    encodeURIComponent:
-      (component: string) =>
-        encodeURI(component, true),
+    encodeURIComponent: (component: string) => encodeURI(component, true),
   });
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,11 +39,12 @@ export function objectEntries<T>(obj: {[key: string]: T}): Array<[string, T]> {
 }
 
 /**
- * URI encode the given string for generating signed URLs.
+ * URI encode the given string for generating signed URLs:
+ * Encode every byte except `A-Z a-Z 0-9 ~ - . _`.
  *
- * This implementation differs from encodeURIComponent() in these ways:
- *  - `! * ' ( )` characters are encoded;
- *  - `/` is not encoded if encodeSlash is true.
+ * encodeURI patches encodeURIComponent() by:
+ *  - additionally encoding `! * ' ( )` characters;
+ *  - conditionally encoding `/` if encodeSlash is `true`.
  * @param {string} uri The URI to encode.
  * @param [boolean=false] encodeSlash If `true`, the "/" character is not encoded.
  * @return {string} The encoded string.

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,26 +39,16 @@ export function objectEntries<T>(obj: {[key: string]: T}): Array<[string, T]> {
 }
 
 /**
- * URI encode the given string for generating signed URLs:
- * Encode every byte except `A-Z a-Z 0-9 ~ - . _`.
+ * Encode `str` with encodeURIComponent, plus these
+ * reserved characters: `! * ' ( )`.
  *
- * encodeURI patches encodeURIComponent() by:
- *  - additionally encoding `! * ' ( )` characters (@see [MDN: fixedEncodeURIComponent]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent}
- *  - conditionally encoding `/` if encodeSlash is `true`.
- * @param {string} uri The URI to encode.
- * @param [boolean=false] encodeSlash If `true`, the "/" character is not encoded.
+ * @see [MDN: fixedEncodeURIComponent]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent}
+ *
+ * @param {string} str The URI component to encode.
  * @return {string} The encoded string.
  */
-export function encodeURI(uri: string, encodeSlash: boolean): string {
-  // Encode using JavaScript's encodeURIComponent, excluding "/" if encodeSlash is
-  // `true`.
-  const encoded = uri
-    .split('/')
-    .map(encodeURIComponent)
-    .join(encodeSlash ? '%2F' : '/');
-
-  // Encode additional characters not encoded by encodeURIComponent.
-  return encoded.replace(
+export function fixedEncodeURIComponent(str: string): string {
+  return encodeURIComponent(str).replace(
     /[!'()*]/g,
     c =>
       '%' +
@@ -67,6 +57,24 @@ export function encodeURI(uri: string, encodeSlash: boolean): string {
         .toString(16)
         .toUpperCase()
   );
+}
+
+/**
+ * URI encode `uri` for generating signed URLs, using fixedEncodeURIComponent.
+ *
+ * Encode every byte except `A-Z a-Z 0-9 ~ - . _`.
+ *
+ * @param {string} uri The URI to encode.
+ * @param [boolean=false] encodeSlash If `true`, the "/" character is not encoded.
+ * @return {string} The encoded string.
+ */
+export function encodeURI(uri: string, encodeSlash: boolean): string {
+  // Split the string by `/`, and conditionally rejoin them with either
+  // %2F if encodeSlash is `true`, or '/' if `false`.
+  return uri
+    .split('/')
+    .map(fixedEncodeURIComponent)
+    .join(encodeSlash ? '%2F' : '/');
 }
 
 /**

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -3068,7 +3068,7 @@ describe('storage', () => {
     const localFile = fs.readFileSync(FILES.logo.path);
     let file: File;
 
-    beforeEach(done => {
+    before(done => {
       file = bucket.file('LogoToSign.jpg');
       fs.createReadStream(FILES.logo.path)
         .pipe(file.createWriteStream())
@@ -3086,21 +3086,6 @@ describe('storage', () => {
       const res = await fetch(signedReadUrl);
       const body = await res.text();
       assert.strictEqual(body, localFile.toString());
-      await file.delete();
-    });
-
-    it('should create a signed delete url', async () => {
-      const [signedDeleteUrl] = await file.getSignedUrl({
-        version: 'v2',
-        action: 'delete',
-        expires: Date.now() + 5000,
-      });
-
-      await fetch(signedDeleteUrl, {method: 'DELETE'});
-      assert.rejects(
-        () => file.getMetadata(),
-        (err: ApiError) => err.code === 404
-      );
     });
 
     it('should work with multi-valued extension headers', async () => {
@@ -3118,6 +3103,21 @@ describe('storage', () => {
       });
       const body = await res.text();
       assert.strictEqual(body, localFile.toString());
+    });
+
+    it('should create a signed delete url', async () => {
+      await file.delete();
+      const [signedDeleteUrl] = await file.getSignedUrl({
+        version: 'v2',
+        action: 'delete',
+        expires: Date.now() + 5000,
+      });
+
+      await fetch(signedDeleteUrl, {method: 'DELETE'});
+      assert.rejects(
+        () => file.getMetadata(),
+        (err: ApiError) => err.code === 404
+      );
     });
   });
 
@@ -3152,18 +3152,12 @@ describe('storage', () => {
     const localFile = fs.readFileSync(FILES.logo.path);
     let file: File;
 
-    beforeEach(done => {
+    before(done => {
       file = bucket.file('LogoToSign.jpg');
       fs.createReadStream(FILES.logo.path)
         .pipe(file.createWriteStream())
         .on('error', done)
         .on('finish', done.bind(null, null));
-    });
-
-    afterEach(async () => {
-      try {
-        await file.delete();
-      } catch {}
     });
 
     it('should create a signed read url', async () => {
@@ -3176,17 +3170,6 @@ describe('storage', () => {
       const res = await fetch(signedReadUrl);
       const body = await res.text();
       assert.strictEqual(body, localFile.toString());
-    });
-
-    it('should create a signed delete url', async () => {
-      const [signedDeleteUrl] = await file.getSignedUrl({
-        version: 'v4',
-        action: 'delete',
-        expires: Date.now() + 5000,
-      });
-      await fetch(signedDeleteUrl!, {method: 'DELETE'});
-      const [exists] = await file.exists();
-      assert.strictEqual(exists, false);
     });
 
     it('should work with special characters in extension headers', async () => {
@@ -3205,6 +3188,17 @@ describe('storage', () => {
       });
       const body = await res.text();
       assert.strictEqual(body, localFile.toString());
+    });
+
+    it('should create a signed delete url', async () => {
+      const [signedDeleteUrl] = await file.getSignedUrl({
+        version: 'v4',
+        action: 'delete',
+        expires: Date.now() + 5000,
+      });
+      await fetch(signedDeleteUrl!, {method: 'DELETE'});
+      const [exists] = await file.exists();
+      assert.strictEqual(exists, false);
     });
   });
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -3010,7 +3010,7 @@ describe('File', () => {
 
       it('should URI encode file names', done => {
         directoryFile.getSignedUrl(CONFIG, (err: Error, signedUrl: string) => {
-          assert(signedUrl.includes(encodeURIComponent(directoryFile.name)));
+          assert(signedUrl.includes(directoryFile.name));
           done();
         });
       });

--- a/test/file.ts
+++ b/test/file.ts
@@ -167,6 +167,7 @@ describe('File', () => {
   // tslint:disable-next-line: no-any
   let directoryFile: any;
 
+  // tslint:disable-next-line: no-any
   let specialCharsFile: any;
 
   // tslint:disable-next-line: no-any
@@ -3021,11 +3022,16 @@ describe('File', () => {
       });
 
       it('should URI encode file name with special characters', done => {
-        specialCharsFile.getSignedUrl(CONFIG, (err: Error, signedUrl: string) => {
-          assert.ifError(err);
-          assert(signedUrl.includes("special/azAZ%21%2A%27%28%29%2A%25/file.jpg"));
-          done();
-        });
+        specialCharsFile.getSignedUrl(
+          CONFIG,
+          (err: Error, signedUrl: string) => {
+            assert.ifError(err);
+            assert(
+              signedUrl.includes('special/azAZ%21%2A%27%28%29%2A%25/file.jpg')
+            );
+            done();
+          }
+        );
       });
 
       it('should add response-content-type parameter', done => {

--- a/test/file.ts
+++ b/test/file.ts
@@ -3023,7 +3023,8 @@ describe('File', () => {
       it('should URI encode file name with special characters', done => {
         specialCharsFile.getSignedUrl(CONFIG, (err: Error, signedUrl: string) => {
           assert.ifError(err);
-          assert(signedUrl.includes("special/azAZ%21%2A%28%29%2A%25/file.jpg"));
+          assert(signedUrl.includes("special/azAZ%21%2A%27%28%29%2A%25/file.jpg"));
+          done();
         });
       });
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -2899,7 +2899,7 @@ describe('File', () => {
 
       it('should URI encode file names', done => {
         directoryFile.getSignedUrl(CONFIG, (err: Error, signedUrl: string) => {
-          assert(signedUrl.includes(encodeURIComponent(directoryFile.name)));
+          assert(signedUrl.includes(directoryFile.name));
           done();
         });
       });

--- a/test/file.ts
+++ b/test/file.ts
@@ -167,6 +167,8 @@ describe('File', () => {
   // tslint:disable-next-line: no-any
   let directoryFile: any;
 
+  let specialCharsFile: any;
+
   // tslint:disable-next-line: no-any
   let STORAGE: any;
   // tslint:disable-next-line: no-any
@@ -214,6 +216,9 @@ describe('File', () => {
 
     directoryFile = new File(BUCKET, 'directory/file.jpg');
     directoryFile.request = util.noop;
+
+    specialCharsFile = new File(BUCKET, "special/azAZ!*'()*%/file.jpg");
+    specialCharsFile.request = util.noop;
 
     createGunzipOverride = null;
     handleRespOverride = null;
@@ -3012,6 +3017,13 @@ describe('File', () => {
         directoryFile.getSignedUrl(CONFIG, (err: Error, signedUrl: string) => {
           assert(signedUrl.includes(directoryFile.name));
           done();
+        });
+      });
+
+      it('should URI encode file name with special characters', done => {
+        specialCharsFile.getSignedUrl(CONFIG, (err: Error, signedUrl: string) => {
+          assert.ifError(err);
+          assert(signedUrl.includes("special/azAZ%21%2A%28%29%2A%25/file.jpg"));
         });
       });
 


### PR DESCRIPTION
Fixes #859  🦕

Made changes to how signed URLs (v2 and v4) are url-encoded:
1. `encodeURIComponent` does not encode the following characters: `! * ' ( )`, which should have been encoded.
2. Slashes `/` in the object's (file) name should not have been encoded. (caused issue #857)