### PR TITLE
docs: change some indents for better markup

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1572,12 +1572,12 @@ class Bucket extends ServiceObject {
    * @property {string} [objectNamePrefix] If present, only apply this
    *     notification configuration to object names that begin with this prefix.
    * @property {string} [payloadFormat] The desired content of the Payload.
-   *     Defaults to `JSON_API_V1`.
+   * Defaults to `JSON_API_V1`.
    *
-   *     Acceptable values are:
-   *     - `JSON_API_V1`
+   * Acceptable values are:
+   * - `JSON_API_V1`
    *
-   *     - `NONE`
+   * - `NONE`
    * @property {string} [userProject] The ID of the project which will be
    *     billed for the request.
    */
@@ -1598,13 +1598,13 @@ class Bucket extends ServiceObject {
    * @see [Notifications: insert]{@link https://cloud.google.com/storage/docs/json_api/v1/notifications/insert}
    *
    * @param {Topic|string} topic The Cloud PubSub topic to which this
-   *     subscription publishes. If the project ID is omitted, the current
+   * subscription publishes. If the project ID is omitted, the current
    * project ID will be used.
    *
-   *     Acceptable formats are:
-   *     - `projects/grape-spaceship-123/topics/my-topic`
+   * Acceptable formats are:
+   * - `projects/grape-spaceship-123/topics/my-topic`
    *
-   *     - `my-topic`
+   * - `my-topic`
    * @param {CreateNotificationOptions} [options] Metadata to set for the
    *     notification.
    * @param {object} [options.customAttributes] An optional list of additional
@@ -1615,12 +1615,12 @@ class Bucket extends ServiceObject {
    * @param {string} [options.objectNamePrefix] If present, only apply this
    *     notification configuration to object names that begin with this prefix.
    * @param {string} [options.payloadFormat] The desired content of the Payload.
-   *     Defaults to `JSON_API_V1`.
+   * Defaults to `JSON_API_V1`.
    *
-   *     Acceptable values are:
-   *     - `JSON_API_V1`
+   * Acceptable values are:
+   * - `JSON_API_V1`
    *
-   *     - `NONE`
+   * - `NONE`
    * @param {string} [options.userProject] The ID of the project which will be
    *     billed for the request.
    * @param {CreateNotificationCallback} [callback] Callback function.
@@ -2610,17 +2610,18 @@ class Bucket extends ServiceObject {
    *     "https://cdn.example.com".
    *     See [reference]{@link https://cloud.google.com/storage/docs/access-control/signed-urls#example}
    * @property {object} [extensionHeaders] If these headers are used, the
-   *     server will check to make sure that the client provides matching
+   * server will check to make sure that the client provides matching
    * values. See [Canonical extension
    * headers](https://cloud.google.com/storage/docs/access-control/signed-urls#about-canonical-extension-headers)
-   *     for the requirements of this feature, most notably:
-   *       - The header name must be prefixed with `x-goog-`
-   *       - The header name must be all lowercase
-   *     Note: Multi-valued header passed as an array in the extensionHeaders
-   *           object is converted into a string, delimited by `,` with
-   *           no space. Requests made using the signed URL will need to
-   *           delimit multi-valued headers using a single `,` as well, or
-   *           else the server will report a mismatched signature.
+   * for the requirements of this feature, most notably:
+   * - The header name must be prefixed with `x-goog-`
+   * - The header name must be all lowercase
+   *
+   * Note: Multi-valued header passed as an array in the extensionHeaders
+   *       object is converted into a string, delimited by `,` with
+   *       no space. Requests made using the signed URL will need to
+   *       delimit multi-valued headers using a single `,` as well, or
+   *       else the server will report a mismatched signature.
    * @property {object} [queryParams] Additional query parameters to include
    *     in the signed URL.
    */
@@ -2658,17 +2659,18 @@ class Bucket extends ServiceObject {
    *     "https://cdn.example.com".
    *     See [reference]{@link https://cloud.google.com/storage/docs/access-control/signed-urls#example}
    * @param {object} [config.extensionHeaders] If these headers are used, the
-   *     server will check to make sure that the client provides matching
+   * server will check to make sure that the client provides matching
    * values. See [Canonical extension
    * headers](https://cloud.google.com/storage/docs/access-control/signed-urls#about-canonical-extension-headers)
-   *     for the requirements of this feature, most notably:
-   *       - The header name must be prefixed with `x-goog-`
-   *       - The header name must be all lowercase
-   *     Note: Multi-valued header passed as an array in the extensionHeaders
-   *           object is converted into a string, delimited by `,` with
-   *           no space. Requests made using the signed URL will need to
-   *           delimit multi-valued headers using a single `,` as well, or
-   *           else the server will report a mismatched signature.
+   * for the requirements of this feature, most notably:
+   * - The header name must be prefixed with `x-goog-`
+   * - The header name must be all lowercase
+   *
+   * Note: Multi-valued header passed as an array in the extensionHeaders
+   *       object is converted into a string, delimited by `,` with
+   *       no space. Requests made using the signed URL will need to
+   *       delimit multi-valued headers using a single `,` as well, or
+   *       else the server will report a mismatched signature.
    * @property {object} [config.queryParams] Additional query parameters to include
    *     in the signed URL.
    * @param {GetSignedUrlCallback} [callback] Callback function.
@@ -3474,24 +3476,24 @@ class Bucket extends ServiceObject {
    * @property {string} [offset] The starting byte of the upload stream, for
    *     resuming an interrupted upload. Defaults to 0.
    * @property {string} [predefinedAcl] Apply a predefined set of access
-   *     controls to this object.
+   * controls to this object.
    *
-   *     Acceptable values are:
-   *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
+   * Acceptable values are:
+   * - **`authenticatedRead`** - Object owner gets `OWNER` access, and
    *       `allAuthenticatedUsers` get `READER` access.
    *
-   *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
+   * - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
    *       project team owners get `OWNER` access.
    *
-   *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
+   * - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
    *       team owners get `READER` access.
    *
-   *     - **`private`** - Object owner gets `OWNER` access.
+   * - **`private`** - Object owner gets `OWNER` access.
    *
-   *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
+   * - **`projectPrivate`** - Object owner gets `OWNER` access, and project
    *       team members get access according to their roles.
    *
-   *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
+   * - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
    *       get `READER` access.
    * @property {boolean} [private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
@@ -3562,25 +3564,24 @@ class Bucket extends ServiceObject {
    * @param {string} [options.offset] The starting byte of the upload stream, for
    *     resuming an interrupted upload. Defaults to 0.
    * @param {string} [options.predefinedAcl] Apply a predefined set of access
-   *     controls to this object.
+   * controls to this object.
+   * Acceptable values are:
+   * - **`authenticatedRead`** - Object owner gets `OWNER` access, and
+   *   `allAuthenticatedUsers` get `READER` access.
    *
-   *     Acceptable values are:
-   *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
-   *       `allAuthenticatedUsers` get `READER` access.
+   * - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
+   *   project team owners get `OWNER` access.
    *
-   *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
-   *       project team owners get `OWNER` access.
+   * - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
+   *   team owners get `READER` access.
    *
-   *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
-   *       team owners get `READER` access.
+   * - **`private`** - Object owner gets `OWNER` access.
    *
-   *     - **`private`** - Object owner gets `OWNER` access.
+   * - **`projectPrivate`** - Object owner gets `OWNER` access, and project
+   *   team members get access according to their roles.
    *
-   *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
-   *       team members get access according to their roles.
-   *
-   *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
-   *       get `READER` access.
+   * - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
+   *   get `READER` access.
    * @param {boolean} [options.private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
    * @param {boolean} [options.public] Make the uploaded file public. (Alias for

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -3492,7 +3492,7 @@ class Bucket extends ServiceObject {
    *       team members get access according to their roles.
    *
    *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
-   * get `READER` access.
+   *       get `READER` access.
    * @property {boolean} [private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
    * @property {boolean} [public] Make the uploaded file public. (Alias for
@@ -3580,7 +3580,7 @@ class Bucket extends ServiceObject {
    *       team members get access according to their roles.
    *
    *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
-   * get `READER` access.
+   *       get `READER` access.
    * @param {boolean} [options.private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
    * @param {boolean} [options.public] Make the uploaded file public. (Alias for

--- a/src/file.ts
+++ b/src/file.ts
@@ -1469,25 +1469,25 @@ class File extends ServiceObject<File> {
    * @property {object} [metadata] Metadata to set on the file.
    * @property {string} [origin] Origin header to set for the upload.
    * @property {string} [predefinedAcl] Apply a predefined set of access
-   *     controls to this object.
+   * controls to this object.
    *
-   *     Acceptable values are:
-   *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
-   *       `allAuthenticatedUsers` get `READER` access.
+   * Acceptable values are:
+   * - **`authenticatedRead`** - Object owner gets `OWNER` access, and
+   *   `allAuthenticatedUsers` get `READER` access.
    *
-   *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
-   *       project team owners get `OWNER` access.
+   * - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
+   *   project team owners get `OWNER` access.
    *
-   *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
-   *       team owners get `READER` access.
+   * - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
+   *   team owners get `READER` access.
    *
-   *     - **`private`** - Object owner gets `OWNER` access.
+   * - **`private`** - Object owner gets `OWNER` access.
    *
-   *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
-   *       team members get access according to their roles.
+   * - **`projectPrivate`** - Object owner gets `OWNER` access, and project
+   *   team members get access according to their roles.
    *
-   *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
-   *       get `READER` access.
+   * - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
+   *   get `READER` access.
    * @property {boolean} [private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
    * @property {boolean} [public] Make the uploaded file public. (Alias for
@@ -1587,25 +1587,25 @@ class File extends ServiceObject<File> {
    * @property {number} [offset] The starting byte of the upload stream, for
    *     resuming an interrupted upload. Defaults to 0.
    * @property {string} [predefinedAcl] Apply a predefined set of access
-   *     controls to this object.
+   * controls to this object.
    *
-   *     Acceptable values are:
-   *     - **`authenticatedRead`** - Object owner gets `OWNER` access, and
-   *       `allAuthenticatedUsers` get `READER` access.
+   * Acceptable values are:
+   * - **`authenticatedRead`** - Object owner gets `OWNER` access, and
+   *   `allAuthenticatedUsers` get `READER` access.
    *
-   *     - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
-   *       project team owners get `OWNER` access.
+   * - **`bucketOwnerFullControl`** - Object owner gets `OWNER` access, and
+   *   project team owners get `OWNER` access.
    *
-   *     - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
-   *       team owners get `READER` access.
+   * - **`bucketOwnerRead`** - Object owner gets `OWNER` access, and project
+   *   team owners get `READER` access.
    *
-   *     - **`private`** - Object owner gets `OWNER` access.
+   * - **`private`** - Object owner gets `OWNER` access.
    *
-   *     - **`projectPrivate`** - Object owner gets `OWNER` access, and project
-   *       team members get access according to their roles.
+   * - **`projectPrivate`** - Object owner gets `OWNER` access, and project
+   *   team members get access according to their roles.
    *
-   *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
-   *       get `READER` access.
+   * - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
+   *   get `READER` access.
    * @property {boolean} [private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
    * @property {boolean} [public] Make the uploaded file public. (Alias for
@@ -2769,17 +2769,18 @@ class File extends ServiceObject<File> {
    *     this parameter is not provided here, the client must not provide any value
    *     for this HTTP header in its request.
    * @param {object} [config.extensionHeaders] If these headers are used, the
-   *     server will check to make sure that the client provides matching
+   * server will check to make sure that the client provides matching
    * values. See [Canonical extension
    * headers](https://cloud.google.com/storage/docs/access-control/signed-urls#about-canonical-extension-headers)
-   *     for the requirements of this feature, most notably:
-   *       - The header name must be prefixed with `x-goog-`
-   *       - The header name must be all lowercase
-   *     Note: Multi-valued header passed as an array in the extensionHeaders
-   *           object is converted into a string, delimited by `,` with
-   *           no space. Requests made using the signed URL will need to
-   *           delimit multi-valued headers using a single `,` as well, or
-   *           else the server will report a mismatched signature.
+   * for the requirements of this feature, most notably:
+   * - The header name must be prefixed with `x-goog-`
+   * - The header name must be all lowercase
+   *
+   * Note: Multi-valued header passed as an array in the extensionHeaders
+   *       object is converted into a string, delimited by `,` with
+   *       no space. Requests made using the signed URL will need to
+   *       delimit multi-valued headers using a single `,` as well, or
+   *       else the server will report a mismatched signature.
    * @param {object} [config.queryParams] Additional query parameters to include
    *     in the signed URL.
    * @param {string} [config.promptSaveAs] The filename to prompt the user to

--- a/src/file.ts
+++ b/src/file.ts
@@ -1487,7 +1487,7 @@ class File extends ServiceObject<File> {
    *       team members get access according to their roles.
    *
    *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
-   * get `READER` access.
+   *       get `READER` access.
    * @property {boolean} [private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
    * @property {boolean} [public] Make the uploaded file public. (Alias for
@@ -1605,7 +1605,7 @@ class File extends ServiceObject<File> {
    *       team members get access according to their roles.
    *
    *     - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers`
-   * get `READER` access.
+   *       get `READER` access.
    * @property {boolean} [private] Make the uploaded file private. (Alias for
    *     `options.predefinedAcl = 'private'`)
    * @property {boolean} [public] Make the uploaded file public. (Alias for

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -130,13 +130,13 @@ class Notification extends ServiceObject {
        * @method Notification#exists
        *
        * @param {Topic|string} topic The Cloud PubSub topic to which this
-       *     subscription publishes. If the project ID is omitted, the current
-       *     project ID will be used.
+       * subscription publishes. If the project ID is omitted, the current
+       * project ID will be used.
        *
-       *     Acceptable formats are:
-       *     - `projects/grape-spaceship-123/topics/my-topic`
+       * Acceptable formats are:
+       * - `projects/grape-spaceship-123/topics/my-topic`
        *
-       *     - `my-topic`
+       * - `my-topic`
        * @param {CreateNotificationRequest} [options] Metadata to set for
        *     the notification.
        * @param {CreateNotificationCallback} [callback] Callback function.


### PR DESCRIPTION
Thank you for making a great product.

[Current document](https://googleapis.dev/nodejs/storage/latest/index.html) is really nice, but some markups are broken or unnatural, that's why I propose some jsdoc changes here.

Note: I didn't open an issue because that description would be nearly the same as this pull request. Let me know if I should open an issue even though.

* Commit  7f532b3 fixes some indents. Not effective if d779740 (see below) is accepted.

| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/4680738/116517780-5ffb3d80-a90a-11eb-91e6-bb11151dd420.png) | <img width="541" alt="スクリーンショット 2021-04-29 14 05 59" src="https://user-images.githubusercontent.com/4680738/116518024-b49eb880-a90a-11eb-9c9b-ee1138ba7306.png"> |

* Commit d779740 provides the better display of list elements by modifying some part of the current indent rule.

| | Before ([current doc](https://googleapis.dev/nodejs/storage/latest/index.html)) | After (this PR) |
| --- | --- | --- |
| `predefinedAcl` (e.g. [Bucket upload](https://googleapis.dev/nodejs/storage/latest/Bucket.html#upload)) | <img width="541" src="https://user-images.githubusercontent.com/4680738/116518024-b49eb880-a90a-11eb-9c9b-ee1138ba7306.png"> | ![](https://user-images.githubusercontent.com/4680738/116518381-2119b780-a90b-11eb-8021-1f095389e3e0.png) |
| `extensionHeaders` (e.g. [Bucket getSignedUrl](https://googleapis.dev/nodejs/storage/latest/Bucket.html#getSignedUrl)) | ![](https://user-images.githubusercontent.com/4680738/116518613-6a6a0700-a90b-11eb-943e-cc2ebba88281.png) | ![](https://user-images.githubusercontent.com/4680738/116518629-71911500-a90b-11eb-900b-77310915fcf0.png) |
| `topic` (e.g. [Bucket createNotification](https://googleapis.dev/nodejs/storage/latest/Bucket.html#createNotification)) | ![](https://user-images.githubusercontent.com/4680738/116518790-ab621b80-a90b-11eb-8100-ee148962f1e4.png) | ![](https://user-images.githubusercontent.com/4680738/116518826-b321c000-a90b-11eb-8631-66e1c00077df.png) |
| `payloadFormat` (e.g. [Bucket createNotification](https://googleapis.dev/nodejs/storage/latest/Bucket.html#createNotification)) | ![](https://user-images.githubusercontent.com/4680738/116518869-c16fdc00-a90b-11eb-90b2-60027b0586eb.png) | ![](https://user-images.githubusercontent.com/4680738/116518878-c46acc80-a90b-11eb-9f48-ffc8bfc5efc8.png) |

I roughly searched the whole code and it seems no other part of the code should be fixed.

I think this markup is much better than the current one, though this change may be against current indentation custom. Feel free to tell me your opinion.

---
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)