### PR TITLE
fix: Determine `Content-Length` Before Attempting Multi-chunk Upload

### DIFF
--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -725,9 +725,8 @@ export class Upload extends Writable {
 
       const bytesToUpload = value!.chunk.byteLength;
 
-      // Important: we want to know if the upstream has ended and we shouldn't expect any more
-      // before unshifting data back into the queue. This way we will know if this is the last
-      // request or not.
+      // Important: we want to know if the upstream has ended and the queue is empty before
+      // unshifting data back into the queue. This way we will know if this is the last request or not.
       const isLastChunkOfUpload = !(await this.waitForNextChunk());
 
       // Important: put the data back in the queue for the actual upload iterator

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -668,20 +668,18 @@ export class Upload extends Writable {
     // Set `expectedUploadSize` to `contentLength` if available
     if (typeof this.contentLength === 'number') {
       expectedUploadSize = this.contentLength - this.numBytesWritten;
-    }
 
-    // `expectedUploadSize` should be no more than the `chunkSize`.
-    // It's possible this is the last chunk request for a multiple
-    // chunk upload, thus smaller than the chunk size.
-    if (this.chunkSize) {
-      expectedUploadSize = expectedUploadSize
-        ? Math.min(this.chunkSize, expectedUploadSize)
-        : this.chunkSize;
+      // `expectedUploadSize` should be no more than the `chunkSize`.
+      // It's possible this is the last chunk request for a multiple
+      // chunk upload, thus smaller than the chunk size.
+      if (this.chunkSize) {
+        expectedUploadSize = Math.min(this.chunkSize, expectedUploadSize);
+      }
     }
 
     // A queue for the upstream data
     const upstreamQueue = this.upstreamIterator(
-      expectedUploadSize,
+      expectedUploadSize ?? this.chunkSize ?? undefined,
       multiChunkMode // multi-chunk mode should return 1 chunk per request
     );
 

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -733,21 +733,23 @@ export class Upload extends Writable {
       // Important: put the data back in the queue for the actual upload iterator
       this.unshiftChunkBuffer(value!.chunk);
 
-      let contentLength = this.contentLength;
+      let totalObjectSize = this.contentLength;
 
       if (typeof this.contentLength !== 'number' && isLastChunkOfUpload) {
         // Let's let the server know this is the last chunk since
         // we didn't know the content-length beforehand.
-        contentLength = bytesToUpload + this.numBytesWritten;
+        totalObjectSize = bytesToUpload + this.numBytesWritten;
       }
 
       // `- 1` as the ending byte is inclusive in the request.
       const endingByte = bytesToUpload + this.numBytesWritten - 1;
 
+      // `Content-Length` for multiple chunk uploads is the size of the chunk,
+      // not the overall object
       headers['Content-Length'] = bytesToUpload;
       headers[
         'Content-Range'
-      ] = `bytes ${this.offset}-${endingByte}/${contentLength}`;
+      ] = `bytes ${this.offset}-${endingByte}/${totalObjectSize}`;
     } else {
       headers['Content-Range'] = `bytes ${this.offset}-*/${this.contentLength}`;
     }

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -720,21 +720,40 @@ export class Upload extends Writable {
     // If using multiple chunk upload, set appropriate header
     if (multiChunkMode) {
       // We need to know how much data is available upstream to set the `Content-Range` header.
-      const result = await this.upstreamIterator(
-        expectedUploadSize,
-        true
-      ).next();
+      const oneChunkIterator = this.upstreamIterator(expectedUploadSize, true);
+      const {value} = await oneChunkIterator.next();
 
-      const bytesToUpload = result.value!.chunk.byteLength;
-      // Important: put the data back in the queue for the actual upload
-      this.unshiftChunkBuffer(result.value!.chunk);
+      const bytesToUpload = value!.chunk.byteLength;
+
+      // Important: we want to know if the upstream has ended and we shouldn't expect any more
+      // before unshifting data back into the queue. This way we will know if this is the last
+      // request or not.
+      const isLastChunkOfUpload = !(await this.waitForNextChunk());
+
+      // Important: put the data back in the queue for the actual upload iterator
+      this.unshiftChunkBuffer(value!.chunk);
+
+      console.dir({
+        expectedUploadSize,
+        bytesToUpload,
+        isLastChunkOfUpload,
+      });
+
+      let contentLength = this.contentLength;
+
+      if (typeof this.contentLength !== 'number' && isLastChunkOfUpload) {
+        // Let's let the server know this is the last chunk since
+        // we didn't know the content-length beforehand.
+        contentLength = bytesToUpload + this.numBytesWritten;
+      }
 
       // `- 1` as the ending byte is inclusive in the request.
       const endingByte = bytesToUpload + this.numBytesWritten - 1;
+
       headers['Content-Length'] = bytesToUpload;
       headers[
         'Content-Range'
-      ] = `bytes ${this.offset}-${endingByte}/${this.contentLength}`;
+      ] = `bytes ${this.offset}-${endingByte}/${contentLength}`;
     } else {
       headers['Content-Range'] = `bytes ${this.offset}-*/${this.contentLength}`;
     }

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2707,6 +2707,7 @@ describe('storage', () => {
               .on('error', reject);
           });
         });
