### PR TITLE
fix: revert skip validation

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1379,7 +1379,7 @@ class File extends ServiceObject<File> {
         rawResponseStream.on('error', onComplete);
 
         const headers = rawResponseStream.toJSON().headers;
-        isCompressed = headers['content-encoding'] === 'gzip'
+        isCompressed = headers['content-encoding'] === 'gzip';
         const throughStreams: Writable[] = [];
 
         if (shouldRunValidation) {

--- a/src/file.ts
+++ b/src/file.ts
@@ -1272,7 +1272,6 @@ class File extends ServiceObject<File> {
 
     const throughStream = streamEvents(new PassThrough());
 
-    let isServedCompressed = true;
     let crc32c = true;
     let md5 = false;
 
@@ -1379,7 +1378,7 @@ class File extends ServiceObject<File> {
         rawResponseStream.on('error', onComplete);
 
         const headers = rawResponseStream.toJSON().headers;
-        isServedCompressed = headers['content-encoding'] === 'gzip';
+        const isCompressed = headers['content-encoding'] === 'gzip';
         const throughStreams: Writable[] = [];
 
         if (shouldRunValidation) {
@@ -1400,7 +1399,7 @@ class File extends ServiceObject<File> {
           throughStreams.push(validateStream);
         }
 
-        if (isServedCompressed && options.decompress) {
+        if (isCompressed && options.decompress) {
           throughStreams.push(zlib.createGunzip());
         }
 
@@ -1438,25 +1437,6 @@ class File extends ServiceObject<File> {
         if (rangeRequest || !shouldRunValidation) {
           throughStream.end();
           return;
-        }
-
-        // TODO(https://github.com/googleapis/nodejs-storage/issues/709):
-        // Remove once the backend issue is fixed.
-        // If object is stored compressed (having
-        // metadata.contentEncoding === 'gzip') and was served decompressed,
-        // then skip checksum validation because the remote checksum is computed
-        // against the compressed version of the object.
-        if (!isServedCompressed) {
-          try {
-            await this.getMetadata({userProject: options.userProject});
-          } catch (e) {
-            throughStream.destroy(e);
-            return;
-          }
-          if (this.metadata.contentEncoding === 'gzip') {
-            throughStream.end();
-            return;
-          }
         }
 
         // If we're doing validation, assume the worst-- a data integrity

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2502,33 +2502,6 @@ describe('storage', () => {
       });
     });
 
-    it('should skip validation if file is served decompressed', async () => {
-      const filename = 'logo-gzipped.png';
-      await bucket.upload(FILES.logo.path, {destination: filename, gzip: true});
-
-      tmp.setGracefulCleanup();
-      const {name: tmpFilePath} = tmp.fileSync();
-
-      const file = bucket.file(filename);
-
-      await new Promise((resolve, reject) => {
-        file
-          .createReadStream()
-          .on('error', reject)
-          .on('response', raw => {
-            assert.strictEqual(
-              raw.toJSON().headers['content-encoding'],
-              undefined
-            );
-          })
-          .pipe(fs.createWriteStream(tmpFilePath))
-          .on('error', reject)
-          .on('finish', resolve);
-      });
-
-      await file.delete();
-    });
-
     describe('simple write', () => {
       it('should save arbitrary data', done => {
         const file = bucket.file('TestFile');

--- a/test/file.ts
+++ b/test/file.ts
@@ -1387,24 +1387,6 @@ describe('File', () => {
         file.requestStream = getFakeSuccessfulRequest(data);
       });
 
-      describe('server decompression', () => {
-        it('should skip validation if file was stored compressed', done => {
-          file.metadata.contentEncoding = 'gzip';
-
-          const validateStub = sinon.stub().returns(true);
-          fakeValidationStream.test = validateStub;
-
-          file
-            .createReadStream({validation: 'crc32c'})
-            .on('error', done)
-            .on('end', () => {
-              assert(validateStub.notCalled);
-              done();
-            })
-            .resume();
-        });
-      });
-
       it('should emit errors from the validation stream', done => {
         const error = new Error('Error.');
 
@@ -1451,14 +1433,12 @@ describe('File', () => {
           .resume();
       });
 
-      it.only('should pass the userProject to getMetadata', done => {
+      it('should pass the userProject to getMetadata', done => {
         const fakeOptions = {
           userProject: 'grapce-spaceship-123',
         };
 
         file.getMetadata = (options: GetFileMetadataOptions) => {
-          console.log(options.userProject);
-          console.log(fakeOptions.userProject);
           assert.strictEqual(options.userProject, fakeOptions.userProject);
           setImmediate(done);
           return Promise.resolve({});

--- a/test/file.ts
+++ b/test/file.ts
@@ -1451,12 +1451,14 @@ describe('File', () => {
           .resume();
       });
 
-      it('should pass the userProject to getMetadata', done => {
+      it.only('should pass the userProject to getMetadata', done => {
         const fakeOptions = {
           userProject: 'grapce-spaceship-123',
         };
 
         file.getMetadata = (options: GetFileMetadataOptions) => {
+          console.log(options.userProject);
+          console.log(fakeOptions.userProject);
           assert.strictEqual(options.userProject, fakeOptions.userProject);
           setImmediate(done);
           return Promise.resolve({});


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/1716
Reverts workaround logic implemented for https://github.com/googleapis/nodejs-storage/issues/709 by https://github.com/googleapis/nodejs-storage/pull/1063