### PR TITLE
chore!: drop `keepAcl` parameter in file copy

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -304,7 +304,6 @@ export interface FileOptions {
 
 export interface CopyOptions {
   destinationKmsKeyName?: string;
-  keepAcl?: string;
   predefinedAcl?: string;
   token?: string;
   userProject?: string;
@@ -840,8 +839,6 @@ class File extends ServiceObject<File> {
    *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`,
    *     that will be used to encrypt the object. Overwrites the object
    * metadata's `kms_key_name` value, if any.
-   * @property {string} [keepAcl] This parameter is not supported and will be
-   *     removed in the next major.
    * @property {string} [predefinedAcl] Set the ACL for the new file.
    * @property {string} [token] A previously-returned `rewriteToken` from an
    *     unfinished rewrite request.
@@ -966,12 +963,6 @@ class File extends ServiceObject<File> {
       callback = optionsOrCallback;
     } else if (optionsOrCallback) {
       options = optionsOrCallback;
-    }
-
-    // eslint-disable-next-line no-prototype-builtins
-    if (options.hasOwnProperty('keepAcl')) {
-      // TODO: remove keepAcl from interface in next major.
-      emitWarning();
     }
 
     options = extend(true, {}, options);
@@ -3622,17 +3613,6 @@ class File extends ServiceObject<File> {
 promisifyAll(File, {
   exclude: ['request', 'setEncryptionKey'],
 });
-
-let warned = false;
-export function emitWarning() {
-  if (!warned) {
-    warned = true;
-    process.emitWarning(
-      'keepAcl parameter is not supported and will be removed in the next major',
-      'DeprecationWarning'
-    );
-  }
-}
 
 /**
  * Reference to the {@link File} class.

--- a/test/file.ts
+++ b/test/file.ts
@@ -350,65 +350,6 @@ describe('File', () => {
   });
 
   describe('copy', () => {
-    describe('depricate `keepAcl`', () => {
-      // eslint-disable-next-line
-      let STORAGE2: any;
-      // eslint-disable-next-line
-      let BUCKET2: any;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let file2: any;
-      beforeEach(() => {
-        STORAGE2 = {
-          createBucket: util.noop,
-          request: util.noop,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          makeAuthenticatedRequest(req: {}, callback: any) {
-            if (callback) {
-              (callback.onAuthenticated || callback)(null, req);
-            }
-          },
-          bucket(name: string) {
-            return new Bucket(this, name);
-          },
-        };
-        BUCKET2 = new Bucket(STORAGE, 'bucket-name');
-        file2 = new File(BUCKET, FILE_NAME);
-      });
-
-      it('should warn if `keepAcl` parameter is passed', done => {
-        file.request = util.noop;
-
-        // since --throw-deprication is enabled using try=>catch block
-        try {
-          file.copy('newFile', {keepAcl: 'private'}, assert.ifError);
-        } catch (err) {
-          assert.strictEqual(
-            err.message,
-            'keepAcl parameter is not supported and will be removed in the next major'
-          );
-          assert.strictEqual(err.name, 'DeprecationWarning');
-          done();
-        }
-      });
-
-      it('should warn only once `keepAcl` parameter is passed', done => {
-        file.request = util.noop;
-
-        // since --throw-deprication is enabled using try=>catch block
-        try {
-          file.copy('newFile', {keepAcl: 'private'}, assert.ifError);
-        } catch (err) {
-          assert.strictEqual(
-            err.message,
-            'keepAcl parameter is not supported and will be removed in the next major'
-          );
-          assert.strictEqual(err.name, 'DeprecationWarning');
-        }
-        file2.copy('newFile2', {keepAcl: 'private'}, assert.ifError);
-        done();
-      });
-    });
-
     it('should throw if no destination is provided', () => {
       assert.throws(() => {
         file.copy();


### PR DESCRIPTION
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
