### PR TITLE
chore: Label deprecated options with TS style syntax

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -116,7 +116,10 @@ export interface EnableLoggingOptions {
 export interface GetFilesOptions {
   autoPaginate?: boolean;
   delimiter?: string;
-  /** @deprecated */
+  /**
+   * @deprecated dirrectory is deprecated
+   * @internal
+   * */
   directory?: string;
   endOffset?: string;
   includeTrailingDelimiter?: boolean;

--- a/src/file.ts
+++ b/src/file.ts
@@ -2313,6 +2313,7 @@ class File extends ServiceObject<File> {
    *     Currently, this method is an alias to `getSignedPolicyV2()`,
    *     and will be removed in a future major release.
    *     We recommend signing new policies using v4.
+   * @internal
    *
    * @throws {Error} If an expiration timestamp from the past is given.
    * @throws {Error} If options.equals has an array with less or more than two

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -74,8 +74,16 @@ export interface PreconditionOptions {
 
 export interface StorageOptions extends ServiceOptions {
   retryOptions?: RetryOptions;
-  autoRetry?: boolean; //Deprecated. Use retryOptions instead.
-  maxRetries?: number; //Deprecated. Use retryOptions instead.
+  /**
+   * @deprecated Use retryOptions instead.
+   * @internal
+   */
+  autoRetry?: boolean;
+  /**
+   * @deprecated Use retryOptions instead.
+   * @internal
+   */
+  maxRetries?: number;
   /**
    * **This option is deprecated.**
    * @todo Remove in next major release.


### PR DESCRIPTION
Deprecated properties still show up with api-extractor. To get the same behavior
as with JSDocs, we need to mark deprected items `internal`. See
https://api-extractor.com/pages/tsdoc/tag_deprecated/
