### PR TITLE
fix: add publicUrl to exclude promisifyAll

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -3798,7 +3798,7 @@ class File extends ServiceObject<File> {
  * that a callback is omitted.
  */
 promisifyAll(File, {
-  exclude: ['request', 'setEncryptionKey'],
+  exclude: ['request', 'setEncryptionKey', 'publicUrl'],
 });
 
 /**

--- a/src/file.ts
+++ b/src/file.ts
@@ -3798,7 +3798,7 @@ class File extends ServiceObject<File> {
  * that a callback is omitted.
  */
 promisifyAll(File, {
-  exclude: ['request', 'setEncryptionKey', 'publicUrl'],
+  exclude: ['publicUrl', 'request', 'setEncryptionKey'],
 });
 
 /**

--- a/test/file.ts
+++ b/test/file.ts
@@ -74,7 +74,11 @@ const fakePromisify = {
     }
 
     promisified = true;
-    assert.deepStrictEqual(options.exclude, ['publicUrl', 'request', 'setEncryptionKey']);
+    assert.deepStrictEqual(options.exclude, [
+      'publicUrl',
+      'request',
+      'setEncryptionKey',
+    ]);
   },
 };
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -74,7 +74,7 @@ const fakePromisify = {
     }
 
     promisified = true;
-    assert.deepStrictEqual(options.exclude, ['request', 'setEncryptionKey']);
+    assert.deepStrictEqual(options.exclude, ['publicUrl', 'request', 'setEncryptionKey']);
   },
 };
 


### PR DESCRIPTION
Fixes #1344 

I exclude "publicUrl" from the list of functions that will use promises