### PR TITLE
test: update retry conf test data

### DIFF
--- a/conformance-test/scenarios/scenarioFive.ts
+++ b/conformance-test/scenarios/scenarioFive.ts
@@ -18,7 +18,9 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 5;
-const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
+  test => test.id === SCENARIO_NUMBER_TO_TEST
+);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioFive.ts
+++ b/conformance-test/scenarios/scenarioFive.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 5;
 const retryTestCase: RetryTestCase | undefined =
-  testFile.retryStrategyTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioFive.ts
+++ b/conformance-test/scenarios/scenarioFive.ts
@@ -18,8 +18,7 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 5;
-const retryTestCase: RetryTestCase | undefined =
-  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioFour.ts
+++ b/conformance-test/scenarios/scenarioFour.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 4;
 const retryTestCase: RetryTestCase | undefined =
-  testFile.retryStrategyTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioFour.ts
+++ b/conformance-test/scenarios/scenarioFour.ts
@@ -18,8 +18,7 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 4;
-const retryTestCase: RetryTestCase | undefined =
-  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioFour.ts
+++ b/conformance-test/scenarios/scenarioFour.ts
@@ -18,7 +18,9 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 4;
-const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
+  test => test.id === SCENARIO_NUMBER_TO_TEST
+);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioOne.ts
+++ b/conformance-test/scenarios/scenarioOne.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 1;
 const retryTestCase: RetryTestCase | undefined =
-  testFile.retryStrategyTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioOne.ts
+++ b/conformance-test/scenarios/scenarioOne.ts
@@ -18,7 +18,9 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 1;
-const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
+  test => test.id === SCENARIO_NUMBER_TO_TEST
+);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioOne.ts
+++ b/conformance-test/scenarios/scenarioOne.ts
@@ -18,8 +18,7 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 1;
-const retryTestCase: RetryTestCase | undefined =
-  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioSeven.ts
+++ b/conformance-test/scenarios/scenarioSeven.ts
@@ -18,7 +18,9 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 7;
-const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
+  test => test.id === SCENARIO_NUMBER_TO_TEST
+);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioSeven.ts
+++ b/conformance-test/scenarios/scenarioSeven.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 7;
 const retryTestCase: RetryTestCase | undefined =
-  testFile.retryStrategyTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioSeven.ts
+++ b/conformance-test/scenarios/scenarioSeven.ts
@@ -18,8 +18,7 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 7;
-const retryTestCase: RetryTestCase | undefined =
-  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioSix.ts
+++ b/conformance-test/scenarios/scenarioSix.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 6;
 const retryTestCase: RetryTestCase | undefined =
-  testFile.retryStrategyTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioSix.ts
+++ b/conformance-test/scenarios/scenarioSix.ts
@@ -18,8 +18,7 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 6;
-const retryTestCase: RetryTestCase | undefined =
-  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioSix.ts
+++ b/conformance-test/scenarios/scenarioSix.ts
@@ -18,7 +18,9 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 6;
-const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
+  test => test.id === SCENARIO_NUMBER_TO_TEST
+);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioThree.ts
+++ b/conformance-test/scenarios/scenarioThree.ts
@@ -18,8 +18,7 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 3;
-const retryTestCase: RetryTestCase | undefined =
-  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioThree.ts
+++ b/conformance-test/scenarios/scenarioThree.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 3;
 const retryTestCase: RetryTestCase | undefined =
-  testFile.retryStrategyTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioThree.ts
+++ b/conformance-test/scenarios/scenarioThree.ts
@@ -18,7 +18,9 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 3;
-const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
+  test => test.id === SCENARIO_NUMBER_TO_TEST
+);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioTwo.ts
+++ b/conformance-test/scenarios/scenarioTwo.ts
@@ -18,8 +18,7 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 2;
-const retryTestCase: RetryTestCase | undefined =
-  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioTwo.ts
+++ b/conformance-test/scenarios/scenarioTwo.ts
@@ -18,7 +18,9 @@ import {executeScenario, RetryTestCase} from '../conformanceCommon';
 import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 2;
-const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+const retryTestCase: RetryTestCase | undefined = testFile.retryTests.find(
+  test => test.id === SCENARIO_NUMBER_TO_TEST
+);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/scenarios/scenarioTwo.ts
+++ b/conformance-test/scenarios/scenarioTwo.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 
 const SCENARIO_NUMBER_TO_TEST = 2;
 const retryTestCase: RetryTestCase | undefined =
-  testFile.retryStrategyTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
+  testFile.retryTests.find(test => test.id === SCENARIO_NUMBER_TO_TEST);
 
 describe(`Scenario ${SCENARIO_NUMBER_TO_TEST}`, () => {
   assert(retryTestCase);

--- a/conformance-test/test-data/retryStrategyTestData.json
+++ b/conformance-test/test-data/retryStrategyTestData.json
@@ -1,5 +1,5 @@
 {
-  "retryStrategyTests": [
+  "retryTests": [
     {
       "id": 1,
       "description": "always_idempotent",
@@ -130,7 +130,7 @@
     },
     {
       "id": 5,
-      "description": "non_retryable_errors",
+      "description": "non-retryable errors",
       "cases": [
         {
           "instructions": ["return-400"]
@@ -248,10 +248,13 @@
           "instructions": ["return-reset-connection", "return-503"]
         },
         {
+          "instructions": ["return-408"]
+        },
+        {
           "instructions": ["return-503-after-256K"]
         },
         {
-          "instructions": ["return-503-after-8192K"]
+          "instructions": ["return-503-after-8192K", "return-408"]
         }
       ],
       "methods": [

--- a/conformance-test/test-data/retryStrategyTestData.json
+++ b/conformance-test/test-data/retryStrategyTestData.json
@@ -254,7 +254,7 @@
           "instructions": ["return-503-after-256K"]
         },
         {
-          "instructions": ["return-503-after-8192K", "return-408"]
+          "instructions": ["return-503-after-8192K"]
         }
       ],
       "methods": [


### PR DESCRIPTION
Copies the retry_test json from the latest in the conformance test repo. Rename retryStrategyTest to retryTest for consistency, and add 408 errors for upload tests. S8 is still not implemented in node so that part is skipped.

