### PR TITLE
fix(perf): Dont always need credentials when signing

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -277,8 +277,14 @@ export class URLSigner {
     const credentialScope = `${datestamp}/auto/storage/goog4_request`;
 
     const sign = async () => {
-      const credentials = await this.authClient.getCredentials();
-      const credential = `${credentials.client_email}/${credentialScope}`;
+      let client_email;
+      if ((this.authClient as any).jsonContent?.client_email == null) { // eslint-disable-line
+        const credentials = await this.authClient.getCredentials();
+        client_email = credentials.client_email;
+      } else {
+        client_email = (this.authClient as any).jsonContent.client_email; // eslint-disable-line
+      }
+      const credential = `${client_email}/${credentialScope}`;
       const dateISO = dateFormat.format(
         config.accessibleAt ? config.accessibleAt : new Date(),
         'YYYYMMDD[T]HHmmss[Z]',


### PR DESCRIPTION
When getting signed urls, the credentials are always loaded
only so that the client email can be used in the signing blob.
The Google Auth client caches the email on the first call, which never
changed. When using GCE/GKE for authentication, calling
`getCredentials()` makes a call to the metadata service.
This call is often not needed because the email is already known.
In the case of signing many files at once, this can really degrade the
metadata service and cause timeout errors.
This change simply uses the cached client email if it exists, before
making a remote call

Fixes #1386