### PR TITLE
refactor(deps): replace concat-stream with get-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
     "@google-cloud/promisify": "^2.0.0",
     "arrify": "^2.0.0",
     "compressible": "^2.0.12",
-    "concat-stream": "^2.0.0",
     "date-and-time": "^0.14.0",
     "duplexify": "^4.0.0",
     "extend": "^3.0.2",
     "gaxios": "^3.0.0",
     "gcs-resumable-upload": "^3.1.0",
+    "get-stream": "^6.0.0",
     "hash-stream-validation": "^0.2.2",
     "mime": "^2.2.0",
     "mime-types": "^2.0.8",
@@ -77,6 +77,8 @@
     "@google-cloud/pubsub": "^2.0.0",
     "@grpc/grpc-js": "^1.0.3",
     "@grpc/proto-loader": "^0.5.1",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
     "@types/compressible": "^2.0.0",
     "@types/concat-stream": "^1.6.0",
     "@types/configstore": "^4.0.0",
@@ -111,8 +113,6 @@
     "tmp": "^0.2.0",
     "typescript": "^3.8.3",
     "uuid": "^8.0.0",
-    "yargs": "^16.0.0",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "yargs": "^16.0.0"
   }
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -24,7 +24,7 @@ import {
 import {promisifyAll} from '@google-cloud/promisify';
 
 import compressible = require('compressible');
-import concat = require('concat-stream');
+import getStream = require('get-stream');
 import * as crypto from 'crypto';
 import * as dateFormat from 'date-and-time';
 import * as extend from 'extend';
@@ -1267,12 +1267,10 @@ class File extends ServiceObject<File> {
       ) => {
         if (err) {
           // Get error message from the body.
-          rawResponseStream.pipe(
-            concat(body => {
-              err.message = body.toString();
-              throughStream.destroy(err);
-            })
-          );
+          getStream(rawResponseStream).then(body => {
+            err.message = body;
+            throughStream.destroy(err);
+          });
 
           return;
         }
@@ -1992,7 +1990,12 @@ class File extends ServiceObject<File> {
         .on('error', callback)
         .on('finish', callback);
     } else {
-      fileStream.on('error', callback).pipe(concat(callback.bind(null, null)));
+      getStream
+        .buffer(fileStream)
+        .then(
+          callback.bind(null, null) as (contents: Buffer) => void,
+          callback as (error: RequestError) => void
+        );
     }
   }
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -1992,10 +1992,8 @@ class File extends ServiceObject<File> {
     } else {
       getStream
         .buffer(fileStream)
-        .then(
-          callback.bind(null, null) as (contents: Buffer) => void,
-          callback as (error: RequestError) => void
-        );
+        .then(contents => callback?.(null, contents))
+        .catch(callback as (error: RequestError) => void);
     }
   }
 


### PR DESCRIPTION
Ref https://packagephobia.com/result?p=concat-stream https://packagephobia.com/result?p=get-stream

Concat-stream is a big package with not relevant in node 10 dependencies.
In this diff I replaced it with dependency-free get-stream with promise
based api.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
