### PR TITLE
feat(iam): getIamPolicy to support requestedPolicyVersion

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -75,11 +75,13 @@ export interface Policy {
 export interface PolicyBinding {
   role: string;
   members: string[];
-  condition?: {
-    title?: string;
-    description?: string;
-    expression?: string;
-  }
+  condition?: Expr;
+}
+
+export interface Expr {
+  title?: string;
+  description?: string;
+  expression: string;
 }
 
 /**
@@ -151,7 +153,7 @@ class Iam {
   getPolicy(callback: GetPolicyCallback): void;
   /**
    * @typedef {object} GetPolicyOptions Requested options for IAM#getPolicy().
-   * @param {number} [requestedPolicyVersion] The version of IAM policies to
+   * @property {number} [requestedPolicyVersion] The version of IAM policies to
    *     request. If a policy with a condition is requested without setting
    *     this, the server will return an error. This must be set to a value
    *     of 3 to retrieve IAM policies containing conditions. This is to
@@ -160,7 +162,7 @@ class Iam {
    *     return a policy with version lower than the one that was requested,
    *     based on the feature syntax in the policy fetched.
    *     @see [IAM Policy versions]{@link https://cloud.google.com/iam/docs/policies#versions}
-   * @param {string} [userProject] The ID of the project which will be
+   * @property {string} [userProject] The ID of the project which will be
    *     billed for the request.
    */
   /**
@@ -170,12 +172,33 @@ class Iam {
    */
   /**
    * @typedef {object} Policy
-   * @property {array} policy.bindings Bindings associate members with roles.
+   * @property {PolicyBinding[]} policy.bindings Bindings associate members with roles.
    * @property {string} [policy.etag] Etags are used to perform a read-modify-write.
    * @property {number} [policy.version] The syntax schema version of the Policy.
    *      To set an IAM policy with conditional binding, this field must be set to
    *      3 or greater.
    *     @see [IAM Policy versions]{@link https://cloud.google.com/iam/docs/policies#versions}
+   */
+  /**
+   * @typedef {object} PolicyBinding
+   * @property {string} role Role that is assigned to members.
+   * @property {string[]} members Specifies the identities requesting access for the bucket.
+   * @property {Expr} [condition] The condition that is associated with this binding.
+   */
+  /**
+   * @typedef {object} Expr
+   * @property {string} [title] An optional title for the expression, i.e. a
+   *     short string describing its purpose. This can be used e.g. in UIs
+   *     which allow to enter the expression.
+   * @property {string} [description] An optional description of the
+   *     expression. This is a longer text which describes the expression,
+   *     e.g. when hovered over it in a UI.
+   * @property {string} expression Textual representation of an expression in
+   *     Common Expression Language syntax. The application context of the
+   *     containing message determines which well-known feature set of CEL
+   *     is supported.The condition that is associated with this binding.
+   *
+   * @see [Condition] https://cloud.google.com/storage/docs/access-control/iam#conditions
    */
   /**
    * Get the IAM policy.
@@ -232,7 +255,7 @@ class Iam {
     this.request_(
       {
         uri: '/iam',
-        qs: qs,
+        qs,
       },
       cb!
     );

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -737,7 +737,8 @@ describe('storage', () => {
 
         const [policy] = await bucket.iam.getPolicy();
 
-        const serviceAccount = (await storage.authClient.getCredentials()).client_email;
+        const serviceAccount = (await storage.authClient.getCredentials())
+          .client_email;
         const conditionalBinding = {
           role: 'roles/storage.objectViewer',
           members: [`serviceAccount:${serviceAccount}`],
@@ -753,7 +754,9 @@ describe('storage', () => {
 
         await bucket.iam.setPolicy(policy);
 
-        const [newPolicy] = await bucket.iam.getPolicy({requestedPolicyVersion: 3});
+        const [newPolicy] = await bucket.iam.getPolicy({
+          requestedPolicyVersion: 3,
+        });
         assert.deepStrictEqual(newPolicy.bindings, policy.bindings);
       });
 

--- a/test/iam.ts
+++ b/test/iam.ts
@@ -93,12 +93,26 @@ describe('storage/iam', () => {
       };
 
       iam.request_ = (reqOpts: DecorateRequestOptions) => {
-        assert.strictEqual(reqOpts.qs, options);
+        assert.deepStrictEqual(reqOpts.qs, options);
         done();
       };
 
       iam.getPolicy(options, assert.ifError);
     });
+
+    it('should map requestedPolicyVersion option to optionsRequestedPolicyVersion', done => {
+      const VERSION = 3;
+      const options = {
+        requestedPolicyVersion: VERSION
+      };
+
+      iam.request_ = (reqOpts: DecorateRequestOptions) => {
+        assert.deepStrictEqual(reqOpts.qs, {optionsRequestedPolicyVersion: VERSION});
+        done();
+      };
+
+      iam.getPolicy(options, assert.ifError);
+    })
   });
 
   describe('setPolicy', () => {

--- a/test/iam.ts
+++ b/test/iam.ts
@@ -103,16 +103,18 @@ describe('storage/iam', () => {
     it('should map requestedPolicyVersion option to optionsRequestedPolicyVersion', done => {
       const VERSION = 3;
       const options = {
-        requestedPolicyVersion: VERSION
+        requestedPolicyVersion: VERSION,
       };
 
       iam.request_ = (reqOpts: DecorateRequestOptions) => {
-        assert.deepStrictEqual(reqOpts.qs, {optionsRequestedPolicyVersion: VERSION});
+        assert.deepStrictEqual(reqOpts.qs, {
+          optionsRequestedPolicyVersion: VERSION,
+        });
         done();
       };
 
       iam.getPolicy(options, assert.ifError);
-    })
+    });
   });
 
   describe('setPolicy', () => {


### PR DESCRIPTION
Minimal code changes is involved in this PR.
We map `optionsRequestedPolicyVersion` to `requestedPolicyVersion` so the surface is uniform across products.