### PR TITLE
fix: check e is not null

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -265,7 +265,7 @@ const RETRYABLE_ERR_FN_DEFAULT = function (err?: ApiError) {
 
     if (err.errors) {
       for (const e of err.errors) {
-        const reason = e.reason?.toLowerCase();
+        const reason = e?.reason?.toLowerCase();
         if (
           (reason && reason.includes('eai_again')) || //DNS lookup error
           reason === 'econnreset' ||


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/1690 🦕
