### PR TITLE
fix: Improve STORAGE_EMULATOR_HOST usage

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -724,7 +724,7 @@ export class Storage extends Service {
     options = Object.assign({}, options, {apiEndpoint});
 
     // Note: EMULATOR_HOST is an experimental configuration variable. Use apiEndpoint instead.
-    const baseUrl = EMULATOR_HOST || `${options.apiEndpoint}/storage/v1`;
+    const baseUrl = `${EMULATOR_HOST || options.apiEndpoint}/storage/v1`;
 
     const config = {
       apiEndpoint: options.apiEndpoint!,

--- a/test/index.ts
+++ b/test/index.ts
@@ -493,7 +493,7 @@ describe('Storage', () => {
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
+        assert.strictEqual(calledWith.baseUrl, `${EMULATOR_HOST}/storage/v1`);
         assert.strictEqual(
           calledWith.apiEndpoint,
           'https://internal.benchmark.com/path'
@@ -507,7 +507,7 @@ describe('Storage', () => {
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
+        assert.strictEqual(calledWith.baseUrl, `${EMULATOR_HOST}/storage/v1`);
         assert.strictEqual(calledWith.apiEndpoint, 'https://some.api.com');
       });
 
@@ -520,7 +520,7 @@ describe('Storage', () => {
         });
 
         const calledWith = storage.calledWith_[0];
-        assert.strictEqual(calledWith.baseUrl, EMULATOR_HOST);
+        assert.strictEqual(calledWith.baseUrl, `${EMULATOR_HOST}/storage/v1`);
         assert.strictEqual(
           calledWith.apiEndpoint,
           'https://internal.benchmark.com/path'


### PR DESCRIPTION
## Problem

 - if provided `STORAGE_EMULATOR_HOST` env, `apiEndpoint == baseUrl`. This lead to invalid url to fetch data, because no `storage/v1` in `baseUrl`
 - if provided `apiEndpoint`, in this case all works

## Expected behaviour

 - `STORAGE_EMULATOR_HOST` env works same way as `apiEndpoint` property

## Fix

 - Apply same logic for `STORAGE_EMULATOR_HOST` as for `apiEndpoint` to generate `baseUrl`
