### PR TITLE
fix: truncated `createReadStream` through early `end` event

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1417,9 +1417,7 @@ class File extends ServiceObject<File> {
     // Authenticate the request, then pipe the remote API request to the stream
     // returned to the user.
     const makeRequest = () => {
-      const query = {
-        alt: 'media',
-      } as FileQuery;
+      const query: FileQuery = {alt: 'media'};
 
       if (this.generation) {
         query.generation = this.generation;
@@ -1460,8 +1458,7 @@ class File extends ServiceObject<File> {
         })
         .on('response', res => {
           throughStream.emit('response', res);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          util.handleResp(null, res, null, onResponse as any);
+          util.handleResp(null, res, null, onResponse);
         })
         .resume();
 
@@ -1525,7 +1522,7 @@ class File extends ServiceObject<File> {
         const handoffStream = new PassThrough({
           final: async cb => {
             // Preserving `onComplete`'s ability to
-            // close `throughStream` before pipeline
+            // destroy `throughStream` before pipeline
             // attempts to.
             await onComplete(null);
             cb();
@@ -1558,7 +1555,6 @@ class File extends ServiceObject<File> {
         }
 
         if (rangeRequest || !shouldRunValidation) {
-          throughStream.end();
           return;
         }
 
@@ -1576,7 +1572,6 @@ class File extends ServiceObject<File> {
             return;
           }
           if (this.metadata.contentEncoding === 'gzip') {
-            throughStream.end();
             return;
           }
         }
@@ -1611,14 +1606,14 @@ class File extends ServiceObject<File> {
 
           throughStream.destroy(mismatchError);
         } else {
-          throughStream.end();
+          return;
         }
       };
     };
 
     throughStream.on('reading', makeRequest);
 
-    return throughStream as Readable;
+    return throughStream;
   }
 
   createResumableUpload(

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2099,6 +2099,27 @@ describe('storage', () => {
       });
     });
 
+    it('should read an entire file if range `start:0` is provided', done => {
+      bucket.upload(FILES.big.path, (err: Error | null, file?: File | null) => {
+        assert.ifError(err);
+
+        const fileSize = file!.metadata.size;
+        const byteRange = {start: 0};
+
+        let sizeStreamed = 0;
+        file!
+          .createReadStream(byteRange)
+          .on('data', (chunk: Buffer) => {
+            sizeStreamed += chunk.byteLength;
+          })
+          .on('error', done)
+          .on('end', () => {
+            assert.strictEqual(sizeStreamed, fileSize);
+            file!.delete(done);
+          });
+      });
+    });
+
     it('should support readable[Symbol.asyncIterator]()', async () => {
       const fileContents = fs.readFileSync(FILES.big.path);
 

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -1719,7 +1719,7 @@ describe('storage', () => {
 
           // Validate the desired functionality
           const results = await testFunction(USER_PROJECT_OPTIONS);
-          return results;
+          return results as ReturnType<F>;
         }
 
         it('bucket#combine', async () => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2099,27 +2099,6 @@ describe('storage', () => {
       });
     });
 
-    it('should read an entire file if range `start:0` is provided', done => {
-      bucket.upload(FILES.big.path, (err: Error | null, file?: File | null) => {
-        assert.ifError(err);
-
-        const fileSize = file!.metadata.size;
-        const byteRange = {start: 0};
-
-        let sizeStreamed = 0;
-        file!
-          .createReadStream(byteRange)
-          .on('data', (chunk: Buffer) => {
-            sizeStreamed += chunk.byteLength;
-          })
-          .on('error', done)
-          .on('end', () => {
-            assert.strictEqual(sizeStreamed, fileSize);
-            file!.delete(done);
-          });
-      });
-    });
-
     it('should support readable[Symbol.asyncIterator]()', async () => {
       const fileContents = fs.readFileSync(FILES.big.path);
 
@@ -2138,6 +2117,14 @@ describe('storage', () => {
       const [file] = await bucket.upload(FILES.big.path);
       const [remoteContents] = await file.download();
       assert.strictEqual(String(fileContents), String(remoteContents));
+    });
+
+    it('should download an entire file if range `start:0` is provided', async () => {
+      const fileContents = fs.readFileSync(FILES.big.path);
+      const [file] = await bucket.upload(FILES.big.path);
+      const [result] = await file.download({start: 0});
+
+      assert.strictEqual(result.toString(), fileContents.toString());
     });
 
     it('should download an empty file', async () => {


### PR DESCRIPTION
Fixes #2044 🦕
Fixes #2055 🦕