### PR TITLE
fix(deps): updated gcs-resumable-upload dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "duplexify": "^4.0.0",
     "extend": "^3.0.2",
     "gaxios": "^4.0.0",
-    "gcs-resumable-upload": "^3.1.3",
+    "gcs-resumable-upload": "^3.1.4",
     "get-stream": "^6.0.0",
     "hash-stream-validation": "^0.2.2",
     "mime": "^2.2.0",


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/1373 🦕

Authentication is bypassed when using an emulator in [this](https://github.com/googleapis/gcs-resumable-upload/releases/tag/v3.1.4) release of gcs-resumable-upload. This PR updates the dependency so storage has this fix.