### PR TITLE
docs: fixed formatting for storage constructor

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -380,8 +380,8 @@ export class Storage extends Service {
    * Constructs the Storage client.
    *
    * @example <caption>Create a client that uses Application Default Credentials
-   * (ADC)</caption> 
-   * const {Storage} = require('@google-cloud/storage'); 
+   * (ADC)</caption>
+   * const {Storage} = require('@google-cloud/storage');
    * const storage = new Storage();
    *
    * @example <caption>Create a client with explicit credentials</caption>

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -380,11 +380,11 @@ export class Storage extends Service {
    * Constructs the Storage client.
    *
    * @example <caption>Create a client that uses Application Default Credentials
-   * (ADC)</caption> const {Storage} = require('@google-cloud/storage'); const
-   * storage = new Storage();
+   * (ADC)</caption> 
+   * const {Storage} = require('@google-cloud/storage'); 
+   * const storage = new Storage();
    *
    * @example <caption>Create a client with explicit credentials</caption>
-   * storage');/storage');
    * const storage = new Storage({
    *   projectId: 'your-project-id',
    *   keyFilename: '/path/to/keyfile.json'


### PR DESCRIPTION
The current documentation for the storage constructor renders like this: 
![image](https://user-images.githubusercontent.com/25015959/117848473-327e9000-b238-11eb-9523-a2dcb53f8147.png)
This PR aims to fix this.