### PR TITLE
docs:  fix typo in readme

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,7 +1,7 @@
 # benchwrapper
 
 benchwrapper is a lightweight gRPC server that wraps the storage library for
-bencharmking purposes.
+benchmarking purposes.
 
 ## Running
 


### PR DESCRIPTION
I felt this was a misspelling, but I didn't understand.
If you misspell and find this fix useful, please incorporate my fix if you like.

I didn't create an issue because it's a small change.
