### PR TITLE
types: split out SignedUrlResponse

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -108,8 +108,6 @@ export interface GetSignedUrlConfig {
   queryParams?: Query;
 }
 
-export type GetSignedUrlResponse = [GetSignedUrlResponse];
-
 export interface GetFileMetadataOptions {
   userProject?: string;
 }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -87,7 +87,9 @@ export interface SignerGetSignedUrlConfig {
   contentType?: string;
 }
 
-export type GetSignedUrlResponse = string;
+export type SignerGetSignedUrlResponse = string;
+
+export type GetSignedUrlResponse = [SignerGetSignedUrlResponse];
 
 export interface GetSignedUrlCallback {
   (err: Error | null, url?: string): void;
@@ -119,7 +121,7 @@ export class URLSigner {
     this.authClient = authClient;
   }
 
-  getSignedUrl(cfg: SignerGetSignedUrlConfig): Promise<GetSignedUrlResponse> {
+  getSignedUrl(cfg: SignerGetSignedUrlConfig): Promise<SignerGetSignedUrlResponse> {
     const expiresInSeconds = this.parseExpires(cfg.expires);
     const method = cfg.method;
 

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -121,7 +121,9 @@ export class URLSigner {
     this.authClient = authClient;
   }
 
-  getSignedUrl(cfg: SignerGetSignedUrlConfig): Promise<SignerGetSignedUrlResponse> {
+  getSignedUrl(
+    cfg: SignerGetSignedUrlConfig
+  ): Promise<SignerGetSignedUrlResponse> {
     const expiresInSeconds = this.parseExpires(cfg.expires);
     const method = cfg.method;
 


### PR DESCRIPTION
VS code complained of duplicate local variable with the referencing to self in #1119. I think this is a little bit cleaner.