### PR TITLE
fix(chore): MODULE_NOT_FOUND uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "retry-request": "^4.2.2",
     "stream-events": "^1.0.4",
     "teeny-request": "^7.1.3",
-    "xdg-basedir": "^4.0.0"
+    "xdg-basedir": "^4.0.0",
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "@google-cloud/pubsub": "^2.0.0",
@@ -111,7 +112,6 @@
     "sinon": "^14.0.0",
     "tmp": "^0.2.0",
     "typescript": "~3.9.10",
-    "uuid": "^8.0.0",
     "yargs": "^16.0.0"
   }
 }


### PR DESCRIPTION
I cannot run my application because I got this error message.
First Image
![image](https://user-images.githubusercontent.com/22399181/169307434-62a079e2-a995-4750-a620-5e65fb4226cb.png)

Second Image
![image](https://user-images.githubusercontent.com/22399181/169307488-1aec383a-f118-4f74-8bc2-47aa03deaa67.png)


After learning the codebase, I found a bug from this PR 3 days ago https://github.com/googleapis/nodejs-storage/pull/1920.
We should move uuid from `devDependencies` to `dependencies` because we are using it in prod.