### PR TITLE
chore: update file.isPublic URL format

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -3059,9 +3059,9 @@ class File extends ServiceObject<File> {
     util.makeRequest(
       {
         method: 'HEAD',
-        uri: `http://${
+        uri: `${this.storage.apiEndpoint}/${
           this.bucket.name
-        }.storage.googleapis.com/${encodeURIComponent(this.name)}`,
+        }/${encodeURIComponent(this.name)}`,
       },
       {
         retryOptions: this.storage.retryOptions,

--- a/test/file.ts
+++ b/test/file.ts
@@ -4041,9 +4041,9 @@ describe('File', () => {
 
     it('should correctly format URL in the request', done => {
       file = new File(BUCKET, 'my#file$.png');
-      const expectedURL = `http://${
+      const expectedURL = `https://storage.googleapis.com/${
         BUCKET.name
-      }.storage.googleapis.com/${encodeURIComponent(file.name)}`;
+      }/${encodeURIComponent(file.name)}`;
 
       fakeUtil.makeRequest = function (
         reqOpts: DecorateRequestOptions,


### PR DESCRIPTION
This PR neither fixes broken functionality nor adds new functionality. 

The storage API allows for `storage.googleapis.com/bucket-name/object-name` and `bucket-name.storage.googleapis.com/object-name` (both resolve to the XML API)

https://cloud.google.com/storage/docs/request-endpoints#xml-api

This refactor is useful for retry conformance testing purposes.