### PR TITLE
fix: Transform network failures into specific TLS timeout

### DIFF
--- a/src/nodejs-common/util.ts
+++ b/src/nodejs-common/util.ts
@@ -256,6 +256,12 @@ export interface ParsedHttpResponseBody {
   err?: Error;
 }
 
+export enum UtilExceptionMessages {
+  TLS_TIMEOUT_ERROR_MESSAGE = 'Request or TLS handshake timed out. This may be due to CPU starvation or a temporary network issue.',
+  ETIMEDOUT_ERROR_MESSAGE = 'Connection timed out. This suggests a network issue or the server took too long to respond.',
+  ECONNRESET_ERROR_MESSAGE = 'Connection reset by peer. The connection was closed unexpectedly, possibly by a firewall or network issue.',
+}
+
 /**
  * Custom error type for API errors.
  *
@@ -914,15 +920,29 @@ export class Util {
         (err: Error | null, response: {}, body: any) => {
           if (err) {
             const lowerCaseMessage = err.message.toLowerCase();
-            const isTLsTimeoutOrConnReset =
-              /tls handshake|timed out|etimedout|econnreset/.test(
-                lowerCaseMessage
+            let newError: Error | undefined;
+
+            if (lowerCaseMessage.includes('tls handshake')) {
+              newError = new Error(
+                UtilExceptionMessages.TLS_TIMEOUT_ERROR_MESSAGE
               );
-            if (isTLsTimeoutOrConnReset) {
-              const TLS_TIMEOUT_ERROR_MESSAGE =
-                'Request or TLS handshake timed out. This may be due to CPU starvation or a temporary network issue.';
-              const timeOutError = new Error(TLS_TIMEOUT_ERROR_MESSAGE);
-              err = timeOutError;
+            } else if (
+              lowerCaseMessage.includes('etimedout') ||
+              lowerCaseMessage.includes('timed out')
+            ) {
+              newError = new Error(
+                UtilExceptionMessages.ETIMEDOUT_ERROR_MESSAGE
+              );
+            } else if (lowerCaseMessage.includes('econnreset')) {
+              newError = new Error(
+                UtilExceptionMessages.ECONNRESET_ERROR_MESSAGE
+              );
+            }
+
+            if (newError) {
+              // Preserve the original stack trace for better debugging
+              newError.stack = err.stack;
+              err = newError;
             }
           }
           util.handleResp(err, response as {} as r.Response, body, callback!);

--- a/src/nodejs-common/util.ts
+++ b/src/nodejs-common/util.ts
@@ -912,6 +912,25 @@ export class Util {
         options,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (err: Error | null, response: {}, body: any) => {
+          // Check for a TLS handshake timeout.
+          // This is a conceptual check, the exact error format may vary.
+          if (
+            err &&
+            (err.message?.includes('TLS handshake') ||
+              err.message?.includes('timed out') ||
+              err.message?.includes('ETIMEDOUT') ||
+              err.message?.includes('ECONNRESET'))
+          ) {
+            // Create and use your custom error type.
+            const tlsTimeoutError = new ApiError({
+              code: 408,
+              message:
+                'TLS handshake timeout. This may be due to CPU starvation.',
+              response: response as r.Response,
+            });
+            // Replace the original error with the more descriptive one.
+            err = tlsTimeoutError;
+          }
           util.handleResp(err, response as {} as r.Response, body, callback!);
         }
       );

--- a/src/nodejs-common/util.ts
+++ b/src/nodejs-common/util.ts
@@ -915,14 +915,13 @@ export class Util {
           if (err) {
             const lowerCaseMessage = err.message.toLowerCase();
             const isTLsTimeoutOrConnReset =
-              lowerCaseMessage.includes('tls handshake') ||
-              lowerCaseMessage.includes('timed out') ||
-              lowerCaseMessage.includes('etimedout') ||
-              lowerCaseMessage.includes('econnreset');
-            if (isTLsTimeoutOrConnReset) {
-              const timeOutError = new Error(
-                'Request or TLS handshake timed out. This may be due to CPU starvation or a temporary network issue.'
+              /tls handshake|timed out|etimedout|econnreset/.test(
+                lowerCaseMessage
               );
+            if (isTLsTimeoutOrConnReset) {
+              const TLS_TIMEOUT_ERROR_MESSAGE =
+                'Request or TLS handshake timed out. This may be due to CPU starvation or a temporary network issue.';
+              const timeOutError = new Error(TLS_TIMEOUT_ERROR_MESSAGE);
               err = timeOutError;
             }
           }

--- a/src/nodejs-common/util.ts
+++ b/src/nodejs-common/util.ts
@@ -920,9 +920,10 @@ export class Util {
               lowerCaseMessage.includes('etimedout') ||
               lowerCaseMessage.includes('econnreset');
             if (isTLsTimeoutOrConnReset) {
-              err = new Error(
+              const timeOutError = new Error(
                 'Request or TLS handshake timed out. This may be due to CPU starvation or a temporary network issue.'
               );
+              err = timeOutError;
             }
           }
           util.handleResp(err, response as {} as r.Response, body, callback!);

--- a/test/nodejs-common/util.ts
+++ b/test/nodejs-common/util.ts
@@ -49,7 +49,6 @@ import {
 } from '../../src/nodejs-common/util.js';
 import {DEFAULT_PROJECT_ID_TOKEN} from '../../src/nodejs-common/service.js';
 import duplexify from 'duplexify';
-import {EventEmitter, Writable} from 'stream';
 
 nock.disableNetConnect();
 
@@ -1986,6 +1985,7 @@ describe('common/util', () => {
     });
   });
 });
+
 function createMakeRequestStub(
   sandbox: sinon.SinonSandbox,
   networkError: Error,
@@ -2000,9 +2000,12 @@ function createMakeRequestStub(
   sandbox
     .stub(util, 'makeRequest')
     .callsFake((_authenticatedReqOpts, cfg, callback) => {
-      const mockRequestStream = new EventEmitter() as unknown as Writable & {
-        abort: () => void;
-      };
+      const mockRequestStream = new stream.Duplex({
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+        read() {},
+      }) as stream.Duplex & {abort: () => void};
       mockRequestStream.abort = () => {};
 
       if (!cfg.stream) {


### PR DESCRIPTION
## Description

> This change refines error handling in `util.makeRequest` to intercept and transform common low-level network failures (`ECONNRESET`, `ETIMEDOUT`, `"timed out"`, `"TLS handshake"`) into **three distinct and specific standard `Error` messages**.
>
>The following raw errors are now intercepted:
>* `ECONNRESET`
>* `ETIMEDOUT`
>* Generic messages containing `"timed out"`
>* Generic messages containing `"TLS handshake"`
>
>Instead of a single message, developers now receive tailored diagnostic information: a specific message for **TLS/CPU starvation issues**, one for **network timeouts**, and one for **connection resets**. This provides clearer guidance for debugging. The original stack trace is preserved on the new `Error` object. This is an additive change with no breaking impacts, validated by a consolidated, data-driven unit test suite.
>
>By transforming these errors and preserving the original stack trace, we prevent the propagation of cryptic, low-level network codes and provide developers with a clear, unified diagnostic message tailored to the type of connection failure experienced.
>

## Impact

>The impact of this change is primarily positive, improving the developer experience:
>
>* **Improved Error Diagnostics (Granular):** Developers receive **three distinct, specific messages** instead of a single ambiguous one. For instance, a `TLS handshake` error receives a special message related to **CPU starvation** to guide performance debugging.
>* **Consistent Error Handling:** Facilitates easier integration with custom error retry and logging mechanisms by providing a predictable, standard `Error` structure (augmented with the original stack trace) rather than a raw, non-standard network error object.
>* **No Breaking Changes:** This is a purely additive fix that catches and transforms errors that would have been thrown anyway. It does not alter the successful path for requests.
>

## Testing

>**Yes, unit tests were added.**
>
>* A dedicated unit test suite, **`Network Connectivity Errors`**, was created under `makeAuthenticatedRequestFactory` to validate the new transformation logic.
>* The test structure was consolidated into a single, **data-driven `forEach` loop** that verifies the mapping of the four common failure modes to the **three distinct output messages** defined in the `UtilExceptionMessages` enum.
>
>* A single test loop replaced four separate tests, covering all conditions:
>    * `should transform raw ECONNRESET into specific network error`
>    * `should transform raw "TLS handshake" into specific network error`
>    * `should transform raw generic "timed out" into specific network error`
>    * `should transform raw ETIMEDOUT into specific network error`
>
>**Tests Changed?** No existing tests were modified.
>
>**Breaking Changes?** No breaking changes are necessary.
>

## Additional Information
>
>*  **Error Object Change:** The transformation logic was simplified to augment a **standard JavaScript `Error`** object.
>* **Test Structure:** The tests were consolidated into a single `forEach` loop for improved clarity and maintainability.
>* **Stubbing:** The `authClient` was stubbed to guarantee successful authorization, forcing execution into the network path where the error injection and transformation occur, preventing test timeouts.
> The logic ensures that if an error is transformed, the original stack trace (`err.stack`) is preserved on the new `Error` object, allowing developers to debug the source of the failure effectively.

## Checklist

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes #
