### PR TITLE
fix: only throw if `storageClass` and specific storage class name provide different values

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -641,7 +641,7 @@ export class Storage extends Service {
 
     Object.keys(storageClasses).forEach(storageClass => {
       if (body[storageClass]) {
-        if (metadata.storageClass) {
+        if (metadata.storageClass && metadata.storageClass !== storageClass) {
           throw new Error(
             `Both \`${storageClass}\` and \`storageClass\` were provided.`
           );

--- a/test/index.ts
+++ b/test/index.ts
@@ -619,7 +619,29 @@ describe('Storage', () => {
       storage.createBucket(BUCKET_NAME, {storageClass}, done);
     });
 
-    it('should throw when both `storageClass` and storageClass name are provided', () => {
+    it('should allow settings `storageClass` to same value as provided storage class name', done => {
+      const storageClass = 'coldline';
+      storage.request = (
+        reqOpts: DecorateRequestOptions,
+        callback: Function
+      ) => {
+        assert.strictEqual(
+          reqOpts.json.storageClass,
+          storageClass.toUpperCase()
+        );
+        callback(); // done
+      };
+
+      assert.doesNotThrow(() => {
+        storage.createBucket(
+          BUCKET_NAME,
+          {storageClass, [storageClass]: true},
+          done
+        );
+      });
+    });
+
+    it('should throw when `storageClass` is set do different value than provided storageClass name', () => {
       assert.throws(() => {
         storage.createBucket(
           BUCKET_NAME,

--- a/test/index.ts
+++ b/test/index.ts
@@ -641,7 +641,7 @@ describe('Storage', () => {
       });
     });
 
-    it('should throw when `storageClass` is set do different value than provided storageClass name', () => {
+    it('should throw when `storageClass` is set to different value than provided storageClass name', () => {
       assert.throws(() => {
         storage.createBucket(
           BUCKET_NAME,


### PR DESCRIPTION
To complement #1323 changes

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

