### PR TITLE
samples: update bucketMetadata

### DIFF
--- a/samples/bucketMetadata.js
+++ b/samples/bucketMetadata.js
@@ -37,9 +37,7 @@ function main(bucketName = 'my-bucket') {
     // Get Bucket Metadata
     const [metadata] = await storage.bucket(bucketName).getMetadata();
 
-    for (const [key, value] of Object.entries(metadata)) {
-      console.log(`${key}: ${value}`);
-    }
+    console.log(JSON.stringify(metadata, null, 2));
   }
   // [END storage_get_bucket_metadata]
   getBucketMetadata().catch(console.error);


### PR DESCRIPTION
The bucketMetadata.js sample was incorrectly printing bucket metadata because it didn't account for nested Objects. I updated to print the metadata as a JSON string instead.