### PR TITLE
chore: update dependencies to support workload identity federation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "api-documenter": "api-documenter yaml --input-folder=temp"
   },
   "dependencies": {
-    "@google-cloud/common": "^3.5.0",
+    "@google-cloud/common": "^3.6.0",
     "@google-cloud/paginator": "^3.0.0",
     "@google-cloud/promisify": "^2.0.0",
     "arrify": "^2.0.0",
@@ -62,7 +62,7 @@
     "duplexify": "^4.0.0",
     "extend": "^3.0.2",
     "gaxios": "^4.0.0",
-    "gcs-resumable-upload": "^3.1.0",
+    "gcs-resumable-upload": "^3.1.3",
     "get-stream": "^6.0.0",
     "hash-stream-validation": "^0.2.2",
     "mime": "^2.2.0",


### PR DESCRIPTION
Bump up versions for:
- `@google-cloud/common` to "^3.6.0"
- `gcs-resumable-upload` to "^3.1.3"

The underlying `google-auth-library` dependencies in those libraries support workload identity federation.