### PR TITLE
fix: Remove `pumpify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "mime": "^3.0.0",
     "mime-types": "^2.0.8",
     "p-limit": "^3.0.1",
-    "pumpify": "^2.0.0",
     "retry-request": "^5.0.0",
     "teeny-request": "^8.0.0",
     "uuid": "^8.0.0"
@@ -85,7 +84,6 @@
     "@types/node": "^17.0.30",
     "@types/node-fetch": "^2.1.3",
     "@types/proxyquire": "^1.3.28",
-    "@types/pumpify": "^1.4.1",
     "@types/request": "^2.48.4",
     "@types/sinon": "^10.0.0",
     "@types/tmp": "0.2.3",

--- a/src/file.ts
+++ b/src/file.ts
@@ -77,7 +77,6 @@ import {
   SetMetadataOptions,
 } from './nodejs-common/service-object';
 import * as r from 'teeny-request';
-import {ReadableStream} from 'stream/web';
 
 export type GetExpirationDateResponse = [Date];
 export interface GetExpirationDateCallback {
@@ -4024,7 +4023,7 @@ class File extends ServiceObject<File> {
    *
    * @param hashCalculatingStream
    * @param verify
-   * @returns
+   * @returns {boolean} Returns `true` if valid, throws with error otherwise
    */
   async #validateIntegrity(
     hashCalculatingStream: HashStreamValidator,

--- a/src/file.ts
+++ b/src/file.ts
@@ -1954,7 +1954,7 @@ class File extends ServiceObject<File> {
      * A callback for determining when the underlying pipeline is complete.
      * It's possible the pipeline callback could error before the write stream
      * calls `final` so by default this will destroy the write stream unless the
-     * write stream sets this callback via it's `final` handler.
+     * write stream sets this callback via its `final` handler.
      * @param error An optional error
      */
     let pipelineCallback: (error?: Error | null) => void = error => {

--- a/test/file.ts
+++ b/test/file.ts
@@ -2260,7 +2260,6 @@ describe('File', () => {
         writable.end();
 
         writable.on('error', (err: ApiError) => {
-          console.log(err, 'FILE_NO_UPLOAD');
           assert.strictEqual(err.code, 'FILE_NO_UPLOAD');
           done();
         });

--- a/test/file.ts
+++ b/test/file.ts
@@ -2210,6 +2210,7 @@ describe('File', () => {
 
       file.startSimpleUpload_ = (stream: duplexify.Duplexify) => {
         stream.setWritable(new PassThrough());
+        stream.emit('metadata');
 
         stream.on('finish', () => {
           streamFinishedCalled = true;
@@ -2232,6 +2233,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = fakeMetadata.crc32c;
@@ -2248,6 +2250,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = fakeMetadata.crc32c;
@@ -2270,6 +2273,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = fakeMetadata.md5;
@@ -2287,6 +2291,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = fakeMetadata.md5;
@@ -2309,6 +2314,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = {md5Hash: 'bad-hash'};
@@ -2331,6 +2337,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = {md5Hash: 'bad-hash'};
@@ -2349,6 +2356,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = {md5Hash: 'bad-hash'};
@@ -2371,6 +2379,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = {crc32c: 'not-md5'};
@@ -2393,6 +2402,7 @@ describe('File', () => {
 
         file.startResumableUpload_ = (stream: duplexify.Duplexify) => {
           stream.setWritable(new PassThrough());
+          stream.emit('metadata');
 
           stream.on('finish', () => {
             file.metadata = {md5Hash: 'bad-hash'};


### PR DESCRIPTION
Fixes #1915 🦕

As a follow-up, we should remove [`duplexify`](https://github.com/mafintosh/duplexify), which is a breaking change as it is exposed as a return type in a few places. In many places, a `Transform` stream makes more sense and is much cleaner.