### PR TITLE
feat: remove gaxios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "date-and-time": "^1.0.0",
     "duplexify": "^4.0.0",
     "extend": "^3.0.2",
-    "gaxios": "^4.0.0",
     "gcs-resumable-upload": "^3.1.4",
     "get-stream": "^6.0.0",
     "hash-stream-validation": "^0.2.2",

--- a/src/file.ts
+++ b/src/file.ts
@@ -1256,10 +1256,14 @@ class File extends ServiceObject<File> {
         query.userProject = options.userProject;
       }
 
+      interface Headers {
+        [index: string]: any;
+      }
+
       const headers = {
         'Accept-Encoding': 'gzip',
         'Cache-Control': 'no-store',
-      } as any;
+      } as Headers;
 
       if (rangeRequest) {
         const start = typeof options.start === 'number' ? options.start : '0';

--- a/src/file.ts
+++ b/src/file.ts
@@ -3016,7 +3016,8 @@ class File extends ServiceObject<File> {
         } else {
           callback!(null, true);
         }
-      });
+      }
+    );
   }
 
   makePrivate(

--- a/src/file.ts
+++ b/src/file.ts
@@ -1257,7 +1257,7 @@ class File extends ServiceObject<File> {
       }
 
       interface Headers {
-        [index: string]: any;
+        [index: string]: string;
       }
 
       const headers = {

--- a/src/file.ts
+++ b/src/file.ts
@@ -2995,18 +2995,6 @@ class File extends ServiceObject<File> {
    */
 
   isPublic(callback?: IsPublicCallback): Promise<IsPublicResponse> | void {
-    const callbackFunction = function (err: Error | ApiError | null) {
-      if (err) {
-        const apiError = err as ApiError;
-        if (apiError.code === 403) {
-          callback!(null, false);
-        } else {
-          callback!(err);
-        }
-      } else {
-        callback!(null, true);
-      }
-    };
     util.makeRequest(
       {
         method: 'HEAD',
@@ -3017,8 +3005,18 @@ class File extends ServiceObject<File> {
       {
         retryOptions: this.storage.retryOptions,
       },
-      callbackFunction
-    );
+      (err: Error | ApiError | null) => {
+        if (err) {
+          const apiError = err as ApiError;
+          if (apiError.code === 403) {
+            callback!(null, false);
+          } else {
+            callback!(err);
+          }
+        } else {
+          callback!(null, true);
+        }
+      });
   }
 
   makePrivate(

--- a/src/file.ts
+++ b/src/file.ts
@@ -2995,31 +2995,31 @@ class File extends ServiceObject<File> {
    */
 
   isPublic(callback?: IsPublicCallback): Promise<IsPublicResponse> | void {
-      const callbackFunction =  function (err: Error | ApiError | null) {
-        if (err) {
-          const apiError = err as ApiError;
-          if (apiError.code === 403) {
-            callback!(null, false);
-          } else {
-            callback!(err);
-          }
+    const callbackFunction = function (err: Error | ApiError | null) {
+      if (err) {
+        const apiError = err as ApiError;
+        if (apiError.code === 403) {
+          callback!(null, false);
+        } else {
+          callback!(err);
         }
-        else {
-          callback!(null, true)
-        }
+      } else {
+        callback!(null, true);
       }
-      util.makeRequest({
+    };
+    util.makeRequest(
+      {
         method: 'HEAD',
         uri: `http://${
           this.bucket.name
         }.storage.googleapis.com/${encodeURIComponent(this.name)}`,
       },
       {
-        retryOptions: this.storage.retryOptions
+        retryOptions: this.storage.retryOptions,
       },
       callbackFunction
-      );
-    }
+    );
+  }
 
   makePrivate(
     options?: MakeFilePrivateOptions

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -435,6 +435,8 @@ export class Storage extends Service {
   getBucketsStream: () => Readable;
   getHmacKeysStream: () => Readable;
 
+  retryOptions: RetryOptions;
+
   /**
    * @typedef {object} StorageOptions
    * @property {string} [projectId] The project ID from the Google Developer's
@@ -576,6 +578,8 @@ export class Storage extends Service {
      * @see Storage.acl
      */
     this.acl = Storage.acl;
+
+    this.retryOptions = config.retryOptions;
 
     this.getBucketsStream = paginator.streamify('getBuckets');
     this.getHmacKeysStream = paginator.streamify('getHmacKeys');

--- a/test/file.ts
+++ b/test/file.ts
@@ -77,10 +77,12 @@ const fakeUtil = Object.assign({}, util, {
   shouldRetryRequest(err: HTTPError) {
     return err.code === 500;
   },
-  makeRequest(reqOpts: DecorateRequestOptions,
+  makeRequest(
+    reqOpts: DecorateRequestOptions,
     config: object,
-    callback: BodyResponseCallback) {
-      callback(null);
+    callback: BodyResponseCallback
+  ) {
+    callback(null);
   },
 });
 
@@ -3625,13 +3627,15 @@ describe('File', () => {
     });
 
     it('should execute callback with `false` in response', done => {
-      fakeUtil.makeRequest = function (reqOpts: DecorateRequestOptions,
-      config: object,
-      callback: BodyResponseCallback) {
-        const error = new ApiError("Permission Denied.");
+      fakeUtil.makeRequest = function (
+        reqOpts: DecorateRequestOptions,
+        config: object,
+        callback: BodyResponseCallback
+      ) {
+        const error = new ApiError('Permission Denied.');
         error.code = 403;
-            callback(error);
-      }
+        callback(error);
+      };
       file.isPublic((err: ApiError, resp: boolean) => {
         assert.ifError(err);
         assert.strictEqual(resp, false);
@@ -3640,26 +3644,30 @@ describe('File', () => {
     });
 
     it('should propagate non-403 errors to user', done => {
-      const error = new ApiError("400 Error.");
+      const error = new ApiError('400 Error.');
       error.code = 400;
-      fakeUtil.makeRequest = function (reqOpts: DecorateRequestOptions,
+      fakeUtil.makeRequest = function (
+        reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback) {
-          callback(error);
-        }
-      file.isPublic((err:ApiError) => {
+        callback: BodyResponseCallback
+      ) {
+        callback(error);
+      };
+      file.isPublic((err: ApiError) => {
         assert.strictEqual(err, error);
         done();
       });
     });
 
     it('should correctly send a HEAD request', done => {
-      fakeUtil.makeRequest = function (reqOpts: DecorateRequestOptions,
+      fakeUtil.makeRequest = function (
+        reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback) {
-          assert.strictEqual(reqOpts.method, 'HEAD');
-          callback(null);
-        }
+        callback: BodyResponseCallback
+      ) {
+        assert.strictEqual(reqOpts.method, 'HEAD');
+        callback(null);
+      };
       file.isPublic((err: ApiError) => {
         assert.ifError(err);
         done();
@@ -3672,12 +3680,14 @@ describe('File', () => {
         BUCKET.name
       }.storage.googleapis.com/${encodeURIComponent(file.name)}`;
 
-      fakeUtil.makeRequest = function (reqOpts: DecorateRequestOptions,
+      fakeUtil.makeRequest = function (
+        reqOpts: DecorateRequestOptions,
         config: object,
-        callback: BodyResponseCallback) {
-          assert.strictEqual(reqOpts.uri, expectedURL);
-          callback(null);
-        }
+        callback: BodyResponseCallback
+      ) {
+        assert.strictEqual(reqOpts.uri, expectedURL);
+        callback(null);
+      };
       file.isPublic((err: ApiError) => {
         assert.ifError(err);
         done();

--- a/test/file.ts
+++ b/test/file.ts
@@ -4358,13 +4358,13 @@ describe('File', () => {
         file.kmsKeyName = 'kms-key-name';
 
         const customRequestInterceptors = [
-          (reqOpts: any) => {
+          (reqOpts: DecorateRequestOptions) => {
             reqOpts.headers = Object.assign({}, reqOpts.headers, {
               a: 'b',
             });
             return reqOpts;
           },
-          (reqOpts: any) => {
+          (reqOpts: DecorateRequestOptions) => {
             reqOpts.headers = Object.assign({}, reqOpts.headers, {
               c: 'd',
             });


### PR DESCRIPTION
Removes dependency on gaxios by refactoring `File.isPublic`. 

This 
1. Allows the library to capitalize on the existing retry logic in `nodejs-common`
2. Removes a dependency
3. Makes the `isPublic` function consistent with most other functions in the library