### PR TITLE
fix(v4-url): collapse whitespaces with the last whitespace in sequence

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -3471,8 +3471,8 @@ class File extends ServiceObject<File> {
         // - Trim leading and trailing spaces.
         // - Convert sequential (2+) spaces into a single space
         const canonicalValue = `${value}`
-         .trim()
-         .replace(/\s+/g, (match: string) => match[match.length-1]);
+          .trim()
+          .replace(/\s+/g, (match: string) => match[match.length - 1]);
 
         return `${headerName}:${canonicalValue}\n`;
       })

--- a/src/file.ts
+++ b/src/file.ts
@@ -3470,7 +3470,9 @@ class File extends ServiceObject<File> {
         //      ',' (no space).
         // - Trim leading and trailing spaces.
         // - Convert sequential (2+) spaces into a single space
-        const canonicalValue = `${value}`.trim().replace(/\s{2,}/g, ' ');
+        const canonicalValue = `${value}`
+         .trim()
+         .replace(/\s+/g, (match: string) => match[match.length-1]);
 
         return `${headerName}:${canonicalValue}\n`;
       })

--- a/test/file.ts
+++ b/test/file.ts
@@ -2937,30 +2937,38 @@ describe('File', () => {
 
       describe('canonical headers', () => {
         it('should collapse spaces from header value', () => {
-          const extensionHeaders = { collapsed: "abc    def" };
+          const extensionHeaders = {collapsed: 'abc    def'};
 
-          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          const canonicalizedHeaders = file.getCanonicalHeaders(
+            extensionHeaders
+          );
           assert.strictEqual(canonicalizedHeaders, 'collapsed:abc def\n');
         });
 
         it('should trim leading spaces from header value', () => {
-          const extensionHeaders = { leading: "  abc" };
+          const extensionHeaders = {leading: '  abc'};
 
-          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          const canonicalizedHeaders = file.getCanonicalHeaders(
+            extensionHeaders
+          );
           assert.strictEqual(canonicalizedHeaders, 'leading:abc\n');
         });
 
         it('should trim trailing spaces from header value', () => {
-          const extensionHeaders = { trailing: "def   " };
+          const extensionHeaders = {trailing: 'def   '};
 
-          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          const canonicalizedHeaders = file.getCanonicalHeaders(
+            extensionHeaders
+          );
           assert.strictEqual(canonicalizedHeaders, 'trailing:def\n');
         });
 
         it('should trim and collapse tabs from header value', () => {
-          const extensionHeaders = { tabs: "\t\t123\t\t\tabc\t\t" };
+          const extensionHeaders = {tabs: '\t\t123\t\t\tabc\t\t'};
 
-          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          const canonicalizedHeaders = file.getCanonicalHeaders(
+            extensionHeaders
+          );
           assert.strictEqual(canonicalizedHeaders, 'tabs:123\tabc\n');
         });
 
@@ -2971,12 +2979,13 @@ describe('File', () => {
             a: 'value',
           };
 
-          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
-          assert.strictEqual(canonicalizedHeaders, [
-            'a:value',
-            'b:value',
-            'c:value',
-          ].join('\n') + '\n')
+          const canonicalizedHeaders = file.getCanonicalHeaders(
+            extensionHeaders
+          );
+          assert.strictEqual(
+            canonicalizedHeaders,
+            ['a:value', 'b:value', 'c:value'].join('\n') + '\n'
+          );
         });
       });
     });

--- a/test/file.ts
+++ b/test/file.ts
@@ -2934,6 +2934,51 @@ describe('File', () => {
           done();
         });
       });
+
+      describe('canonical headers', () => {
+        it('should collapse spaces from header value', () => {
+          const extensionHeaders = { collapsed: "abc    def" };
+
+          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          assert.strictEqual(canonicalizedHeaders, 'collapsed:abc def\n');
+        });
+
+        it('should trim leading spaces from header value', () => {
+          const extensionHeaders = { leading: "  abc" };
+
+          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          assert.strictEqual(canonicalizedHeaders, 'leading:abc\n');
+        });
+
+        it('should trim trailing spaces from header value', () => {
+          const extensionHeaders = { trailing: "def   " };
+
+          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          assert.strictEqual(canonicalizedHeaders, 'trailing:def\n');
+        });
+
+        it('should trim and collapse tabs from header value', () => {
+          const extensionHeaders = { tabs: "\t\t123\t\t\tabc\t\t" };
+
+          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          assert.strictEqual(canonicalizedHeaders, 'tabs:123\tabc\n');
+        });
+
+        it('should order headers', () => {
+          const extensionHeaders = {
+            c: 'value',
+            b: 'value',
+            a: 'value',
+          };
+
+          const canonicalizedHeaders = file.getCanonicalHeaders(extensionHeaders);
+          assert.strictEqual(canonicalizedHeaders, [
+            'a:value',
+            'b:value',
+            'c:value',
+          ].join('\n') + '\n')
+        });
+      });
     });
 
     describe('v2 signed URL', () => {


### PR DESCRIPTION
We assumed sequential whitespaces should be replaced by a single space.
The correct behaviour here is to replace them with the last whitespace character:
`123\t\t\tabc => 123\tabc`