### PR TITLE
fix: self-upload files for Unicode system tests

### DIFF
--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -890,10 +890,8 @@ describe('storage', () => {
       const name = 'Caf\u00e9';
       const expectedContents = 'Normalization Form C';
 
-      //Data setup
-      await bucket.file(name).save(expectedContents);
-
       const file = bucket.file(name);
+      await file.save(expectedContents);
 
       return file
         .get()
@@ -913,10 +911,8 @@ describe('storage', () => {
       const name = 'Cafe\u0301';
       const expectedContents = 'Normalization Form D';
 
-      //Data setup
-      await bucket.file(name).save(expectedContents);
-
       const file = bucket.file(name);
+      await file.save(expectedContents);
 
       return file
         .get()

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -880,17 +880,20 @@ describe('storage', () => {
 
     let bucket: Bucket;
 
-    before(() => {
-      bucket = storage.bucket('storage-library-test-bucket');
+    before(async () => {
+      [bucket] = await storage.createBucket(generateName());
     });
 
     // Normalization form C: a single character for e-acute;
     // URL should end with Cafe%CC%81
-    it('should not perform normalization form C', () => {
+    it('should not perform normalization form C', async () => {
       const name = 'Caf\u00e9';
-      const file = bucket.file(name);
-
       const expectedContents = 'Normalization Form C';
+
+      //Data setup
+      await bucket.file(name).save(expectedContents);
+
+      const file = bucket.file(name);
 
       return file
         .get()
@@ -906,11 +909,14 @@ describe('storage', () => {
 
     // Normalization form D: an ASCII character followed by U+0301 combining
     // character; URL should end with Caf%C3%A9
-    it('should not perform normalization form D', () => {
+    it('should not perform normalization form D', async () => {
       const name = 'Cafe\u0301';
-      const file = bucket.file(name);
-
       const expectedContents = 'Normalization Form D';
+
+      //Data setup
+      await bucket.file(name).save(expectedContents);
+
+      const file = bucket.file(name);
 
       return file
         .get()


### PR DESCRIPTION
The two unicode validation tests depended on a bucket which has been deleted. This PR changes those tests so that they create their own data. 
