### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,6 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# The yoshi-nodejs team is the default owner for anything not
+# The yoshi-nodejs team and @GoogleCloudPlatform/storage-dpe team are the default owner for anything not
 # explicitly taken by someone else.
-*                               @googleapis/yoshi-nodejs
-
-/storage/                          @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-nodejs
+*                               @googleapis/yoshi-nodejs @GoogleCloudPlatform/storage-dpe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+
+# The yoshi-nodejs team is the default owner for anything not
+# explicitly taken by someone else.
+*                               @googleapis/yoshi-nodejs
+
+/storage/                          @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-nodejs


### PR DESCRIPTION
@crwilcox requested teams for repo access across the board for SoDa teams. Adding a CODEOWNERS file with yoshi-nodejs as default and with the storage team.
