### PR TITLE
fix(getFiles): add nextPageToken to fields for autoPaginate

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -2816,6 +2816,13 @@ class Bucket extends ServiceObject<Bucket, BucketMetadata> {
       callback = queryOrCallback as GetFilesCallback;
     }
     query = Object.assign({}, query);
+    if (
+      query.fields &&
+      query.autoPaginate &&
+      !query.fields.includes('nextPageToken')
+    ) {
+      query.fields = `${query.fields},nextPageToken`;
+    }
 
     this.request(
       {

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -1887,6 +1887,29 @@ describe('Bucket', () => {
       );
     });
 
+    it('should add nextPageToken to fields for autoPaginate', done => {
+      bucket.request = (
+        reqOpts: DecorateRequestOptions,
+        callback: Function
+      ) => {
+        assert.strictEqual(reqOpts.qs.fields, 'items(name),nextPageToken');
+        callback(null, {
+          items: [{name: 'fake-file-name'}],
+          nextPageToken: 'fake-page-token',
+        });
+      };
+
+      bucket.getFiles(
+        {fields: 'items(name)', autoPaginate: true},
+        (err: Error, files: FakeFile[], nextQuery: {pageToken: string}) => {
+          assert.ifError(err);
+          assert.strictEqual(files[0].name, 'fake-file-name');
+          assert.strictEqual(nextQuery.pageToken, 'fake-page-token');
+          done();
+        }
+      );
+    });
+
     it('should return soft-deleted Files if queried for softDeleted', done => {
       const softDeletedTime = new Date('1/1/2024').toISOString();
       bucket.request = (


### PR DESCRIPTION
`bucket.getFiles()` - returns all files as expected
`bucket.getFiles({fields: 'items(name)'})` - unexpectedly returns only 1,000 files

i noticed that `autoPaginate` and `fields` do not play nicely together unless `nextPageToken` is added to `fields`. hoping to prevent someone else from banging their head on that wall with this change

edit: sorry for the force push after requesting review, just noticed a typo in the commit message