+
         async function uploadAndVerify(
           file: File,
           options: Omit<UploadOptions, 'destination'>

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2692,7 +2692,7 @@ describe('storage', () => {
   describe('resumable upload', () => {
     describe('multi-chunk upload', () => {
       describe('upload configurations', () => {
-        const filePath: string = FILES.logo.path;
+        const filePath: string = FILES.big.path;
         const fileSize = fs.statSync(filePath).size;
         let crc32c: string;
 

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2744,7 +2744,7 @@ describe('storage', () => {
 
         it('should support uploads where `fileSize % chunkSize != 0` && `!contentLength`', async () => {
           const file = bucket.file(generateName());
-          // off by +1 to ensure `contentLength % chunkSize != 0`
+          // off by +1 to ensure `fileSize % chunkSize != 0`
           const chunkSize = fileSize + 1;
 
           await uploadAndVerify(file, {chunkSize});

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2758,7 +2758,7 @@ describe('storage', () => {
           await uploadAndVerify(file, {chunkSize});
         });
 
-        it('should support uploads where `fileSize > chunkSize && `!contentLength`', async () => {
+        it('should support uploads where `fileSize > chunkSize` && `!contentLength`', async () => {
           const file = bucket.file(generateName());
           // off by -1 to ensure `fileSize > chunkSize`
           const chunkSize = fileSize - 1;

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2688,6 +2688,118 @@ describe('storage', () => {
     });
   });
 
+  describe('resumable upload', () => {
+    describe('multi-chunk upload', () => {
+      describe('upload configurations', () => {
+        const filePath: string = FILES.logo.path;
+        const fileSize = fs.statSync(filePath).size;
+        let crc32c: string;
+
+        before(async () => {
+          // get a CRC32C value from the file
+          crc32c = await new Promise((resolve, reject) => {
+            const crc32c = new CRC32C();
+
+            fs.createReadStream(filePath)
+              .on('data', (d: Buffer) => crc32c.update(d))
+              .on('end', () => resolve(crc32c.toString()))
+              .on('error', reject);
+          });
+        });
+
+        it('should support uploads where `contentLength < chunkSize`', async () => {
+          const file = bucket.file(generateName());
+
+          const contentLength = fileSize;
+          // off by +1 to ensure `contentLength < chunkSize`
+          const chunkSize = fileSize + 1;
+
+          await bucket.upload(filePath, {
+            destination: file,
+            chunkSize,
+            metadata: {
+              contentLength,
+            },
+          });
+
+          const [metadata] = await file.getMetadata();
+
+          // assert we uploaded the expected data
+          assert.equal(metadata.crc32c, crc32c);
+        });
+
+        it('should support uploads where `contentLength % chunkSize != 0`', async () => {
+          const file = bucket.file(generateName());
+
+          const contentLength = fileSize;
+          // off by -1 to ensure `contentLength % chunkSize != 0`
+          const chunkSize = fileSize - 1;
+
+          await bucket.upload(filePath, {
+            destination: file,
+            chunkSize,
+            metadata: {
+              contentLength,
+            },
+          });
+
+          const [metadata] = await file.getMetadata();
+
+          // assert we uploaded the expected data
+          assert.equal(metadata.crc32c, crc32c);
+        });
+
+        it('should support uploads where `fileSize % chunkSize != 0` && `!contentLength`', async () => {
+          const file = bucket.file(generateName());
+          // off by +1 to ensure `contentLength % chunkSize != 0`
+          const chunkSize = fileSize + 1;
+
+          await bucket.upload(filePath, {
+            destination: file,
+            chunkSize,
+          });
+
+          const [metadata] = await file.getMetadata();
+
+          // assert we uploaded the expected data
+          assert.equal(metadata.crc32c, crc32c);
+        });
+
+        it('should support uploads where `fileSize < chunkSize && `!contentLength`', async () => {
+          const file = bucket.file(generateName());
+          // off by `* 2 +1` to ensure `fileSize < chunkSize`
+          const chunkSize = fileSize * 2 + 1;
+
+          await bucket.upload(filePath, {
+            destination: file,
+            chunkSize,
+          });
+
+          const [metadata] = await file.getMetadata();
+
+          // assert we uploaded the expected data
+          assert.equal(metadata.crc32c, crc32c);
+        });
+
+        it('should support uploads where `fileSize > chunkSize && `!contentLength`', async () => {
+          const file = bucket.file(generateName());
+          // off by -1 to ensure `fileSize > chunkSize`
+          const chunkSize = fileSize - 1;
+
+          await bucket.upload(filePath, {
+            destination: file,
+            chunkSize,
+          });
+
+          const [metadata] = await file.getMetadata();
+
+          // assert we uploaded the expected data
+          assert.equal(metadata.crc32c, crc32c);
+        });
+      });
+    });
+  });
+
   describe('bucket upload with progress', () => {
     it('show bytes sent with resumable upload', async () => {
       const fileSize = fs.statSync(FILES.big.path).size;

--- a/test/resumable-upload.ts
+++ b/test/resumable-upload.ts
@@ -1159,13 +1159,8 @@ describe('resumable-upload', () => {
 
           await up.startUploading();
 
-          const endByte = OFFSET + CHUNK_SIZE - 1;
           assert(reqOpts.headers);
-          assert.equal(reqOpts.headers['Content-Length'], CHUNK_SIZE);
-          assert.equal(
-            reqOpts.headers['Content-Range'],
-            `bytes ${OFFSET}-${endByte}/*`
-          );
+          assert.equal(reqOpts.headers['Content-Range'], `bytes ${OFFSET}-*/*`);
           assert.ok(
             X_GOOG_API_HEADER_REGEX.test(reqOpts.headers['x-goog-api-client'])
           );


### PR DESCRIPTION
Fixes #2073  🦕