### PR TITLE
fix(perf): pull hashes without refreshing metadata

### DIFF
--- a/test/file.ts
+++ b/test/file.ts
@@ -768,6 +768,9 @@ describe('File', () => {
   });
 
   describe('createReadStream', () => {
+    const CRC32C_HASH = 'crc32c-hash';
+    const MD5_HASH = 'md5-hash';
+
     function getFakeRequest(data?: {}) {
       let requestOptions: DecorateRequestOptions | undefined;
 
@@ -1130,10 +1133,6 @@ describe('File', () => {
             return requestStream;
           };
 
-          file.getMetadata = (options: object, callback: Function) => {
-            callback();
-          };
-
           file
             .createReadStream({validation: false})
             .on('error', (err: Error) => {
@@ -1154,6 +1153,10 @@ describe('File', () => {
       const GZIPPED_DATA = zlib.gzipSync(DATA);
 
       beforeEach(() => {
+        hashStreamValidationOverride = () =>
+          Object.assign(new PassThrough(), {
+            test: () => true,
+          });
         handleRespOverride = (
           err: Error,
           res: {},
@@ -1166,6 +1169,7 @@ describe('File', () => {
               return {
                 headers: {
                   'content-encoding': 'gzip',
+                  'x-goog-hash': `crc32c=${CRC32C_HASH},md5=${MD5_HASH}`,
                 },
               };
             },
@@ -1227,9 +1231,6 @@ describe('File', () => {
           });
           return createGunzipStream;
         };
-        file.getMetadata = (options: object, callback: Function) => {
-          callback();
-        };
         file
           .createReadStream({validation: false})
           .on('error', (err: Error) => {
@@ -1249,60 +1250,43 @@ describe('File', () => {
       let fakeValidationStream: Stream & {test: Function};
 
       beforeEach(() => {
-        file.metadata.mediaLink = 'http://uri';
-
-        file.getMetadata = (options: {}, callback: Function) => {
-          file.metadata = {
-            crc32c: '####wA==',
-            md5Hash: 'CY9rzUYh03PK3k6DJie09g==',
-          };
-          callback();
-        };
-
+        file.getMetadata = () => Promise.resolve({});
         fakeValidationStream = Object.assign(new PassThrough(), {
           test: () => true,
         });
         hashStreamValidationOverride = () => {
           return fakeValidationStream;
         };
+        handleRespOverride = (
+          err: Error,
+          res: {},
+          body: {},
+          callback: Function
+        ) => {
+          const rawResponseStream = new PassThrough();
+          Object.assign(rawResponseStream, {
+            toJSON() {
+              return {
+                headers: {
+                  'x-goog-hash': `crc32c=${CRC32C_HASH},md5=${MD5_HASH}`,
+                },
+              };
+            },
+          });
+          callback(null, null, rawResponseStream);
+          setImmediate(() => {
+            rawResponseStream.end(data);
+          });
+        };
+        file.requestStream = getFakeSuccessfulRequest(data);
       });
 
       describe('server decompression', () => {
-        beforeEach(() => {
-          handleRespOverride = (
-            err: Error,
-            res: {},
-            body: {},
-            callback: Function
-          ) => {
-            const rawResponseStream = new PassThrough();
-            Object.assign(rawResponseStream, {
-              toJSON() {
-                return {
-                  headers: {},
-                };
-              },
-            });
-            callback(null, null, rawResponseStream);
-            setImmediate(() => {
-              rawResponseStream.end(data);
-            });
-          };
-          file.requestStream = getFakeSuccessfulRequest(data);
-        });
-
         it('should skip validation if file was stored compressed', done => {
+          file.metadata.contentEncoding = 'gzip';
+
           const validateStub = sinon.stub().returns(true);
           fakeValidationStream.test = validateStub;
-
-          file.getMetadata = (options: {}, callback: Function) => {
-            file.metadata = {
-              crc32c: '####wA==',
-              md5Hash: 'CY9rzUYh03PK3k6DJie09g==',
-              contentEncoding: 'gzip',
-            };
-            callback();
-          };
 
           file
             .createReadStream({validation: 'crc32c'})
@@ -1368,18 +1352,19 @@ describe('File', () => {
 
         file.getMetadata = (options: GetFileMetadataOptions) => {
           assert.strictEqual(options.userProject, fakeOptions.userProject);
-          done();
+          setImmediate(done);
+          return Promise.resolve({});
         };
 
-        file.requestStream = getFakeSuccessfulRequest(data);
+        file.requestStream = getFakeSuccessfulRequest('data');
 
         file.createReadStream(fakeOptions).on('error', done).resume();
       });
 
       it('should destroy stream from failed metadata fetch', done => {
         const error = new Error('Error.');
-        file.getMetadata = (options: {}, callback: Function) => {
-          callback(error);
+        file.getMetadata = () => {
+          return Promise.reject(error);
         };
 
         file.requestStream = getFakeSuccessfulRequest('data');
@@ -1395,7 +1380,11 @@ describe('File', () => {
 
       it('should validate with crc32c', done => {
         file.requestStream = getFakeSuccessfulRequest(data);
-
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fakeValidationStream as any).test = (algo: string) => {
+          assert.strictEqual(algo, 'crc32c');
+          return true;
+        };
         file
           .createReadStream({validation: 'crc32c'})
           .on('error', done)
@@ -1430,7 +1419,10 @@ describe('File', () => {
       it('should emit an error if md5 validation fails', done => {
         file.requestStream = getFakeSuccessfulRequest('bad-data');
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (fakeValidationStream as any).test = () => false;
+        (fakeValidationStream as any).test = (algo: string) => {
+          assert.strictEqual(algo, 'md5');
+          return false;
+        };
         file
           .createReadStream({validation: 'md5'})
           .on('error', (err: ApiError) => {
@@ -1441,13 +1433,12 @@ describe('File', () => {
       });
 
       it('should default to crc32c validation', done => {
-        file.getMetadata = (options: {}, callback: Function) => {
-          file.metadata = {
-            crc32c: file.metadata.crc32c,
-          };
-          callback();
+        file.requestStream = getFakeSuccessfulRequest('bad-data');
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fakeValidationStream as any).test = (algo: string) => {
+          assert.strictEqual(algo, 'crc32c');
+          return false;
         };
-        file.requestStream = getFakeSuccessfulRequest(data);
         file
           .createReadStream()
           .on('error', (err: ApiError) => {
@@ -1486,13 +1477,25 @@ describe('File', () => {
         });
 
         it('should destroy if MD5 is requested but absent', done => {
-          file.getMetadata = (options: {}, callback: Function) => {
-            file.metadata = {
-              crc32c: file.metadata.crc32c,
-            };
-            callback();
+          handleRespOverride = (
+            err: Error,
+            res: {},
+            body: {},
+            callback: Function
+          ) => {
+            const rawResponseStream = new PassThrough();
+            Object.assign(rawResponseStream, {
+              toJSON() {
+                return {
+                  headers: {},
+                };
+              },
+            });
+            callback(null, null, rawResponseStream);
+            setImmediate(() => {
+              rawResponseStream.end();
+            });
           };
-
           file.requestStream = getFakeSuccessfulRequest('bad-data');
 
           const readStream = file.createReadStream({validation: 'md5'});


### PR DESCRIPTION
Fixes #1338

This PR narrows the conditions for when a metadata refresh is required during a file download.

Before:

1. user calls file.createReadStream()
1. file finishes downloading
1. we call `file.getMetadata()` to get the remote file's hashes, **even if the user disabled data integrity (validation: `false`)**
1. if validation wasn't explicitly disabled, we confirm data integrity, comparing locally computed hashes vs. hashes from the API

After:

1. user calls file.createReadStream()
1. our API call to begin the download grabs the remote file's hashes from the response headers (`x-goog-hash`)
1. file finishes downloading
1. if validation wasn't explicitly disabled, we confirm data integrity, comparing locally computed hashes vs. hashes from the first call to the API (step 2)

So, one less API call.