### PR TITLE
fix(tests): flaky getSignedPolicy tests

### DIFF
--- a/test/file.ts
+++ b/test/file.ts
@@ -45,6 +45,7 @@ import {
   GetSignedUrlConfig,
   PolicyDocument,
   SetFileMetadataOptions,
+  GetSignedPolicyOptions,
 } from '../src';
 
 let promisified = false;
@@ -2420,11 +2421,13 @@ describe('File', () => {
   });
 
   describe('getSignedPolicy', () => {
-    const CONFIG = {
-      expires: Date.now() + 2000,
-    };
+    let CONFIG: GetSignedPolicyOptions;
 
     beforeEach(() => {
+      CONFIG = {
+        expires: Date.now() + 2000,
+      };
+
       BUCKET.storage.authClient = {
         sign: () => {
           return Promise.resolve('signature');


### PR DESCRIPTION
`getSignedPolicy` has been really flaky with "expiration date in the past" failures, attempting to fix this:

<img width="612" alt="Screen Shot 2020-03-02 at 11 27 50 AM" src="https://user-images.githubusercontent.com/4001432/75710304-2c2a7680-5c79-11ea-8ee8-3f3f81a6acc0.png">
