### PR TITLE
chore: update transfer manager sample region tags

### DIFF
--- a/samples/downloadFileInChunksWithTransferManager.js
+++ b/samples/downloadFileInChunksWithTransferManager.js
@@ -29,7 +29,7 @@ function main(
   destFileName = path.join(cwd, fileName),
   chunkSize = 1024
 ) {
-  // [START storage_download_many_files_transfer_manager]
+  // [START storage_transfer_manager_download_chunks_concurrently]
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
    */
@@ -67,7 +67,7 @@ function main(
   }
 
   downloadFileInChunksWithTransferManager().catch(console.error);
-  // [END storage_download_many_files_transfer_manager]
+  // [END storage_transfer_manager_download_chunks_concurrently]
 }
 
 process.on('unhandledRejection', err => {

--- a/samples/downloadFolderWithTransferManager.js
+++ b/samples/downloadFolderWithTransferManager.js
@@ -21,7 +21,7 @@
 //   usage: node downloadFolderWithTransferManager.js <BUCKET_NAME> <FOLDER_NAME>
 
 function main(bucketName = 'my-bucket', folderName = 'my-folder') {
-  // [START storage_download_folder_transfer_manager]
+  // [START storage_transfer_manager_download_folder]
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
    */
@@ -50,7 +50,7 @@ function main(bucketName = 'my-bucket', folderName = 'my-folder') {
   }
 
   downloadFolderWithTransferManager().catch(console.error);
-  // [END storage_download_folder_transfer_manager]
+  // [END storage_transfer_manager_download_folder]
 }
 
 process.on('unhandledRejection', err => {

--- a/samples/downloadManyFilesWithTransferManager.js
+++ b/samples/downloadManyFilesWithTransferManager.js
@@ -25,7 +25,7 @@ function main(
   firstFileName = 'file1.txt',
   secondFileName = 'file2.txt'
 ) {
-  // [START storage_download_many_files_transfer_manager]
+  // [START storage_transfer_manager_download_many]
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
    */
@@ -57,7 +57,7 @@ function main(
   }
 
   downloadManyFilesWithTransferManager().catch(console.error);
-  // [END storage_download_many_files_transfer_manager]
+  // [END storage_transfer_manager_download_many]
 }
 
 process.on('unhandledRejection', err => {

--- a/samples/uploadDirectoryWithTransferManager.js
+++ b/samples/uploadDirectoryWithTransferManager.js
@@ -21,7 +21,7 @@
 //   usage: node uploadFolderWithTransferManager.js <BUCKET_NAME> <DIRECTORY_NAME>
 
 function main(bucketName = 'my-bucket', directoryName = 'my-directory') {
-  // [START storage_upload_directory_transfer_manager]
+  // [START storage_transfer_manager_upload_directory]
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
    */
@@ -48,7 +48,7 @@ function main(bucketName = 'my-bucket', directoryName = 'my-directory') {
   }
 
   uploadDirectoryWithTransferManager().catch(console.error);
-  // [END storage_upload_directory_transfer_manager]
+  // [END storage_transfer_manager_upload_directory]
 }
 
 process.on('unhandledRejection', err => {

--- a/samples/uploadManyFilesWithTransferManager.js
+++ b/samples/uploadManyFilesWithTransferManager.js
@@ -25,7 +25,7 @@ function main(
   firstFilePath = './local/path/to/file1.txt',
   secondFilePath = './local/path/to/file2.txt'
 ) {
-  // [START storage_upload_many_files_transfer_manager]
+  // [START storage_transfer_manager_upload_many]
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
    */
@@ -57,7 +57,7 @@ function main(
   }
 
   uploadManyFilesWithTransferManager().catch(console.error);
-  // [END storage_upload_many_files_transfer_manager]
+  // [END storage_transfer_manager_upload_many]
 }
 
 process.on('unhandledRejection', err => {


### PR DESCRIPTION
Updates region tags for Transfer Manager samples to bring them in line with planned documentation.

The region tags for sample "downloadFolderWithTransferManager.js" is also renamed here for consistency, but as a separate work item should be changed to a download *bucket* sample at a later time.