### PR TITLE
fix: correct STORAGE_EMULATOR_HOST handling (#2069, #1314)

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -666,7 +666,7 @@ export class Storage extends Service {
     options = Object.assign({}, options, {apiEndpoint});
 
     // Note: EMULATOR_HOST is an experimental configuration variable. Use apiEndpoint instead.
-    const baseUrl = (EMULATOR_HOST || options.apiEndpoint) + '/storage/v1';
+    const baseUrl = new URL('/storage/v1', EMULATOR_HOST || options.apiEndpoint).href;
 
     const config = {
       apiEndpoint: options.apiEndpoint!,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -665,8 +665,12 @@ export class Storage extends Service {
 
     options = Object.assign({}, options, {apiEndpoint});
 
-    // Note: EMULATOR_HOST is an experimental configuration variable. Use apiEndpoint instead.
-    const baseUrl = new URL('/storage/v1', EMULATOR_HOST || options.apiEndpoint).href;
+    // Note: EMULATOR_HOST, if present and not overridden, has been applied to
+    // `options` at this point. Also, this uses string concatenation because the
+    // endpoint may contain a base path, and any trailing slash on that will
+    // have been removed, so using the two-arg URL constructor for relative path
+    // resolution won't work.
+    const baseUrl = new URL(options.apiEndpoint + '/storage/v1').href;
 
     const config = {
       apiEndpoint: options.apiEndpoint!,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -666,7 +666,7 @@ export class Storage extends Service {
     options = Object.assign({}, options, {apiEndpoint});
 
     // Note: EMULATOR_HOST is an experimental configuration variable. Use apiEndpoint instead.
-    const baseUrl = EMULATOR_HOST || `${options.apiEndpoint}/storage/v1`;
+    const baseUrl = (EMULATOR_HOST || options.apiEndpoint) + '/storage/v1';
 
     const config = {
       apiEndpoint: options.apiEndpoint!,

--- a/test/index.ts
+++ b/test/index.ts
@@ -450,14 +450,20 @@ describe('Storage', () => {
         );
       });
 
-      it('should be overriden by apiEndpoint', () => {
+      it('should be overridden by apiEndpoint', () => {
         const storage = new Storage({
           projectId: PROJECT_ID,
           apiEndpoint: 'https://some.api.com',
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST + '/storage/v1');
+        // NOTE: this used to assert partially the opposite of what the test
+        // says: it checked that baseUrl was _not_ overridden, but apiEndpoint
+        // was.
+        assert.strictEqual(
+          calledWith.baseUrl,
+          'https://some.api.com/storage/v1'
+        );
         assert.strictEqual(calledWith.apiEndpoint, 'https://some.api.com');
       });
 
@@ -470,7 +476,13 @@ describe('Storage', () => {
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST + '/storage/v1');
+        // NOTE: this used to assert partially the opposite of what the test
+        // says: it checked that baseUrl was _not_ overridden, but apiEndpoint
+        // was.
+        assert.strictEqual(
+          calledWith.baseUrl,
+          'https://internal.benchmark.com/path/storage/v1'
+        );
         assert.strictEqual(
           calledWith.apiEndpoint,
           'https://internal.benchmark.com/path'

--- a/test/index.ts
+++ b/test/index.ts
@@ -437,13 +437,13 @@ describe('Storage', () => {
         delete process.env.STORAGE_EMULATOR_HOST;
       });
 
-      it('should set baseUrl to env var STORAGE_EMULATOR_HOST', () => {
+      it('should set baseUrl to env var STORAGE_EMULATOR_HOST plus standard path', () => {
         const storage = new Storage({
           projectId: PROJECT_ID,
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
+        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST + '/storage/v1');
         assert.strictEqual(
           calledWith.apiEndpoint,
           'https://internal.benchmark.com/path'
@@ -457,7 +457,7 @@ describe('Storage', () => {
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
+        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST + '/storage/v1');
         assert.strictEqual(calledWith.apiEndpoint, 'https://some.api.com');
       });
 
@@ -470,7 +470,7 @@ describe('Storage', () => {
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
+        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST + '/storage/v1');
         assert.strictEqual(
           calledWith.apiEndpoint,
           'https://internal.benchmark.com/path'


### PR DESCRIPTION
credit to @jpambrun for identifying the fix

Test assertions needed to change slightly since they were asserting the
presence of functionality that doesn't actually work, specifically allowing
one to change the base url to not have `/storage/v1`. The code fundamentally
does not support this at all, and is full of places that are hard coded to
always include that path element. The code _does_ support having a base path
_before_ that however, and so that is what I updated the tests to check.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1314
Fixes #2069
