### PR TITLE
docs: expose Iam in top level documentation

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -127,7 +127,6 @@ interface GetPolicyRequest {
  * @see [IAM Roles](https://cloud.google.com/iam/docs/understanding-roles)
  *
  * @constructor Iam
- * @mixin
  *
  * @param {Bucket} bucket The parent instance.
  * @example


### PR DESCRIPTION
Right now Iam documentation exists here https://googleapis.dev/nodejs/storage/latest/Iam.html but is not exposed in the side panel, so it can be hard for users to find. This exposes this field. 
