### PR TITLE
test: address test flake in system-tests

### DIFF
--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -243,6 +243,7 @@ describe('storage', () => {
 
       it('should not upload a file', done => {
         file.save('new data', err => {
+          console.info(process.env.GOOGLE_APPLICATION_CREDENTIALS);
           console.info('>>>>', err);
           assert(
             err!.message.indexOf('Could not load the default credentials') > -1

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -165,13 +165,6 @@ describe('storage', () => {
       });
   });
 
-  // Some tests delete the application credential environment variable, we
-  // should ensure it's set back to the appropriate value after each run:
-  const ORIGINAL_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-  afterEach(() => {
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = ORIGINAL_CREDENTIALS;
-  });
-
   after(() => {
     return Promise.all([deleteAllBucketsAsync(), deleteAllTopicsAsync()]);
   });
@@ -250,6 +243,7 @@ describe('storage', () => {
 
       it('should not upload a file', done => {
         file.save('new data', err => {
+          console.info('>>>>', err);
           assert(
             err!.message.indexOf('Could not load the default credentials') > -1
           );

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -243,7 +243,7 @@ describe('storage', () => {
 
       it('should not upload a file', done => {
         file.save('new data', err => {
-          console.info(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+          console.info(typeof process.env.GOOGLE_APPLICATION_CREDENTIALS);
           console.info('>>>>', err);
           assert(
             err!.message.indexOf('Could not load the default credentials') > -1

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -165,6 +165,13 @@ describe('storage', () => {
       });
   });
 
+  // Some tests delete the application credential environment variable, we
+  // should ensure it's set back to the appropriate value after each run:
+  const ORIGINAL_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  afterEach(() => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = ORIGINAL_CREDENTIALS;
+  });
+
   after(() => {
     return Promise.all([deleteAllBucketsAsync(), deleteAllTopicsAsync()]);
   });


### PR DESCRIPTION
we've been seeing a frequent test flake recently, related to credentials being unset, let's make sure after each test we set credential environment variable back.

see: #940 
