### PR TITLE
build: Streamline `mocha` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "predocs": "npm run compile",
     "docs": "jsdoc -c .jsdoc.js",
     "system-test": "mocha system-test --timeout 600000 --exit",
-    "conformance-test": "mocha --parallel --require conformance-test/globalHooks.ts conformance-test/",
+    "conformance-test": "mocha --parallel --require ts-node/register --require conformance-test/globalHooks.ts conformance-test/",
     "test": "c8 mocha test",
     "lint": "gts check",
     "samples-test": "npm link && cd samples/ && npm link ../ && npm test && cd ../",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,16 @@
     "google storage",
     "storage"
   ],
+  "mocha": {
+    "require": "ts-node/register",
+    "extension": "ts"
+  },
   "scripts": {
     "predocs": "npm run compile",
     "docs": "jsdoc -c .jsdoc.js",
-    "mocha": "mocha --require ts-node/register --extension ts",
-    "system-test": "npm run mocha -- system-test --timeout 600000 --exit",
-    "conformance-test": "npm run mocha -- --parallel --require conformance-test/globalHooks.ts conformance-test/",
-    "test": "c8 npm run mocha -- test",
+    "system-test": "mocha system-test --timeout 600000 --exit",
+    "conformance-test": "mocha --parallel --require conformance-test/globalHooks.ts conformance-test/",
+    "test": "c8 mocha test",
     "lint": "gts check",
     "samples-test": "npm link && cd samples/ && npm link ../ && npm test && cd ../",
     "all-test": "npm test && npm run system-test && npm run samples-test",


### PR DESCRIPTION
Adds support for native `mocha` config support - now we can use `npx mocha` without passing additional args/config