### PR TITLE
docs: Notification create documentation was listed as exists

### DIFF
--- a/src/notification.ts
+++ b/src/notification.ts
@@ -127,7 +127,7 @@ class Notification extends ServiceObject {
        * Creates a notification subscription for the bucket.
        *
        * @see [Notifications: insert]{@link https://cloud.google.com/storage/docs/json_api/v1/notifications/insert}
-       * @method Notification#exists
+       * @method Notification#create
        *
        * @param {Topic|string} topic The Cloud PubSub topic to which this
        * subscription publishes. If the project ID is omitted, the current


### PR DESCRIPTION
Documentation for `notification.exists` is listed [twice](https://googleapis.dev/nodejs/storage/latest/Notification.html#exists). 
![image](https://user-images.githubusercontent.com/25015959/117043396-04420300-acc2-11eb-9828-bc7d3f3c2a99.png)

This is because the first one should be `notification.create`.
