### PR TITLE
build: should be excludes not exclude

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-11-07T12:21:50.112102Z",
+  "updateTime": "2019-11-11T18:46:15.730212Z",
   "sources": [
     {
       "template": {

--- a/synth.py
+++ b/synth.py
@@ -19,7 +19,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
-s.copy(templates, exclude='.jsdoc.js')
+s.copy(templates, excludes=['.jsdoc.js'])
 
 # Create .config directory under $HOME to get around permissions issues
 # with resumable upload.


### PR DESCRIPTION
fixes nightly synthtool run (`exclude` should be `excludes`, and takes array).

fixes: https://github.com/googleapis/nodejs-storage/issues/927
