### PR TITLE
fix: force setMetadata calls to use promise version, invoke callbacks manually

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1301,8 +1301,12 @@ class Bucket extends ServiceObject {
     );
 
     if (options.append === false) {
-      this.setMetadata({lifecycle: {rule: newLifecycleRules}}, callback);
-      this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      this.setMetadata({lifecycle: {rule: newLifecycleRules}})
+        .then(resp => callback!(null, resp))
+        .catch(callback!)
+        .finally(() => {
+          this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+        });
       return;
     }
 
@@ -1318,16 +1322,17 @@ class Bucket extends ServiceObject {
         metadata.lifecycle && metadata.lifecycle.rule
       );
 
-      this.setMetadata(
-        {
-          lifecycle: {
-            rule: currentLifecycleRules.concat(newLifecycleRules),
-          },
+      this.setMetadata({
+        lifecycle: {
+          rule: currentLifecycleRules.concat(newLifecycleRules),
         },
-        callback!
-      );
+      })
+        .then(resp => callback!(null, resp))
+        .catch(callback!)
+        .finally(() => {
+          this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+        });
     });
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
   }
 
   combine(
@@ -2097,19 +2102,22 @@ class Bucket extends ServiceObject {
   disableRequesterPays(
     callback?: DisableRequesterPaysCallback
   ): Promise<DisableRequesterPaysResponse> | void {
+    const cb = callback || util.noop;
     this.disableAutoRetryConditionallyIdempotent_(
       this.methods.setMetadata,
       AvailableServiceObjectMethods.setMetadata
     );
-    this.setMetadata(
-      {
-        billing: {
-          requesterPays: false,
-        },
+
+    this.setMetadata({
+      billing: {
+        requesterPays: false,
       },
-      callback || util.noop
-    );
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+    })
+      .then(resp => cb(null, resp))
+      .catch(cb)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   enableLogging(
@@ -2277,19 +2285,21 @@ class Bucket extends ServiceObject {
   enableRequesterPays(
     callback?: EnableRequesterPaysCallback
   ): Promise<EnableRequesterPaysResponse> | void {
+    const cb = callback || util.noop;
     this.disableAutoRetryConditionallyIdempotent_(
       this.methods.setMetadata,
       AvailableServiceObjectMethods.setMetadata
     );
-    this.setMetadata(
-      {
-        billing: {
-          requesterPays: true,
-        },
+    this.setMetadata({
+      billing: {
+        requesterPays: true,
       },
-      callback || util.noop
-    );
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+    })
+      .then(resp => cb(null, resp))
+      .catch(cb)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   /**
@@ -3098,7 +3108,8 @@ class Bucket extends ServiceObject {
         }
         return [];
       })
-      .then(files => callback!(null, files), callback!)
+      .then(files => callback!(null, files))
+      .catch(callback!)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;
       });
@@ -3288,17 +3299,19 @@ class Bucket extends ServiceObject {
   removeRetentionPeriod(
     callback?: SetBucketMetadataCallback
   ): Promise<SetBucketMetadataResponse> | void {
+    const cb = callback || util.noop;
     this.disableAutoRetryConditionallyIdempotent_(
       this.methods.setMetadata,
       AvailableServiceObjectMethods.setMetadata
     );
-    this.setMetadata(
-      {
-        retentionPolicy: null,
-      },
-      callback!
-    );
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+    this.setMetadata({
+      retentionPolicy: null,
+    })
+      .then(resp => cb(null, resp))
+      .catch(cb)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   request(reqOpts: DecorateRequestOptions): Promise<[ResponseBody, Metadata]>;
@@ -3403,8 +3416,12 @@ class Bucket extends ServiceObject {
       this.methods.setMetadata,
       AvailableServiceObjectMethods.setMetadata
     );
-    this.setMetadata({labels}, options, callback);
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+    this.setMetadata({labels}, options)
+      .then(resp => callback!(null, resp))
+      .catch(callback!)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   setRetentionPeriod(duration: number): Promise<SetBucketMetadataResponse>;
@@ -3453,19 +3470,21 @@ class Bucket extends ServiceObject {
     duration: number,
     callback?: SetBucketMetadataCallback
   ): Promise<SetBucketMetadataResponse> | void {
+    const cb = callback || util.noop;
     this.disableAutoRetryConditionallyIdempotent_(
       this.methods.setMetadata,
       AvailableServiceObjectMethods.setMetadata
     );
-    this.setMetadata(
-      {
-        retentionPolicy: {
-          retentionPeriod: duration,
-        },
+    this.setMetadata({
+      retentionPolicy: {
+        retentionPeriod: duration,
       },
-      callback!
-    );
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+    })
+      .then(resp => cb(null, resp))
+      .catch(cb)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   setCorsConfiguration(
@@ -3524,17 +3543,20 @@ class Bucket extends ServiceObject {
     corsConfiguration: Cors[],
     callback?: SetBucketMetadataCallback
   ): Promise<SetBucketMetadataResponse> | void {
+    const cb = callback || util.noop;
     this.disableAutoRetryConditionallyIdempotent_(
       this.methods.setMetadata,
       AvailableServiceObjectMethods.setMetadata
     );
-    this.setMetadata(
-      {
-        cors: corsConfiguration,
-      },
-      callback!
-    );
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+
+    this.setMetadata({
+      cors: corsConfiguration,
+    })
+      .then(resp => cb(null, resp))
+      .catch(cb)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   setStorageClass(
@@ -3619,8 +3641,12 @@ class Bucket extends ServiceObject {
       })
       .toUpperCase();
 
-    this.setMetadata({storageClass}, options, callback!);
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+    this.setMetadata({storageClass}, options)
+      .then(() => callback!())
+      .catch(callback!)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1302,7 +1302,7 @@ class Bucket extends ServiceObject {
 
     if (options.append === false) {
       this.setMetadata({lifecycle: {rule: newLifecycleRules}})
-        .then(resp => callback!(null, resp))
+        .then(resp => callback!(null, ...resp))
         .catch(callback!)
         .finally(() => {
           this.storage.retryOptions.autoRetry = this.instanceRetryValue;
@@ -1327,7 +1327,7 @@ class Bucket extends ServiceObject {
           rule: currentLifecycleRules.concat(newLifecycleRules),
         },
       })
-        .then(resp => callback!(null, resp))
+        .then(resp => callback!(null, ...resp))
         .catch(callback!)
         .finally(() => {
           this.storage.retryOptions.autoRetry = this.instanceRetryValue;
@@ -2113,7 +2113,7 @@ class Bucket extends ServiceObject {
         requesterPays: false,
       },
     })
-      .then(resp => cb(null, resp))
+      .then(resp => cb(null, ...resp))
       .catch(cb)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;
@@ -2295,7 +2295,7 @@ class Bucket extends ServiceObject {
         requesterPays: true,
       },
     })
-      .then(resp => cb(null, resp))
+      .then(resp => cb(null, ...resp))
       .catch(cb)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;
@@ -3307,7 +3307,7 @@ class Bucket extends ServiceObject {
     this.setMetadata({
       retentionPolicy: null,
     })
-      .then(resp => cb(null, resp))
+      .then(resp => cb(null, ...resp))
       .catch(cb)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;
@@ -3417,7 +3417,7 @@ class Bucket extends ServiceObject {
       AvailableServiceObjectMethods.setMetadata
     );
     this.setMetadata({labels}, options)
-      .then(resp => callback!(null, resp))
+      .then(resp => callback!(null, ...resp))
       .catch(callback!)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;
@@ -3480,7 +3480,7 @@ class Bucket extends ServiceObject {
         retentionPeriod: duration,
       },
     })
-      .then(resp => cb(null, resp))
+      .then(resp => cb(null, ...resp))
       .catch(cb)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;
@@ -3552,7 +3552,7 @@ class Bucket extends ServiceObject {
     this.setMetadata({
       cors: corsConfiguration,
     })
-      .then(resp => cb(null, resp))
+      .then(resp => cb(null, ...resp))
       .catch(cb)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;

--- a/src/file.ts
+++ b/src/file.ts
@@ -3019,7 +3019,7 @@ class File extends ServiceObject<File> {
     const metadata = extend({}, options.metadata, {acl: null});
 
     this.setMetadata(metadata, query)
-      .then(resp => callback!(null, resp))
+      .then(resp => callback!(null, ...resp))
       .catch(callback!)
       .finally(() => {
         this.storage.retryOptions.autoRetry = this.instanceRetryValue;

--- a/src/file.ts
+++ b/src/file.ts
@@ -3018,8 +3018,12 @@ class File extends ServiceObject<File> {
     // file.
     const metadata = extend({}, options.metadata, {acl: null});
 
-    this.setMetadata(metadata, query, callback!);
-    this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+    this.setMetadata(metadata, query)
+      .then(resp => callback!(null, resp))
+      .catch(callback!)
+      .finally(() => {
+        this.storage.retryOptions.autoRetry = this.instanceRetryValue;
+      });
   }
 
   makePublic(): Promise<MakeFilePublicResponse>;

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -42,7 +42,6 @@ import {
   GetBucketMetadataCallback,
   GetFilesOptions,
   MakeAllFilesPublicPrivateOptions,
-  SetBucketMetadataCallback,
   SetBucketMetadataResponse,
   GetBucketSignedUrlConfig,
   AvailableServiceObjectMethods,

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -623,24 +623,6 @@ describe('Bucket', () => {
       bucket.addLifecycleRule(newRule, assert.ifError);
     });
 
-    it('should pass callback to setMetadata', done => {
-      const rule = {
-        action: {
-          type: 'type',
-        },
-        condition: {},
-      };
-
-      bucket.setMetadata = (
-        metadata: Metadata,
-        callback: SetBucketMetadataCallback
-      ) => {
-        callback(); // done()
-      };
-
-      bucket.addLifecycleRule(rule, done);
-    });
-
     it('should pass error from getMetadata to callback', done => {
       const error = new Error('from getMetadata');
       const rule = {
@@ -672,10 +654,10 @@ describe('Bucket', () => {
 
       bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
+        return Promise.resolve();
       };
 
       bucket.addLifecycleRule(rule, assert.ifError);
-      assert.strictEqual(bucket.storage.retryOptions.autoRetry, true);
       done();
     });
   });
@@ -1446,13 +1428,13 @@ describe('Bucket', () => {
 
   describe('disableRequesterPays', () => {
     it('should call setMetadata correctly', done => {
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = (metadata: {}) => {
         assert.deepStrictEqual(metadata, {
           billing: {
             requesterPays: false,
           },
         });
-        callback(); // done()
+        return Promise.resolve();
       };
 
       bucket.disableRequesterPays(done);
@@ -1460,7 +1442,7 @@ describe('Bucket', () => {
 
     it('should not require a callback', done => {
       bucket.setMetadata = (metadata: {}, callback: Function) => {
-        assert.doesNotThrow(() => callback());
+        assert.strictEqual(callback, undefined);
         done();
       };
 
@@ -1652,13 +1634,13 @@ describe('Bucket', () => {
 
   describe('enableRequesterPays', () => {
     it('should call setMetadata correctly', done => {
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = (metadata: {}) => {
         assert.deepStrictEqual(metadata, {
           billing: {
             requesterPays: true,
           },
         });
-        callback(); // done()
+        return Promise.resolve();
       };
 
       bucket.enableRequesterPays(done);
@@ -1666,7 +1648,7 @@ describe('Bucket', () => {
 
     it('should not require a callback', done => {
       bucket.setMetadata = (metadata: {}, callback: Function) => {
-        assert.doesNotThrow(() => callback());
+        assert.equal(undefined, callback);
         done();
       };
 
@@ -2342,21 +2324,21 @@ describe('Bucket', () => {
 
   describe('removeRetentionPeriod', () => {
     it('should call setMetadata correctly', done => {
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = (metadata: {}) => {
         assert.deepStrictEqual(metadata, {
           retentionPolicy: null,
         });
 
-        callback(); // done()
+        return Promise.resolve();
       };
 
       bucket.removeRetentionPeriod(done);
     });
 
     it('should disable autoRetry when ifMetagenerationMatch is undefined', done => {
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        callback();
+        return Promise.resolve();
       };
 
       bucket.removeRetentionPeriod(done);
@@ -2438,13 +2420,9 @@ describe('Bucket', () => {
   describe('setLabels', () => {
     it('should correctly call setMetadata', done => {
       const labels = {};
-      bucket.setMetadata = (
-        metadata: Metadata,
-        options: {},
-        callback: Function
-      ) => {
+      bucket.setMetadata = (metadata: Metadata) => {
         assert.strictEqual(metadata.labels, labels);
-        callback(); // done()
+        return Promise.resolve();
       };
       bucket.setLabels(labels, done);
     });
@@ -2460,9 +2438,9 @@ describe('Bucket', () => {
     });
 
     it('should disable autoRetry when isMetagenerationMatch is undefined', done => {
-      bucket.setMetadata = (metadata: {}, options: {}, callback: Function) => {
+      bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        callback();
+        return Promise.resolve();
       };
       bucket.setLabels({}, done);
     });
@@ -2472,14 +2450,14 @@ describe('Bucket', () => {
     it('should call setMetadata correctly', done => {
       const duration = 90000;
 
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = (metadata: {}) => {
         assert.deepStrictEqual(metadata, {
           retentionPolicy: {
             retentionPeriod: duration,
           },
         });
 
-        callback(); // done()
+        return Promise.resolve();
       };
 
       bucket.setRetentionPeriod(duration, done);
@@ -2488,9 +2466,9 @@ describe('Bucket', () => {
     it('should disable autoRetry when ifMetagenerationMatch is undefined', done => {
       const duration = 90000;
 
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        callback();
+        return Promise.resolve();
       };
 
       bucket.setRetentionPeriod(duration, done);
@@ -2501,12 +2479,12 @@ describe('Bucket', () => {
     it('should call setMetadata correctly', done => {
       const corsConfiguration = [{maxAgeSeconds: 3600}];
 
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = (metadata: {}) => {
         assert.deepStrictEqual(metadata, {
           cors: corsConfiguration,
         });
 
-        callback(); // done()
+        return Promise.resolve();
       };
 
       bucket.setCorsConfiguration(corsConfiguration, done);
@@ -2515,9 +2493,9 @@ describe('Bucket', () => {
     it('should disable autoRetry when ifMetagenerationMatch is undefined', done => {
       const corsConfiguration = [{maxAgeSeconds: 3600}];
 
-      bucket.setMetadata = (metadata: {}, callback: Function) => {
+      bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        callback();
+        return Promise.resolve();
       };
 
       bucket.setCorsConfiguration(corsConfiguration, done);
@@ -2547,7 +2525,7 @@ describe('Bucket', () => {
       bucket.setStorageClass('hyphenated-class', OPTIONS, CALLBACK);
     });
 
-    it('should call setMetdata correctly', done => {
+    it('should call setMetdata correctly', () => {
       bucket.setMetadata = (
         metadata: Metadata,
         options: {},
@@ -2555,21 +2533,17 @@ describe('Bucket', () => {
       ) => {
         assert.deepStrictEqual(metadata, {storageClass: STORAGE_CLASS});
         assert.strictEqual(options, OPTIONS);
-        assert.strictEqual(callback, CALLBACK);
-        done();
+        assert.strictEqual(callback, undefined);
+        return Promise.resolve();
       };
 
       bucket.setStorageClass(STORAGE_CLASS, OPTIONS, CALLBACK);
     });
 
     it('should disable autoRetry when ifMetagenerationMatch is undefined', done => {
-      bucket.setMetadata = (
-        metadata: Metadata,
-        options: {},
-        callback: Function
-      ) => {
+      bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        callback();
+        return Promise.resolve();
       };
 
       bucket.setStorageClass(STORAGE_CLASS, OPTIONS, done);

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -1433,7 +1433,7 @@ describe('Bucket', () => {
             requesterPays: false,
           },
         });
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.disableRequesterPays(done);
@@ -1639,7 +1639,7 @@ describe('Bucket', () => {
             requesterPays: true,
           },
         });
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.enableRequesterPays(done);
@@ -2328,7 +2328,7 @@ describe('Bucket', () => {
           retentionPolicy: null,
         });
 
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.removeRetentionPeriod(done);
@@ -2337,7 +2337,7 @@ describe('Bucket', () => {
     it('should disable autoRetry when ifMetagenerationMatch is undefined', done => {
       bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.removeRetentionPeriod(done);
@@ -2421,7 +2421,7 @@ describe('Bucket', () => {
       const labels = {};
       bucket.setMetadata = (metadata: Metadata) => {
         assert.strictEqual(metadata.labels, labels);
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
       bucket.setLabels(labels, done);
     });
@@ -2439,7 +2439,7 @@ describe('Bucket', () => {
     it('should disable autoRetry when isMetagenerationMatch is undefined', done => {
       bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
       bucket.setLabels({}, done);
     });
@@ -2456,7 +2456,7 @@ describe('Bucket', () => {
           },
         });
 
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.setRetentionPeriod(duration, done);
@@ -2467,7 +2467,7 @@ describe('Bucket', () => {
 
       bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.setRetentionPeriod(duration, done);
@@ -2483,7 +2483,7 @@ describe('Bucket', () => {
           cors: corsConfiguration,
         });
 
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.setCorsConfiguration(corsConfiguration, done);
@@ -2494,7 +2494,7 @@ describe('Bucket', () => {
 
       bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.setCorsConfiguration(corsConfiguration, done);
@@ -2533,7 +2533,7 @@ describe('Bucket', () => {
         assert.deepStrictEqual(metadata, {storageClass: STORAGE_CLASS});
         assert.strictEqual(options, OPTIONS);
         assert.strictEqual(callback, undefined);
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.setStorageClass(STORAGE_CLASS, OPTIONS, CALLBACK);
@@ -2542,7 +2542,7 @@ describe('Bucket', () => {
     it('should disable autoRetry when ifMetagenerationMatch is undefined', done => {
       bucket.setMetadata = () => {
         assert.strictEqual(bucket.storage.retryOptions.autoRetry, false);
-        return Promise.resolve();
+        return Promise.resolve([]);
       };
 
       bucket.setStorageClass(STORAGE_CLASS, OPTIONS, done);

--- a/test/file.ts
+++ b/test/file.ts
@@ -55,6 +55,7 @@ import {
 } from '../src/file';
 import {ExceptionMessages, IdempotencyStrategy} from '../src/storage';
 import {formatAsUTCISO} from '../src/util';
+import {timeStamp} from 'console';
 
 class HTTPError extends Error {
   code: number;

--- a/test/file.ts
+++ b/test/file.ts
@@ -55,7 +55,6 @@ import {
 } from '../src/file';
 import {ExceptionMessages, IdempotencyStrategy} from '../src/storage';
 import {formatAsUTCISO} from '../src/util';
-import {timeStamp} from 'console';
 
 class HTTPError extends Error {
   code: number;

--- a/test/file.ts
+++ b/test/file.ts
@@ -3642,28 +3642,12 @@ describe('File', () => {
     it('should execute callback with API response', done => {
       const apiResponse = {};
 
-      file.setMetadata = (metadata: {}, query: {}, callback: Function) => {
-        callback(null, apiResponse);
+      file.setMetadata = () => {
+        return Promise.resolve(apiResponse);
       };
 
       file.makePrivate((err: Error, apiResponse_: {}) => {
         assert.ifError(err);
-        assert.strictEqual(apiResponse_, apiResponse);
-
-        done();
-      });
-    });
-
-    it('should execute callback with error & API response', done => {
-      const error = new Error('Error.');
-      const apiResponse = {};
-
-      file.setMetadata = (metadata: {}, query: {}, callback: Function) => {
-        callback(error, apiResponse);
-      };
-
-      file.makePrivate((err: Error, apiResponse_: {}) => {
-        assert.strictEqual(err, error);
         assert.strictEqual(apiResponse_, apiResponse);
 
         done();

--- a/test/file.ts
+++ b/test/file.ts
@@ -3643,7 +3643,7 @@ describe('File', () => {
       const apiResponse = {};
 
       file.setMetadata = () => {
-        return Promise.resolve(apiResponse);
+        return Promise.resolve([apiResponse]);
       };
 
       file.makePrivate((err: Error, apiResponse_: {}) => {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕

Rationale for this change: 

`setMetadata` is a conditionally idempotent operation. Currently if no precondition is provided we flip a flag to turn off retries. However, since `setMetadata` is promisified we are seeing behavior where the flag is getting flipped back before the operation completes. This is causing incorrect behavior. I am changing the internal calls to wait for the promise to finish before flipping the flag back.