### PR TITLE
fix: updated connection reset string

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -268,7 +268,7 @@ const RETRYABLE_ERR_FN_DEFAULT = function (err?: ApiError) {
         const reason = e.reason?.toLowerCase();
         if (
           (reason && reason.includes('eai_again')) || //DNS lookup error
-          reason === 'connection reset by peer' ||
+          reason === 'econnreset' ||
           reason === 'unexpected connection closure'
         ) {
           return true;

--- a/test/index.ts
+++ b/test/index.ts
@@ -329,7 +329,7 @@ describe('Storage', () => {
       const error = new ApiError('Connection Reset By Peer error');
       error.errors = [
         {
-          reason: 'Connection Reset By Peer',
+          reason: 'ECONNRESET',
         },
       ];
       assert.strictEqual(calledWith.retryOptions.retryableErrorFn(error), true);


### PR DESCRIPTION
It is pointed out [here](https://github.com/googleapis/nodejs-storage/issues/1622#issuecomment-931819351) that we're checking for the wrong connection reset string.