### PR TITLE
refactor: Remove `abort-controller` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@google-cloud/paginator": "^3.0.7",
     "@google-cloud/projectify": "^2.0.0",
     "@google-cloud/promisify": "^2.0.0",
-    "abort-controller": "^3.0.0",
     "arrify": "^2.0.0",
     "async-retry": "^1.3.3",
     "compressible": "^2.0.12",

--- a/src/gcs-resumable-upload.ts
+++ b/src/gcs-resumable-upload.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import AbortController from 'abort-controller';
 import {createHash} from 'crypto';
 import * as extend from 'extend';
 import {

--- a/src/gcs-resumable-upload.ts
+++ b/src/gcs-resumable-upload.ts
@@ -867,7 +867,9 @@ export class Upload extends Pumpify {
       reqOpts.params = reqOpts.params || {};
       reqOpts.params.userProject = this.userProject;
     }
-    reqOpts.signal = controller.signal;
+
+    // TypeScript doesn't fully support `AbortSignal` just yet. Remove `as` once supported
+    reqOpts.signal = controller.signal as typeof reqOpts.signal;
     reqOpts.validateStatus = () => true;
 
     const combinedReqOpts = extend(

--- a/test/gcs-resumable-upload.ts
+++ b/test/gcs-resumable-upload.ts
@@ -91,7 +91,6 @@ describe('gcs-resumable-upload', () => {
   const keyFile = path.join(__dirname, '../../test/fixtures/keys.json');
 
   before(() => {
-    mockery.registerMock('abort-controller', {default: AbortController});
     mockery.enable({useCleanCache: true, warnOnUnregistered: false});
     upload = require('../src/gcs-resumable-upload').upload;
   });


### PR DESCRIPTION
Work towards https://github.com/googleapis/nodejs-storage/issues/1743
