### PR TITLE
docs: Fix typo in docstring for delimiter sample

### DIFF
--- a/samples/listFilesByPrefix.js
+++ b/samples/listFilesByPrefix.js
@@ -46,12 +46,12 @@ function main(bucketName = 'my-bucket', prefix = 'test', delimiter = '/') {
      *   /a/1.txt
      *   /a/b/2.txt
      *
-     * If you just specify prefix = '/a', you'll get back:
+     * If you just specify prefix = 'a/', you'll get back:
      *
      *   /a/1.txt
      *   /a/b/2.txt
      *
-     * However, if you specify prefix='/a' and delimiter='/', you'll get back:
+     * However, if you specify prefix='a/' and delimiter='/', you'll get back:
      *
      *   /a/1.txt
      */


### PR DESCRIPTION
Fixes: #1410