### PR TITLE
chore: removed HMAC key test logs

### DIFF
--- a/samples/system-test/hmacKey.test.js
+++ b/samples/system-test/hmacKey.test.js
@@ -108,12 +108,6 @@ async function deleteStaleHmacKeys(serviceAccountEmail, projectId) {
       })
       .map(hmacKey =>
         limit(async () => {
-          console.info(
-            `Will delete HMAC key with access id ${hmacKey.metadata.accessId} and service account email ${hmacKey.metadata.serviceAccountEmail}`
-          );
-          console.info(
-            `This key was created on ${hmacKey.metadata.timeCreated} which is earlier than ${old}`
-          );
           await hmacKey.setMetadata({state: 'INACTIVE'});
           await hmacKey.delete();
         })

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -3923,12 +3923,6 @@ describe('storage', () => {
         })
         .map(hmacKey =>
           limit(async () => {
-            console.info(
-              `Will delete HMAC key with access id ${hmacKey.metadata?.accessId} and service account email ${hmacKey.metadata?.serviceAccountEmail}.`
-            );
-            console.info(
-              `This key was created on ${hmacKey.metadata?.timeCreated} which is earlier than ${old}.`
-            );
             await hmacKey.setMetadata({state: 'INACTIVE'});
             await hmacKey.delete();
           })


### PR DESCRIPTION
These logs were added in this PR https://github.com/googleapis/nodejs-storage/pull/1417/files so that if these tests failed again, they could be debugged via build logs. The tests did not continue to fail, so these logs are no longer needed.