### PR TITLE
fix: deprecate `options.promise` and sync options with Service

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {GoogleAuthOptions, Metadata, Service} from '@google-cloud/common';
+import {Metadata, Service, ServiceOptions} from '@google-cloud/common';
 import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 
@@ -45,7 +45,7 @@ export interface CreateBucketQuery {
   userProject: string;
 }
 
-export interface StorageOptions extends GoogleAuthOptions {
+export interface StorageOptions extends ServiceOptions {
   autoRetry?: boolean;
   maxRetries?: number;
   promise?: typeof Promise;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -49,6 +49,11 @@ export interface StorageOptions extends ServiceOptions {
   autoRetry?: boolean;
   maxRetries?: number;
   /**
+   * **This option is deprecated.**
+   * @todo Remove in next major release.
+   */
+  promise?: typeof Promise;
+  /**
    * The API endpoint of the service used to make requests.
    * Defaults to `storage.googleapis.com`.
    */

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -48,8 +48,6 @@ export interface CreateBucketQuery {
 export interface StorageOptions extends ServiceOptions {
   autoRetry?: boolean;
   maxRetries?: number;
-  promise?: typeof Promise;
-  userAgent?: string;
   /**
    * The API endpoint of the service used to make requests.
    * Defaults to `storage.googleapis.com`.
@@ -349,6 +347,7 @@ export class Storage extends Service {
 
   /**
    * @typedef {object} StorageOptions
+
    * @property {string} [projectId] The project ID from the Google Developer's
    *     Console, e.g. 'grape-spaceship-123'. We will also check the environment
    *     variable `GCLOUD_PROJECT` for your project ID. If your app is running
@@ -370,8 +369,6 @@ export class Storage extends Service {
    * errors. We will exponentially backoff subsequent requests by default.
    * @property {number} [maxRetries=3] Maximum number of automatic retries
    *     attempted before returning the error.
-   * @property {Constructor} [promise] Custom promise module to use instead of
-   *     native Promises.
    * @property {string} [userAgent] The value to be prepended to the User-Agent
    *     header in API requests.
    */
@@ -412,6 +409,8 @@ export class Storage extends Service {
 
     const config = {
       apiEndpoint: options.apiEndpoint!,
+      autoRetry: options.autoRetry,
+      maxRetries: options.maxRetries,
       baseUrl,
       customEndpoint,
       projectIdRequired: false,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -347,7 +347,6 @@ export class Storage extends Service {
 
   /**
    * @typedef {object} StorageOptions
-
    * @property {string} [projectId] The project ID from the Google Developer's
    *     Console, e.g. 'grape-spaceship-123'. We will also check the environment
    *     variable `GCLOUD_PROJECT` for your project ID. If your app is running

--- a/test/index.ts
+++ b/test/index.ts
@@ -169,6 +169,26 @@ describe('Storage', () => {
       assert.strictEqual(calledWith.apiEndpoint, `${apiEndpoint}`);
     });
 
+    it('should propagate autoRetry', () => {
+      const autoRetry = false;
+      const storage = new Storage({
+        projectId: PROJECT_ID,
+        autoRetry,
+      });
+      const calledWith = storage.calledWith_[0];
+      assert.strictEqual(calledWith.autoRetry, autoRetry);
+    });
+
+    it('should propagate maxRetries', () => {
+      const maxRetries = 10;
+      const storage = new Storage({
+        projectId: PROJECT_ID,
+        maxRetries,
+      });
+      const calledWith = storage.calledWith_[0];
+      assert.strictEqual(calledWith.maxRetries, maxRetries);
+    });
+
     it('should set customEndpoint to true when using apiEndpoint', () => {
       const storage = new Storage({
         projectId: PROJECT_ID,


### PR DESCRIPTION
As brought up in https://github.com/googleapis/nodejs-storage/issues/1284#issuecomment-768004492 (thanks, @oscar60310!), the options to the Storage constructor is `GoogleAuthOptions`, but I believe it was meant to be `ServiceOptions`:

```ts
// From @google-cloud/common
export interface ServiceOptions extends GoogleAuthOptions {
  authClient?: GoogleAuth;
  interceptors_?: Interceptor[];
  email?: string;
  token?: string;
  timeout?: number; // http.request.options.timeout
  userAgent?: string;
}

// From @google-cloud/storage
export interface StorageOptions extends GoogleAuthOptions {
  autoRetry?: boolean;
  maxRetries?: number;
  promise?: typeof Promise;
  userAgent?: string;
  apiEndpoint?: string;
}
```

A couple of other fixes and modernizations:

- `autoRetry` was not passed to the Service constructor
- `maxRetries` was not passed to the Service constructor
- The `promise` property was dropped a while ago: https://github.com/googleapis/nodejs-common/issues/107