### PR TITLE
fix: capitalize action in Bucket#addLifecycleRule

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1136,7 +1136,6 @@ class Bucket extends ServiceObject {
     }
 
     options = options || {};
-    callback = callback || util.noop;
 
     const newLifecycleRules = arrify(rule).map(rule => {
       if (typeof rule.action === 'object') {

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1149,13 +1149,8 @@ class Bucket extends ServiceObject {
 
       apiFormattedRule.condition = {};
       apiFormattedRule.action = {
-        type: rule.action,
+        type: rule.action.charAt(0).toUpperCase() + rule.action.slice(1),
       };
-
-      // @TODO: Remove if the API becomes less picky.
-      if (rule.action === 'delete') {
-        apiFormattedRule.action.type = 'Delete';
-      }
 
       if (rule.storageClass) {
         apiFormattedRule.action.storageClass = rule.storageClass;

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -1165,11 +1165,12 @@ describe('storage', () => {
         },
       });
       await bucket.addLifecycleRule({
-        action: 'delete',
+        action: 'setStorageClass',
         condition: {
           age: 60,
           isLive: true,
         },
+        storageClass: 'coldline',
       });
       assert.strictEqual(
         bucket.metadata.lifecycle.rule.length,

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -352,7 +352,7 @@ describe('Bucket', () => {
       bucket.addLifecycleRule(rule, assert.ifError);
     });
 
-    it('should properly convert Delete rules', done => {
+    it('should properly capitalize rule action', done => {
       const rule = {
         action: 'delete',
         condition: {},
@@ -362,7 +362,7 @@ describe('Bucket', () => {
         assert.deepStrictEqual(metadata.lifecycle.rule, [
           {
             action: {
-              type: 'Delete',
+              type: rule.action.charAt(0).toUpperCase() + rule.action.slice(1),
             },
             condition: rule.condition,
           },
@@ -385,7 +385,7 @@ describe('Bucket', () => {
         assert.deepStrictEqual(metadata.lifecycle.rule, [
           {
             action: {
-              type: rule.action,
+              type: rule.action.charAt(0).toUpperCase() + rule.action.slice(1),
               storageClass: rule.storageClass,
             },
             condition: rule.condition,
@@ -402,6 +402,7 @@ describe('Bucket', () => {
       const date = new Date();
 
       const rule = {
+        action: 'delete',
         condition: {
           createdBefore: date,
         },

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -398,6 +398,29 @@ describe('Bucket', () => {
       bucket.addLifecycleRule(rule, assert.ifError);
     });
 
+    it('should properly set condition', done => {
+      const rule = {
+        action: 'delete',
+        condition: {
+          age: 30,
+        },
+      };
+
+      bucket.setMetadata = (metadata: Metadata) => {
+        assert.deepStrictEqual(metadata.lifecycle.rule, [
+          {
+            action: {
+              type: rule.action.charAt(0).toUpperCase() + rule.action.slice(1),
+            },
+            condition: rule.condition,
+          },
+        ]);
+        done();
+      };
+
+      bucket.addLifecycleRule(rule, assert.ifError);
+    });
+
     it('should convert Date object to date string for condition', done => {
       const date = new Date();
 
@@ -492,6 +515,27 @@ describe('Bucket', () => {
       };
 
       bucket.addLifecycleRule(rule, done);
+    });
+
+    it('should pass error from getMetadata to callback', done => {
+      const error = new Error('from getMetadata');
+      const rule = {
+        action: 'delete',
+        condition: {},
+      };
+
+      bucket.getMetadata = (callback: Function) => {
+        callback(error);
+      };
+
+      bucket.setMetadata = () => {
+        done(new Error('Metadata should not be set.'));
+      };
+
+      bucket.addLifecycleRule(rule, (err: Error) => {
+        assert.strictEqual(err, error);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Currently jsdoc sighted sample 

https://github.com/googleapis/nodejs-storage/blob/3db1e832af1cd3a394305b0a1120953d85f86249/src/bucket.ts#L1063-L1069

will fail with
```
Error: Invalid value for: setStorageClass is not a valid value
```

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
