### PR TITLE
fix(docs): rendering for createReadStream method in File class

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1180,7 +1180,7 @@ class File extends ServiceObject<File> {
    *
    * //-
    * // To limit the downloaded data to only a byte range, pass an options
-   * object.
+   * // object.
    * //-
    * const logFile = myBucket.file('access_log');
    * logFile.createReadStream({


### PR DESCRIPTION
### Description

One of the comments in the documentation for `createReadStream` has the following content.

> To limit the downloaded data to only a byte range, pass an options object.

And a part of it ('object') is not rendered as a comment in https://googleapis.dev/nodejs/storage/latest/File.html#createReadStream as it is missing a `//`.

### Checklist

- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/7039523/68425257-ba7f6780-0173-11ea-9113-c6ebb7999d0c.png)

#### After

![image](https://user-images.githubusercontent.com/7039523/68425918-07b00900-0175-11ea-900e-1e1d303a0020.png)

