### PR TITLE
fix: enable retries for simpleUpload_

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -3582,6 +3582,7 @@ class File extends ServiceObject<File> {
     const uri = `${apiEndpoint}/upload/storage/v1/b/${bucketName}/o`;
 
     const reqOpts: DecorateRequestOptions = {
+      maxRetries: 3,
       qs: {
         name: this.name,
       },

--- a/test/file.ts
+++ b/test/file.ts
@@ -4188,6 +4188,7 @@ describe('File', () => {
       makeWritableStreamOverride = (stream: {}, options_: any) => {
         assert.strictEqual(options_.metadata, options.metadata);
         assert.deepStrictEqual(options_.request, {
+          maxRetries: 3,
           qs: {
             name: file.name,
             predefinedAcl: options.predefinedAcl,


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

Rationale for setting value is because default value is set to [0](https://github.com/googleapis/nodejs-common/blob/dbaad170a2e3a6785568523086f15d88fb34eaca/src/util.ts#L465).

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)

Fixes #1281 🦕
Fixes #1233 

Repro steps:

## Setup testbench

1. Clone https://github.com/frankyn/google-cloud-cpp.git repository.
1. Checkout branch nodejs-multipart
1. Change Dir to google/cloud/storage/testbench
1. Follow set up in README.

## Run test script:

```javascript
// Imports the Google Cloud client library
const {Storage} = require('@google-cloud/storage');

// Your Google Cloud Platform project ID
const projectId = 'spec-test-ruby-samples';

// Creates a client
const apiEndpoint = 'http://localhost:8080';
const storage = new Storage({
  projectId: projectId,
  apiEndpoint,
});

// The name for the new bucket
const bucketName = 'anima-frank';
const contents = 'This is the contents of the file.';

storage.bucket(bucketName).create(function(err, bucket, apiResponse) {
  if (!err) {
    // The bucket was created successfully.
    console.log("Bucket created.");
    // Creates the new bucket
    storage
    .bucket(bucketName)
    .file('test')
    .save(contents, {
      resumable: false,
      },
      function(err) {
    if (!err) {
      // File written successfully.
      console.log("File was written!");
    }
    console.log(JSON.stringify(err));
    });
  }
});
```
