### PR TITLE
fix: allow string encryption keys

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2069,10 +2069,12 @@ class File extends ServiceObject<File> {
    * Example of downloading an encrypted file:
    */
   setEncryptionKey(encryptionKey: string | Buffer) {
-    this.encryptionKey = encryptionKey;
-    this.encryptionKeyBase64 = Buffer.from(encryptionKey as string).toString(
-      'base64'
-    );
+    if (Buffer.isBuffer(encryptionKey)) {
+      this.encryptionKey = encryptionKey;
+    } else {
+      this.encryptionKey = Buffer.from(encryptionKey, 'base64');
+    }
+    this.encryptionKeyBase64 = this.encryptionKey.toString('base64');
     this.encryptionKeyHash = crypto
       .createHash('sha256')
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -546,7 +546,7 @@ describe('storage', () => {
       });
 
       it('should set custom encryption during the upload', done => {
-        const key = '12345678901234567890123456789012';
+        const key = crypto.randomBytes(32);
         bucket.upload(
           FILES.big.path,
           {

--- a/test/file.ts
+++ b/test/file.ts
@@ -4175,9 +4175,8 @@ describe('File', () => {
   });
 
   describe('setEncryptionKey', () => {
-    const KEY = crypto.randomBytes(32);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const KEY_BASE64 = Buffer.from(KEY as any).toString('base64');
+    const KEY_BUFFER = crypto.randomBytes(32);
+    const KEY_BASE64 = KEY_BUFFER.toString('base64');
     const KEY_HASH = crypto
       .createHash('sha256')
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -4186,11 +4185,15 @@ describe('File', () => {
     let _file: {};
 
     beforeEach(() => {
-      _file = file.setEncryptionKey(KEY);
+      _file = file.setEncryptionKey(KEY_BUFFER);
     });
 
-    it('should localize the key', () => {
-      assert.strictEqual(file.encryptionKey, KEY);
+    it('should localize the key as a Buffer', () => {
+      file.setEncryptionKey(KEY_BUFFER);
+      assert.deepStrictEqual(file.encryptionKey, KEY_BUFFER);
+
+      file.setEncryptionKey(KEY_BASE64);
+      assert.deepStrictEqual(file.encryptionKey, KEY_BUFFER);
     });
 
     it('should localize the base64 key', () => {


### PR DESCRIPTION
** edit ** I don't know if this was the right thing to do. Holding off for now.

The `encryptionKey` of `bucket.upload({encryptionKey})`, `bucket.file('name', {encryptionKey})`, and possibly others were said to accept either a String or Buffer. However, if a base64 string was provided, it was being re-encoded. This change will allow both to be handled separately, passing along the correct base64-encoded encryption key to the API.