### PR TITLE
fix(types): assert in typescript 3.7

### DIFF
--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -2069,7 +2069,7 @@ describe('Bucket', () => {
       };
 
       FakeServiceObject.prototype.request = ((
-        reqOpts: DecorateRequestOptions,
+        reqOpts: DecorateRequestOptions
       ) => {
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
         assert.strictEqual(reqOpts.qs, options.qs);

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -281,7 +281,9 @@ describe('Bucket', () => {
       });
 
       const bucket = new Bucket(storageInstance, BUCKET_NAME);
-      assert(bucket instanceof ServiceObject);
+      // Using assert.strictEqual instead of assert to prevent
+      // coercing of types.
+      assert.strictEqual(bucket instanceof ServiceObject, true);
 
       const calledWith = bucket.calledWith_[0];
 
@@ -2067,10 +2069,10 @@ describe('Bucket', () => {
       };
 
       FakeServiceObject.prototype.request = ((
-        reqOpts: DecorateRequestOptions
+        reqOpts: DecorateRequestOptions,
       ) => {
-        assert.strictEqual(reqOpts.qs, options.qs);
         assert.strictEqual(reqOpts.qs.userProject, USER_PROJECT);
+        assert.strictEqual(reqOpts.qs, options.qs);
         done();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any;

--- a/test/channel.ts
+++ b/test/channel.ts
@@ -68,7 +68,9 @@ describe('Channel', () => {
 
   describe('initialization', () => {
     it('should inherit from ServiceObject', () => {
-      assert(channel instanceof ServiceObject);
+      // Using assert.strictEqual instead of assert to prevent
+      // coercing of types.
+      assert.strictEqual(channel instanceof ServiceObject, true);
 
       const calledWith = channel.calledWith_[0];
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -264,7 +264,9 @@ describe('File', () => {
     });
 
     it('should inherit from ServiceObject', () => {
-      assert(file instanceof ServiceObject);
+      // Using assert.strictEqual instead of assert to prevent
+      // coercing of types.
+      assert.strictEqual(file instanceof ServiceObject, true);
 
       const calledWith = file.calledWith_[0];
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -123,7 +123,9 @@ describe('Storage', () => {
     });
 
     it('should inherit from Service', () => {
-      assert(storage instanceof Service);
+      // Using assert.strictEqual instead of assert to prevent
+      // coercing of types.
+      assert.strictEqual(storage instanceof Service, true);
 
       const calledWith = storage.calledWith_[0];
 


### PR DESCRIPTION
CI started to fail overnight on some assertions in our tests. I believe this has to do with [Assertion Functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) in TS3.7.

What I basically did in this PR is simply patching the breakrages, as I'm not sure how to proceed otherwise.

Calling on all node/ts experts @googleapis/yoshi-nodejs 