### PR TITLE
docs: Clarify how to specify projectID in samples

### DIFF
--- a/samples/createBucketWithStorageClassAndLocation.js
+++ b/samples/createBucketWithStorageClassAndLocation.js
@@ -40,6 +40,9 @@ function main(
   // Creates a client
   const storage = new Storage();
 
+  // Creates a client using a specific project ID.
+  // const storage = new Storage({"my-gcp-project"});
+
   async function createBucketWithStorageClassAndLocation() {
     // For default values see: https://cloud.google.com/storage/docs/locations and
     // https://cloud.google.com/storage/docs/storage-classes

--- a/samples/createNewBucket.js
+++ b/samples/createNewBucket.js
@@ -27,6 +27,9 @@ function main(bucketName = 'my-bucket') {
   // Creates a client
   const storage = new Storage();
 
+  // Creates a client using a specific project ID.
+  // const storage = new Storage({"my-gcp-project"});
+
   async function createBucket() {
     // Creates a new bucket in the Asia region with the coldline default storage
     // class. Leave the second argument blank for default settings.

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -23,6 +23,10 @@ function main(
 
   // Creates a client
   const storage = new Storage();
+
+  // Creates a client using a specific project ID.
+  // const storage = new Storage({"my-gcp-project"});
+
   // Creates a client from a Google service account key.
   // const storage = new Storage({keyFilename: "key.json"});
 


### PR DESCRIPTION
Adds a comment to quickstart sample as well as bucket creation
samples (which send the project ID in the request) to clarify that
Storage can be initialized for a specific project.

Fixes an internal feedback bug on these samples.
