### PR TITLE
test: fix flaky test should get metadata for an HMAC key

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^8.0.0",
-    "node-fetch": "^2.3.0"
+    "node-fetch": "^2.3.0",
+    "p-limit": "^3.1.0"
   }
 }

--- a/samples/system-test/hmacKey.test.js
+++ b/samples/system-test/hmacKey.test.js
@@ -108,6 +108,12 @@ async function deleteStaleHmacKeys(serviceAccountEmail, projectId) {
       })
       .map(hmacKey =>
         limit(async () => {
+          console.info(
+            `Will delete HMAC key with access id ${hmacKey.metadata.accessId} and service account email ${hmacKey.metadata.serviceAccountEmail}`
+          );
+          console.info(
+            `This key was created on ${hmacKey.metadata.timeCreated} which is earlier than ${old}`
+          );
           await hmacKey.setMetadata({state: 'INACTIVE'});
           await hmacKey.delete();
         })

--- a/samples/system-test/hmacKey.test.js
+++ b/samples/system-test/hmacKey.test.js
@@ -90,10 +90,7 @@ describe('HMAC SA Key samples', () => {
 /*
  * Delete HMAC Keys older than 1 hour
  */
-async function deleteStaleHmacKeys(
-  serviceAccountEmail,
-  projectId
-) {
+async function deleteStaleHmacKeys(serviceAccountEmail, projectId) {
   const old = new Date();
   old.setHours(old.getHours() - 1);
   // list all HMAC keys for the given service account.

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2993,7 +2993,7 @@ describe('storage', () => {
 
     let accessId: string;
 
-    const delay = async (test: any, accessId: string) => {
+    const delay = async (test: Mocha.Context, accessId: string) => {
       const retries = test.currentRetry();
       if (retries === 0) return; // no retry on the first failure.
       // see: https://cloud.google.com/storage/docs/exponential-backoff:

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2993,6 +2993,19 @@ describe('storage', () => {
 
     let accessId: string;
 
+    const delay = async (test: any, accessId: string) => {
+      const retries = test.currentRetry();
+      if (retries === 0) return; // no retry on the first failure.
+      // see: https://cloud.google.com/storage/docs/exponential-backoff:
+      const ms = Math.pow(2, retries) * 500 + Math.random() * 1000;
+      return new Promise(done => {
+        console.info(
+          `retrying "${test.title}" with accessId ${accessId} in ${ms}ms`
+        );
+        setTimeout(done, ms);
+      });
+    };
+
     before(async () => {
       await deleteStaleHmacKeys(SERVICE_ACCOUNT, HMAC_PROJECT!);
       if (SECOND_SERVICE_ACCOUNT) {
@@ -3017,7 +3030,9 @@ describe('storage', () => {
       assert(typeof metadata.updated === 'string');
     });
 
-    it('should get metadata for an HMAC key', async () => {
+    it('should get metadata for an HMAC key', async function () {
+      this.retries(3);
+      delay(this, accessId);
       const hmacKey = storage.hmacKey(accessId, {projectId: HMAC_PROJECT});
       const [metadata] = await hmacKey.getMetadata();
       assert.strictEqual(metadata.accessId, accessId);
@@ -3888,6 +3903,12 @@ describe('storage', () => {
         })
         .map(hmacKey =>
           limit(async () => {
+            console.info(
+              `Will delete HMAC key with access id ${hmacKey.metadata?.accessId} and service account email ${hmacKey.metadata?.serviceAccountEmail}.`
+            );
+            console.info(
+              `This key was created on ${hmacKey.metadata?.timeCreated} which is earlier than ${old}.`
+            );
             await hmacKey.setMetadata({state: 'INACTIVE'});
             await hmacKey.delete();
           })


### PR DESCRIPTION
The suspected issue is that the sample test (running concurrently with the system tests) are deleting the HMAC keys needed by the system-tests. This ports over the function already used by the system-tests to remove old HMAC keys.

The issue could also be that HMAC keys are eventually consistent. In the case that this is happening, 3 retries are added to the failing test with exponential backoff. 

Fixes #https://github.com/googleapis/nodejs-storage/issues/1414 🦕
