### PR TITLE
fix: don't retry non-idempotent functions

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1710,7 +1710,7 @@ class Bucket extends ServiceObject {
         uri: '/notificationConfigs',
         json: snakeize(body),
         qs: query,
-        maxRetries: 0
+        maxRetries: 0,
       },
       (err, apiResponse) => {
         if (err) {

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1710,6 +1710,7 @@ class Bucket extends ServiceObject {
         uri: '/notificationConfigs',
         json: snakeize(body),
         qs: query,
+        maxRetries: 0
       },
       (err, apiResponse) => {
         if (err) {

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1710,7 +1710,7 @@ class Bucket extends ServiceObject {
         uri: '/notificationConfigs',
         json: snakeize(body),
         qs: query,
-        maxRetries: 0
+        maxRetries: 0 //explicitly set this value since this is a non-idempotent function
       },
       (err, apiResponse) => {
         if (err) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -950,6 +950,7 @@ export class Storage extends Service {
         method: 'POST',
         uri: `/projects/${projectId}/hmacKeys`,
         qs: query,
+        maxRetries: 0,
       },
       (err, resp: HmacKeyResourceResponse) => {
         if (err) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -950,7 +950,7 @@ export class Storage extends Service {
         method: 'POST',
         uri: `/projects/${projectId}/hmacKeys`,
         qs: query,
-        maxRetries: 0,
+        maxRetries: 0, //explicitly set this value since this is a non-idempotent function
       },
       (err, resp: HmacKeyResourceResponse) => {
         if (err) {


### PR DESCRIPTION
Don't retry createHmacKey and createNotification since they're not idempotent
