### PR TITLE
fix: error serialization in resumable-upload.ts

### DIFF
--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -1252,7 +1252,9 @@ export class Upload extends Writable {
       }
       this.numRetries++;
     } else {
-      this.destroy(new Error(`Retry limit exceeded - ${JSON.stringify(resp.data)}`);
+      this.destroy(
+        new Error(`Retry limit exceeded - ${JSON.stringify(resp.data)}`)
+      );
     }
   }
 

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -1231,7 +1231,7 @@ export class Upload extends Writable {
 
         if (retryDelay <= 0) {
           this.destroy(
-            new Error(`Retry total time limit exceeded - ${resp.data}`)
+            new Error(`Retry total time limit exceeded - ${JSON.stringify(resp.data)}`)
           );
           return;
         }
@@ -1252,7 +1252,7 @@ export class Upload extends Writable {
       }
       this.numRetries++;
     } else {
-      this.destroy(new Error('Retry limit exceeded - ' + resp.data));
+      this.destroy(new Error(`Retry limit exceeded - ${JSON.stringify(resp.data)}`);
     }
   }
 

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -1231,7 +1231,9 @@ export class Upload extends Writable {
 
         if (retryDelay <= 0) {
           this.destroy(
-            new Error(`Retry total time limit exceeded - ${JSON.stringify(resp.data)}`)
+            new Error(
+              `Retry total time limit exceeded - ${JSON.stringify(resp.data)}`
+            )
           );
           return;
         }

--- a/test/resumable-upload.ts
+++ b/test/resumable-upload.ts
@@ -1874,7 +1874,7 @@ describe('resumable-upload', () => {
         up.destroy = (err: Error) => {
           assert.strictEqual(
             err.message,
-            `Retry limit exceeded - ${RESP.data}`
+            `Retry limit exceeded - ${JSON.stringify(RESP.data)}`
           );
           done();
         };
@@ -1915,7 +1915,7 @@ describe('resumable-upload', () => {
             assert.strictEqual(up.numRetries, 3);
             assert.strictEqual(
               err.message,
-              `Retry limit exceeded - ${RESP.data}`
+              `Retry limit exceeded - ${JSON.stringify(RESP.data)}`
             );
             done();
           });


### PR DESCRIPTION
Existing error handling has wrong error serialization with .toString(), that leads to [object Object] error messages.  Example:
 Error: Retry limit exceeded - [object Object]
 at Upload.attemptDelayedRetry (/usr/src/app/node_modules/@google-cloud/storage/build/cjs/src/resumable-upload.js:818:26)

Better solution would be JSON.stringify the error

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

the issue was discussed with Google Support via DoIT support team as a intermediate
