### PR TITLE
test: fix precondition test

### DIFF
--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -3378,20 +3378,14 @@ describe('storage', () => {
         .file(fileName)
         .save('hello1', {resumable: false});
       await assert.rejects(
-        async () => {
-          await bucketWithVersioning
+        bucketWithVersioning
             .file(fileName, {generation: 0})
-            .save('hello2');
-        },
-        {
-          code: 412,
-          errors: [
-            {
-              reason: 'conditionNotMet',
-            }
-          ]
-        }
-      );
+            .save('hello2'),
+            (err: ApiError) => {
+              assert.strictEqual(err.code, 412);
+              assert.strictEqual(err.errors![0].reason, 'conditionNotMet');
+              return true;
+            });
       await bucketWithVersioning
         .file(fileName)
         .save('hello3', {resumable: false});

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -3385,7 +3385,7 @@ describe('storage', () => {
         },
         {
           code: 412,
-          message: 'Precondition Failed',
+          reason: 'conditionNotMet',
         }
       );
       await bucketWithVersioning

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -3378,14 +3378,13 @@ describe('storage', () => {
         .file(fileName)
         .save('hello1', {resumable: false});
       await assert.rejects(
-        bucketWithVersioning
-            .file(fileName, {generation: 0})
-            .save('hello2'),
-            (err: ApiError) => {
-              assert.strictEqual(err.code, 412);
-              assert.strictEqual(err.errors![0].reason, 'conditionNotMet');
-              return true;
-            });
+        bucketWithVersioning.file(fileName, {generation: 0}).save('hello2'),
+        (err: ApiError) => {
+          assert.strictEqual(err.code, 412);
+          assert.strictEqual(err.errors![0].reason, 'conditionNotMet');
+          return true;
+        }
+      );
       await bucketWithVersioning
         .file(fileName)
         .save('hello3', {resumable: false});

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -3385,7 +3385,11 @@ describe('storage', () => {
         },
         {
           code: 412,
-          reason: 'conditionNotMet',
+          errors: [
+            {
+              reason: 'conditionNotMet',
+            }
+          ]
         }
       );
       await bucketWithVersioning


### PR DESCRIPTION
This test matches the exact error string from the service, which
has changed. Using the reason instead should be more robust.

Same as googleapis/java-storage#861

Fixes #1480

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

