### PR TITLE
fix(types): support metadata override in file.copy()

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -305,6 +305,7 @@ export interface FileOptions {
 
 export interface CopyOptions {
   destinationKmsKeyName?: string;
+  metadata?: Metadata;
   predefinedAcl?: string;
   token?: string;
   userProject?: string;
@@ -861,6 +862,7 @@ class File extends ServiceObject<File> {
    *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`,
    *     that will be used to encrypt the object. Overwrites the object
    * metadata's `kms_key_name` value, if any.
+   * @property {Metadata} [metadata] Metadata to specify on the copied file.
    * @property {string} [predefinedAcl] Set the ACL for the new file.
    * @property {string} [token] A previously-returned `rewriteToken` from an
    *     unfinished rewrite request.

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2810,6 +2810,24 @@ describe('storage', () => {
       await Promise.all([file.delete, copiedFile.delete()]);
     });
 
+    it('should copy an existing file and overwrite metadata', async () => {
+      const opts = {
+        destination: 'CloudLogo',
+        metadata: {
+          metadata: {
+            originalProperty: 'true',
+          },
+        },
+      };
+      const [file] = await bucket.upload(FILES.logo.path, opts);
+      const copyOpts = {metadata: {newProperty: 'true'}};
+      const [copiedFile] = await file.copy('CloudLogoCopy', copyOpts);
+      const [metadata] = await copiedFile.getMetadata();
+      assert.strictEqual(typeof metadata.metadata.originalProperty, 'undefined');
+      assert.strictEqual(metadata.metadata.newProperty, 'true');
+      await Promise.all([file.delete, copiedFile.delete()]);
+    });
+
     it('should respect predefined Acl at file#copy', async () => {
       const opts = {destination: 'CloudLogo'};
       const [file] = await bucket.upload(FILES.logo.path, opts);

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2823,7 +2823,10 @@ describe('storage', () => {
       const copyOpts = {metadata: {newProperty: 'true'}};
       const [copiedFile] = await file.copy('CloudLogoCopy', copyOpts);
       const [metadata] = await copiedFile.getMetadata();
-      assert.strictEqual(typeof metadata.metadata.originalProperty, 'undefined');
+      assert.strictEqual(
+        typeof metadata.metadata.originalProperty,
+        'undefined'
+      );
       assert.strictEqual(metadata.metadata.newProperty, 'true');
       await Promise.all([file.delete, copiedFile.delete()]);
     });


### PR DESCRIPTION
Fixes #1398 

`file.copy()` allows overwriting the original file's metadata:

```js
const originalFile = bucket.file('original-file-name')
const [copiedFile] = await originalFile.copy('new-file-name', {metadata: {thisIsACopy: 'true'}})
const [metadata] = await copiedFile.getMetadata()
// metadata.metadata.thisIsACopy === 'true'
```

But, we didn't document it through JSDocs or type docs. This fixes that and adds a system test.