### PR TITLE
test: should throw original error message on non JSON response on large metadata

### DIFF
--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2143,19 +2143,19 @@ describe('storage', () => {
       };
 
       const file = bucket.file('large-metadata-error-test');
-      try {
-        // Save file with metadata size more then 2MB.
-        await file.save('test', {
-          resumable: false,
-          metadata: {
+      await assert.rejects(
+        async () => {
+          await file.save('test', {
+            resumable: false,
             metadata: {
-              custom: largeCustomMeta(2.1e6),
+              metadata: {
+                custom: largeCustomMeta(2.1e6),
+              },
             },
-          },
-        });
-      } catch (err) {
-        assert(err!.message.includes('Metadata part is too large.'));
-      }
+          });
+        },
+        (err: Error) => err.message.indexOf('Metadata part is too large.') > -1
+      );
     });
 
     it('should read a byte range from a file', done => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2143,19 +2143,16 @@ describe('storage', () => {
       };
 
       const file = bucket.file('large-metadata-error-test');
-      await assert.rejects(
-        async () => {
-          await file.save('test', {
-            resumable: false,
+      await assert.rejects(async () => {
+        await file.save('test', {
+          resumable: false,
+          metadata: {
             metadata: {
-              metadata: {
-                custom: largeCustomMeta(2.1e6),
-              },
+              custom: largeCustomMeta(2.1e6),
             },
-          });
-        },
-        (err: Error) => err.message.indexOf('Metadata part is too large.') > -1
-      );
+          },
+        });
+      }, /Metadata part is too large/);
     });
 
     it('should read a byte range from a file', done => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2143,21 +2143,19 @@ describe('storage', () => {
       };
 
       const file = bucket.file('large-metadata-error-test');
-      // Save file with metadata size more then 2MB.
-      await file.save(
-        'test',
-        {
+      try {
+        // Save file with metadata size more then 2MB.
+        await file.save('test', {
           resumable: false,
           metadata: {
             metadata: {
               custom: largeCustomMeta(2.1e6),
             },
           },
-        },
-        err => {
-          assert(err!.message.includes('Metadata part is too large.'));
-        }
-      );
+        });
+      } catch (err) {
+        assert(err!.message.includes('Metadata part is too large.'));
+      }
     });
 
     it('should read a byte range from a file', done => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2133,7 +2133,7 @@ describe('storage', () => {
         });
     });
 
-    it('should thow orignal error message on non JSON response on large metadata', async () => {
+    it('should throw original error message on non JSON response on large metadata', async () => {
       const largeCustomMeta = (size: number) => {
         let str = '';
         for (let i = 0; i < size; i++) {
@@ -2144,19 +2144,18 @@ describe('storage', () => {
 
       const file = bucket.file('large-metadata-error-test');
       // Save file with metadata size more then 2MB.
-      await assert.rejects(
-        async () => {
-          await file.save('test', {
-            resumable: false,
-            metadata: {
-              metadata: {
-                custom: largeCustomMeta(2.1e6),
-              },
-            },
-          });
-        },
+      await file.save(
+        'test',
         {
-          message: 'Cannot parse response as JSON: Metadata part is too large.',
+          resumable: false,
+          metadata: {
+            metadata: {
+              custom: largeCustomMeta(2.1e6),
+            },
+          },
+        },
+        err => {
+          assert(err!.message.includes('Metadata part is too large.'));
         }
       );
     });

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2143,16 +2143,17 @@ describe('storage', () => {
       };
 
       const file = bucket.file('large-metadata-error-test');
-      await assert.rejects(async () => {
-        await file.save('test', {
+      await assert.rejects(
+        file.save('test', {
           resumable: false,
           metadata: {
             metadata: {
               custom: largeCustomMeta(2.1e6),
             },
           },
-        });
-      }, /Metadata part is too large/);
+        }),
+        /Metadata part is too large/
+      );
     });
 
     it('should read a byte range from a file', done => {


### PR DESCRIPTION
In recent PR it's failing.
Ref:
#1240 
#1238 