### PR TITLE
test: allow environmentally-conditional errors

### DIFF
--- a/bin/benchwrapper.js
+++ b/bin/benchwrapper.js
@@ -46,7 +46,7 @@ function read(call, callback) {
     .bucket(bucketName)
     .file(objectName)
     .download({validation: false})
-    .then(() => callback(null, null))
+    .then(() => callback(null, null));
 }
 
 function write(call, callback) {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -241,10 +241,15 @@ describe('storage', () => {
       });
 
       it('should not upload a file', async () => {
-        await assert.rejects(
-          () => file.save('new data'),
-          /Could not load the default credentials/
-        );
+        try {
+          await file.save('new data');
+        } catch (e) {
+          const allowedErrorMessages = [
+            /Could not load the default credentials/,
+            /does not have storage\.objects\.create access/,
+          ];
+          assert(allowedErrorMessages.some(msg => msg.test(e.message)));
+        }
       });
     });
   });


### PR DESCRIPTION
Fixes #1105 

We've been getting a different (expected) error message on Kokoro vs local development environments. This allows either one to pass the test.