### PR TITLE
docs: replace reference docs link with RAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/nodejs-storage/blob/main/LICENSE)
 
-[client-docs]: https://googleapis.dev/nodejs/storage/latest
+[client-docs]: https://cloud.google.com/nodejs/docs/reference/storage/latest
 [product-docs]: https://cloud.google.com/storage
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project


### PR DESCRIPTION
Use Cloud RAD as default ref docs link

Internal bug: b/239367570
