### PR TITLE
feat: Experimental getFirebaseDownloadUrl API

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -276,7 +276,7 @@ export type GetFirebaseDownloadUrlCallback = GetSignedUrlCallback;
 
 interface FirebaseStorageMetadata {
   metadata?: {
-    firebaseStorageDownloadTokens?: string;
+    firebaseStorageDownloadTokens?: string | string[];
   };
 }
 
@@ -2932,7 +2932,12 @@ class File extends ServiceObject<File> {
     return this.getMetadata().then(response => {
       const metadata = response[0] as FirebaseStorageMetadata;
       if (metadata?.metadata?.firebaseStorageDownloadTokens) {
-        return metadata.metadata.firebaseStorageDownloadTokens;
+        const existingTokens = metadata.metadata.firebaseStorageDownloadTokens;
+        if (typeof existingTokens === 'string') {
+          return existingTokens;
+        } else if (existingTokens.length > 0) {
+          return existingTokens[0];
+        }
       }
 
       const token = generateDownloadToken();

--- a/test/file.ts
+++ b/test/file.ts
@@ -3222,6 +3222,24 @@ describe('File', () => {
       });
     });
 
+    it('should construct a Firebase download URL from the existing token list', done => {
+      const getMetadataStub = sandbox.stub(file, 'getMetadata').resolves([
+        {
+          metadata: {
+            firebaseStorageDownloadTokens: ['1st-token', '2nd-token'],
+          },
+        },
+      ]);
+      const expectedUrl = `https://firebasestorage.googleapis.com/v0/b/${file.bucket.name}/o/${file.name}?alt=media&token=1st-token`;
+
+      file.getFirebaseDownloadUrl((err: Error | null, url: string) => {
+        assert.ifError(err);
+        assert.strictEqual(url, expectedUrl);
+        assert.deepStrictEqual(getMetadataStub.callCount, 1);
+        done();
+      });
+    });
+
     it('should construct a Firebase download URL with a newly generated token', done => {
       const getMetadataStub = sandbox.stub(file, 'getMetadata').resolves([{}]);
       const setMetadataStub = sandbox.stub(file, 'setMetadata').resolves();


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)

Fixes #244 (using this old issue temporarily to kickoff the discussion) 🦕

### Background

Currently this library only supports generating signed URLs. Signed URLs have an expiry time, and are attached to a private key. They become invalid when the expiry time is up or when the private key gets cycled out. Firebase Storage (which operates on top of GCS) supports a notion of permanent download URLs. These URLs remain valid until the developer explicitly revokes them, and therefore are better for saving into a database or some other permanent record keeping system.

### Problem

There's currently a feature gap in the GCS SDK due to it only supporting signed URLs. Server-side Firebase developers have no easy way for generating Firebase download URLs using this library (or the Firebase Admin SDK that re-exports this library). This has resulted in several reported issues and questions on SO. 

The temporary nature of signed URLs often causes problems in environments like GCF where developers use application default credentials. The underlying service account automatically gets cycled out within a week or so, leaving all the signed URLs invalid. Firebase download URLs are a better fit for such use cases.

For more context:

* https://stackoverflow.com/questions/42956250/get-download-url-from-file-uploaded-with-cloud-functions-for-firebase
#244
* https://github.com/googleapis/nodejs-storage/issues/697
* https://github.com/firebase/extensions/issues/140#issuecomment-595195942

### Solution

Adding a new `getFirebaseDownloadUrl()` method to the `File` class that generates Firebase Storage download URLs (token based access control). 

Just wanted to know what the community thinks about this approach, and possible ways we can improve it.