### PR TITLE
refactor: Improve `offset` < `numBytesWritten` error message

### DIFF
--- a/src/gcs-resumable-upload/index.ts
+++ b/src/gcs-resumable-upload/index.ts
@@ -661,10 +661,14 @@ export class Upload extends Pumpify {
 
     // Check if the offset (server) is too far behind the current stream
     if (this.offset < this.numBytesWritten) {
-      this.emit(
-        'error',
-        new RangeError('The offset is lower than the number of bytes written')
-      );
+      const delta = this.numBytesWritten - this.offset;
+      let message = 'The offset is lower than the number of bytes written. ';
+      message += `Server has ${this.offset} bytes, the stream has sent `;
+      message += `${this.numBytesWritten} bytes - thus ${delta} bytes are missing. `;
+      message += 'Stopping as this could result in data loss. ';
+      message += 'Create a new upload object to continue.';
+
+      this.emit('error', new RangeError(message));
       return;
     }
 

--- a/src/gcs-resumable-upload/index.ts
+++ b/src/gcs-resumable-upload/index.ts
@@ -662,11 +662,7 @@ export class Upload extends Pumpify {
     // Check if the offset (server) is too far behind the current stream
     if (this.offset < this.numBytesWritten) {
       const delta = this.numBytesWritten - this.offset;
-      let message = 'The offset is lower than the number of bytes written. ';
-      message += `Server has ${this.offset} bytes, the stream has sent `;
-      message += `${this.numBytesWritten} bytes - thus ${delta} bytes are missing. `;
-      message += 'Stopping as this could result in data loss. ';
-      message += 'Create a new upload object to continue.';
+      const message = `The offset is lower than the number of bytes written. The server has ${this.offset} bytes and while  ${this.numBytesWritten} bytes has been uploaded - thus ${delta} bytes are missing. Stopping as this could result in data loss. Initiate a new upload to continue.`;
 
       this.emit('error', new RangeError(message));
       return;
@@ -982,10 +978,8 @@ export class Upload extends Pumpify {
 
   private restart() {
     if (this.numBytesWritten) {
-      let message =
-        'Attempting to restart an upload after unrecoverable bytes have been written from upstream. ';
-      message += 'Stopping as this could result in data loss. ';
-      message += 'Create a new upload object to continue.';
+      const message =
+        'Attempting to restart an upload after unrecoverable bytes have been written from upstream. Stopping as this could result in data loss. Initiate a new upload to continue.';
 
       this.emit('error', new RangeError(message));
       return;

--- a/test/gcs-resumable-upload.ts
+++ b/test/gcs-resumable-upload.ts
@@ -1030,7 +1030,7 @@ describe('gcs-resumable-upload', () => {
         const m = error.message;
         assert(m.includes('offset is lower than the number of bytes written'));
         assert(m.includes(`server has ${expectedServer} bytes`));
-        assert(m.includes(`stream has sent ${up.numBytesWritten} bytes`));
+        assert(m.includes(`${expectedSent} bytes has been uploaded`));
         assert(m.includes(`${expectedDelta} bytes are missing`));
         done();
       });

--- a/test/gcs-resumable-upload.ts
+++ b/test/gcs-resumable-upload.ts
@@ -1029,7 +1029,7 @@ describe('gcs-resumable-upload', () => {
 
         const m = error.message;
         assert(m.includes('offset is lower than the number of bytes written'));
-        assert(m.includes(`Server has ${expectedServer} bytes`));
+        assert(m.includes(`server has ${expectedServer} bytes`));
         assert(m.includes(`stream has sent ${up.numBytesWritten} bytes`));
         assert(m.includes(`${expectedDelta} bytes are missing`));
         done();

--- a/test/gcs-resumable-upload.ts
+++ b/test/gcs-resumable-upload.ts
@@ -1020,13 +1020,18 @@ describe('gcs-resumable-upload', () => {
     it('should emit error if `offset` < `numBytesWritten`', done => {
       up.numBytesWritten = 1;
 
+      const expectedSent = up.numBytesWritten;
+      const expectedServer = 0;
+      const expectedDelta = expectedSent - expectedServer;
+
       up.on('error', (error: Error) => {
         assert(error instanceof RangeError);
-        assert(
-          /The offset is lower than the number of bytes written/.test(
-            error.message
-          )
-        );
+
+        const m = error.message;
+        assert(m.includes('offset is lower than the number of bytes written'));
+        assert(m.includes(`Server has ${expectedServer} bytes`));
+        assert(m.includes(`stream has sent ${up.numBytesWritten} bytes`));
+        assert(m.includes(`${expectedDelta} bytes are missing`));
         done();
       });
 


### PR DESCRIPTION
Helps customers when debugging `offset` < `numBytesWritten` errors.

Example: https://github.com/googleapis/nodejs-storage/issues/1780#issuecomment-1046437193