### PR TITLE
fix(types): wrap GetSignedUrlResponse

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -108,6 +108,8 @@ export interface GetSignedUrlConfig {
   queryParams?: Query;
 }
 
+export type GetSignedUrlResponse = [GetSignedUrlResponse];
+
 export interface GetFileMetadataOptions {
   userProject?: string;
 }


### PR DESCRIPTION
Fixes #1114 

`File#getSignedUrl()` returns what `URLSigner#getSignedUrl()` returns. But, the File method is promisified, which means we actually send back `[resp]`, and not just `resp`. Does this solution make sense?