### PR TITLE
Revert "fix: correct STORAGE_EMULATOR_HOST handling (#2069, #1314)"

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -664,12 +664,8 @@ export class Storage extends Service {
 
     options = Object.assign({}, options, {apiEndpoint});
 
-    // Note: EMULATOR_HOST, if present and not overridden, has been applied to
-    // `options` at this point. Also, this uses string concatenation because the
-    // endpoint may contain a base path, and any trailing slash on that will
-    // have been removed, so using the two-arg URL constructor for relative path
-    // resolution won't work.
-    const baseUrl = new URL(options.apiEndpoint + '/storage/v1').href;
+    // Note: EMULATOR_HOST is an experimental configuration variable. Use apiEndpoint instead.
+    const baseUrl = EMULATOR_HOST || `${options.apiEndpoint}/storage/v1`;
 
     const config = {
       apiEndpoint: options.apiEndpoint!,

--- a/test/index.ts
+++ b/test/index.ts
@@ -435,33 +435,27 @@ describe('Storage', () => {
         delete process.env.STORAGE_EMULATOR_HOST;
       });
 
-      it('should set baseUrl to env var STORAGE_EMULATOR_HOST plus standard path', () => {
+      it('should set baseUrl to env var STORAGE_EMULATOR_HOST', () => {
         const storage = new Storage({
           projectId: PROJECT_ID,
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST + '/storage/v1');
+        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
         assert.strictEqual(
           calledWith.apiEndpoint,
           'https://internal.benchmark.com/path'
         );
       });
 
-      it('should be overridden by apiEndpoint', () => {
+      it('should be overriden by apiEndpoint', () => {
         const storage = new Storage({
           projectId: PROJECT_ID,
           apiEndpoint: 'https://some.api.com',
         });
 
         const calledWith = storage.calledWith_[0];
-        // NOTE: this used to assert partially the opposite of what the test
-        // says: it checked that baseUrl was _not_ overridden, but apiEndpoint
-        // was.
-        assert.strictEqual(
-          calledWith.baseUrl,
-          'https://some.api.com/storage/v1'
-        );
+        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
         assert.strictEqual(calledWith.apiEndpoint, 'https://some.api.com');
       });
 
@@ -474,13 +468,7 @@ describe('Storage', () => {
         });
 
         const calledWith = storage.calledWith_[0];
-        // NOTE: this used to assert partially the opposite of what the test
-        // says: it checked that baseUrl was _not_ overridden, but apiEndpoint
-        // was.
-        assert.strictEqual(
-          calledWith.baseUrl,
-          'https://internal.benchmark.com/path/storage/v1'
-        );
+        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
         assert.strictEqual(
           calledWith.apiEndpoint,
           'https://internal.benchmark.com/path'


### PR DESCRIPTION
Reverts googleapis/nodejs-storage#2070

Implementing this is a breaking change for Firebase Storage emulator - we will need to sync and plan with Firebase in order for this to work without breaking existing customers.

Fixes: https://github.com/googleapis/nodejs-storage/issues/2086