### PR TITLE
fix(bucket): Only disable resumable uploads for bucket.upload (fixes #1133)

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -3454,7 +3454,10 @@ class Bucket extends ServiceObject {
           return;
         }
 
-        options.resumable = fd.size > RESUMABLE_THRESHOLD;
+        if (fd.size <= RESUMABLE_THRESHOLD) {
+          // Only disable resumable uploads so createWriteStream still attempts them and falls back to simple upload.
+          options.resumable = false;
+        }
 
         upload();
       });

--- a/test/testdata/dummylargetestfile.txt
+++ b/test/testdata/dummylargetestfile.txt
@@ -1,3 +1,0 @@
-This is a test file!
-
-When using fs.stat should be stubbed to return a large file size

--- a/test/testdata/dummylargetestfile.txt
+++ b/test/testdata/dummylargetestfile.txt
@@ -1,0 +1,3 @@
+This is a test file!
+
+When using fs.stat should be stubbed to return a large file size


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1133 

I've added a test case for this by stubbing `fs.stat` - I hope that's ok!