### PR TITLE
fix(deps): update gcs-resumable-upload, remove gitnpm usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "duplexify": "^3.5.0",
     "extend": "^3.0.2",
     "gaxios": "^3.0.0",
-    "gcs-resumable-upload": "^2.2.4",
+    "gcs-resumable-upload": "^3.0.0",
     "hash-stream-validation": "^0.2.2",
     "mime": "^2.2.0",
     "mime-types": "^2.0.8",

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -3267,7 +3267,7 @@ class Bucket extends ServiceObject {
    * input file is larger than 5 MB.*
    *
    * For faster crc32c computation, you must manually install
-   * [`fast-crc32c`](http://www.gitnpm.com/fast-crc32c):
+   * [`fast-crc32c`](https://www.npmjs.com/package/fast-crc32c):
    *
    *     $ npm install --save fast-crc32c
    *

--- a/src/file.ts
+++ b/src/file.ts
@@ -1122,7 +1122,7 @@ class File extends ServiceObject<File> {
    * recourse is to try downloading the file again.
    *
    * For faster crc32c computation, you must manually install
-   * [`fast-crc32c`](http://www.gitnpm.com/fast-crc32c):
+   * [`fast-crc32c`](https://www.npmjs.com/package/fast-crc32c):
    *
    *     $ npm install --save fast-crc32c
    *
@@ -1608,21 +1608,21 @@ class File extends ServiceObject<File> {
    * by setting `options.resumable` to `false`.
    *
    * Resumable uploads require write access to the $HOME directory. Through
-   * [`config-store`](http://www.gitnpm.com/configstore), some metadata is
-   * stored. By default, if the directory is not writable, we will fall back to
-   * a simple upload. However, if you explicitly request a resumable upload, and
-   * we cannot write to the config directory, we will return a
+   * [`config-store`](https://www.npmjs.com/package/configstore), some metadata
+   * is stored. By default, if the directory is not writable, we will fall back
+   * to a simple upload. However, if you explicitly request a resumable upload,
+   * and we cannot write to the config directory, we will return a
    * `ResumableUploadError`.
    *
    * <p class="notice">
    *   There is some overhead when using a resumable upload that can cause
    *   noticeable performance degradation while uploading a series of small
-   * files. When uploading files less than 10MB, it is recommended that the
-   * resumable feature is disabled.
+   *   files. When uploading files less than 10MB, it is recommended that the
+   *   resumable feature is disabled.
    * </p>
    *
    * For faster crc32c computation, you must manually install
-   * [`fast-crc32c`](http://www.gitnpm.com/fast-crc32c):
+   * [`fast-crc32c`](https://www.npmjs.com/package/fast-crc32c):
    *
    *     $ npm install --save fast-crc32c
    *


### PR DESCRIPTION
I am renovate.

This PR updates gcs-resumable-upload and removes usage of "gitnpm.com" throughout the docs. The "git-npm" project (as its formerly known by Google Developer's Console), has been shut down. It may come to exist in the future in another form in the future. RIP: https://github.com/stephenplusplus/gitnpm