### PR TITLE
feat: public url of a file

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -3061,6 +3061,25 @@ class File extends ServiceObject<File> {
     );
   }
 
+  /**
+   * The public URL of this File
+   * Use {@link File#makePublic} to enable anonymous access via the returned URL.
+   *
+   * @returns {string}
+   *
+   * @example
+   * const {Storage} = require('@google-cloud/storage');
+   * const storage = new Storage();
+   * const bucket = storage.bucket('albums');
+   * const file = bucket.file('my-file');
+   *
+   * file.publicUrl();
+   *  // Will return "https://storage.googleapis.com/albums/my-file"
+   */
+  publicUrl(): string {
+    return `${STORAGE_POST_POLICY_BASE_URL}/${this.bucket.name}/${this.name}`;
+  }
+
   move(
     destination: string | Bucket | File,
     options?: MoveOptions

--- a/src/file.ts
+++ b/src/file.ts
@@ -3077,7 +3077,7 @@ class File extends ServiceObject<File> {
    *  // Will return "https://storage.googleapis.com/albums/my-file"
    */
   publicUrl(): string {
-    return `${STORAGE_POST_POLICY_BASE_URL}/${this.bucket.name}/${this.name}`;
+    return `${this.storage.apiEndpoint}/${this.bucket.name}/${this.name}`;
   }
 
   move(

--- a/src/file.ts
+++ b/src/file.ts
@@ -3073,8 +3073,8 @@ class File extends ServiceObject<File> {
    * const bucket = storage.bucket('albums');
    * const file = bucket.file('my-file');
    *
-   * file.publicUrl();
-   *  // Will return "https://storage.googleapis.com/albums/my-file"
+   * const publicUrl = file.publicUrl();
+   *  // publicUrl will be "https://storage.googleapis.com/albums/my-file"
    */
   publicUrl(): string {
     return `${this.storage.apiEndpoint}/${this.bucket.name}/${this.name}`;

--- a/test/file.ts
+++ b/test/file.ts
@@ -3455,6 +3455,49 @@ describe('File', () => {
     });
   });
 
+  describe('publicUrl', () => {
+    it('should return the public URL', done => {
+      const NAME = 'file-name';
+      const file = new File(BUCKET, NAME);
+      assert.strictEqual(
+        file.publicUrl(),
+        `https://storage.googleapis.com/bucket-name/${NAME}`
+      );
+      done();
+    });
+
+    it('with slash in the name', done => {
+      const NAME = 'parent/child';
+      const file = new File(BUCKET, NAME);
+      assert.strictEqual(
+        file.publicUrl(),
+        `https://storage.googleapis.com/bucket-name/${NAME}`
+      );
+      done();
+    });
+
+    it('with tilde in the name', done => {
+      const NAME = 'foo~bar';
+      const file = new File(BUCKET, NAME);
+      assert.strictEqual(
+        file.publicUrl(),
+        `https://storage.googleapis.com/bucket-name/${NAME}`
+      );
+      done();
+    });
+
+    it('with non ascii in the name', done => {
+      const NAME = '\u2603';
+      console.log(NAME);
+      const file = new File(BUCKET, NAME);
+      assert.strictEqual(
+        file.publicUrl(),
+        `https://storage.googleapis.com/bucket-name/${NAME}`
+      );
+      done();
+    });
+  });
+
   describe('isPublic', () => {
     const sandbox = sinon.createSandbox();
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -3488,7 +3488,6 @@ describe('File', () => {
 
     it('with non ascii in the name', done => {
       const NAME = '\u2603';
-      console.log(NAME);
       const file = new File(BUCKET, NAME);
       assert.strictEqual(
         file.publicUrl(),


### PR DESCRIPTION
Created a function publicUrl equivalent to [this python function](https://github.com/googleapis/python-storage/blob/2dc91c947e3693023b4478a15c460693808ea2d9/google/cloud/storage/blob.py#L317).

Fixes https://github.com/googleapis/nodejs-storage/issues/931
