### PR TITLE
fix: update CopyOptions type to include cacheControl, contentType and contentEncoding

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -304,6 +304,9 @@ export interface FileOptions {
 }
 
 export interface CopyOptions {
+  cacheControl?: string;
+  contentEncoding?: string;
+  contentType?: string;
   destinationKmsKeyName?: string;
   metadata?: Metadata;
   predefinedAcl?: string;
@@ -857,6 +860,9 @@ class File extends ServiceObject<File> {
    * @typedef {object} CopyOptions Configuration options for File#copy(). See an
    *     [Object
    * resource](https://cloud.google.com/storage/docs/json_api/v1/objects#resource).
+   * @property {string} [cacheControl] The cacheControl setting for the new file.
+   * @property {string} [contentEncoding] The contentEncoding setting for the new file.
+   * @property {string} [contentType] The contentType setting for the new file.
    * @property {string} [destinationKmsKeyName] Resource name of the Cloud
    *     KMS key, of the form
    *     `projects/my-project/locations/location/keyRings/my-kr/cryptoKeys/my-key`,

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2810,7 +2810,7 @@ describe('storage', () => {
       await Promise.all([file.delete, copiedFile.delete()]);
     });
 
-    it('should copy an existing file and overwrite metadata', async () => {
+    it('should copy an existing file and overwrite custom metadata', async () => {
       const opts = {
         destination: 'CloudLogo',
         metadata: {
@@ -2828,6 +2828,27 @@ describe('storage', () => {
         'undefined'
       );
       assert.strictEqual(metadata.metadata.newProperty, 'true');
+      await Promise.all([file.delete, copiedFile.delete()]);
+    });
+
+    it('should copy an existing file and overwrite metadata', async () => {
+      const opts = {
+        destination: 'CloudLogo',
+      };
+      const CACHE_CONTROL = 'private';
+      const CONTENT_ENCODING = 'gzip';
+      const CONTENT_TYPE = 'application/octet-stream';
+      const [file] = await bucket.upload(FILES.logo.path, opts);
+      const copyOpts = {
+        cacheControl: CACHE_CONTROL,
+        contentEncoding: CONTENT_ENCODING,
+        contentType: CONTENT_TYPE,
+      };
+      const [copiedFile] = await file.copy('CloudLogoCopy', copyOpts);
+      const [metadata] = await copiedFile.getMetadata();
+      assert.strictEqual(metadata.contentEncoding, CONTENT_ENCODING);
+      assert.strictEqual(metadata.cacheControl, CACHE_CONTROL);
+      assert.strictEqual(metadata.contentType, CONTENT_TYPE);
       await Promise.all([file.delete, copiedFile.delete()]);
     });
 

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2837,7 +2837,7 @@ describe('storage', () => {
       };
       const CACHE_CONTROL = 'private';
       const CONTENT_ENCODING = 'gzip';
-      const CONTENT_TYPE = 'application/octet-stream';
+      const CONTENT_TYPE = 'text/plain';
       const [file] = await bucket.upload(FILES.logo.path, opts);
       const copyOpts = {
         cacheControl: CACHE_CONTROL,


### PR DESCRIPTION
As explained in https://github.com/googleapis/nodejs-storage/issues/1422, `File.copy` already allows users to update these fields. It was missing documentation. This adds that documentation by adding those fields to the type & adds a system test for it.

Fixes: https://github.com/googleapis/nodejs-storage/issues/1422 🦕
