### PR TITLE
fix: do not check access of configPath

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1447,9 +1447,9 @@ class File extends ServiceObject<File> {
    */
   /**
    * @typedef {object} CreateResumableUploadOptions
-   * @property {string} [configPath] Where the `gcs-resumable-upload`
-   *     configuration file should be stored on your system. This maps to the
-   *     [configstore option by the same
+   * @property {string} [configPath] A full JSON file path to use with
+   *     `gcs-resumable-upload`. This maps to the [configstore option by the
+   *     same
    * name](https://github.com/yeoman/configstore/tree/0df1ec950d952b1f0dfb39ce22af8e505dffc71a#configpath).
    * @property {object} [metadata] Metadata to set on the file.
    * @property {string} [origin] Origin header to set for the upload.
@@ -1554,8 +1554,8 @@ class File extends ServiceObject<File> {
   /**
    * @typedef {object} CreateWriteStreamOptions Configuration options for File#createWriteStream().
    * @property {string} [configPath] **This only applies to resumable
-   *     uploads.** Where the `gcs-resumable-upload` configuration file should
-   * be stored on your system. This maps to the [configstore option by the same
+   *     uploads.** A full JSON file path to use with `gcs-resumable-upload`.
+   *     This maps to the [configstore option by the same
    * name](https://github.com/yeoman/configstore/tree/0df1ec950d952b1f0dfb39ce22af8e505dffc71a#configpath).
    * @property {string} [contentType] Alias for
    *     `options.metadata.contentType`. If set to `auto`, the file name is used
@@ -1759,6 +1759,11 @@ class File extends ServiceObject<File> {
     stream.on('writing', () => {
       if (options.resumable === false) {
         this.startSimpleUpload_(fileWriteStream, options);
+        return;
+      }
+
+      if (options.configPath) {
+        this.startResumableUpload_(fileWriteStream, options);
         return;
       }
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -1709,6 +1709,21 @@ describe('File', () => {
       writable.write('data');
     });
 
+    it('should start a resumable upload if configPath is provided', done => {
+      const options = {
+        metadata: METADATA,
+        configPath: '/config/path.json',
+      };
+      const writable = file.createWriteStream(options);
+
+      file.startResumableUpload_ = (stream: {}, options_: {}) => {
+        assert.deepStrictEqual(options_, options);
+        done();
+      };
+
+      writable.write('data');
+    });
+
     it('should start a resumable upload if specified', done => {
       const options = {
         metadata: METADATA,


### PR DESCRIPTION
Fixes #909

A couple things happened along this journey to fix #909.

I learned that the [configstore](http://gitnpm.com/configstore) `configPath` option isn't for a directory, it's actually the file name. We use that through gcs-resumable-upload to persist metadata about the progress of a resumable upload.

Even though that understanding was wrong, I didn't make any actual code changes in this PR. All I did was rephrase the documentation. Interestingly, the documentation was half-correct when it said "This maps to the configstore option by the same name." So... breaking change? I would not say it is, since code-wise, things behave the same.

Oh, what was #909 about? It's amazingly described, so you could read it just for fun, but to sum it up: when the user gave us a `configPath`, we were trying to make sure that the directory is writable. We don't need to worry about that, gcs-resumable-upload/configstore will sort all of that out, as that's more in their domain. The reason we have the writable access check is strictly for environments (GAE (see #55)) where the user doesn't even think about simple or resumable. They're just uploading a file. Sometimes, we would try to use a resumable upload that defaults to their home directory, but there wouldn't be one, or it was not writable. So, the check is strictly to make sure the "auto-detected $HOME-like environment" is writable. Otherwise, we fall back to a simple upload.

But, if a user provides `configPath`, they obviously know what they're doing, and they want a resumable upload. This PR codifies that assumption.

So, here was my fix. @ddgenome -- let me know what you think!