### PR TITLE
fix: Handle unhandled error in `startResumableUpload_`

### DIFF
--- a/test/file.ts
+++ b/test/file.ts
@@ -1991,6 +1991,25 @@ describe('File', () => {
       writable.write('data');
     });
 
+    it('should emit RangeError', done => {
+      const error = new RangeError(
+        'Cannot provide an `offset` without providing a `uri`'
+      );
+
+      const opitons = {
+        offset: 1,
+        isPartialUpload: true,
+      };
+      const writable = file.createWriteStream(opitons);
+
+      writable.on('error', (err: RangeError) => {
+        assert.deepEqual(err, error);
+        done();
+      });
+
+      writable.write('data');
+    });
+
     it('should emit progress via resumable upload', done => {
       const progress = {};
 


### PR DESCRIPTION
* Added error handling using `stream.destroy`

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2494
