### PR TITLE
fix(types): add `CreateBucketRequest.storageClass`

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -83,6 +83,7 @@ export interface CreateBucketRequest {
   requesterPays?: boolean;
   retentionPolicy?: object;
   standard?: boolean;
+  storageClass?: string;
   userProject?: string;
   location?: string;
   versioning?: Versioning;


### PR DESCRIPTION
Closes #1248

The `CreateBucketRequest` interface was not accepting the `storageClass` string.