### PR TITLE
fix: :bug: fix the issue 2667, do not mutate object given to options …

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2309,7 +2309,7 @@ class File extends ServiceObject<File, FileMetadata> {
       cb = optionsOrCallback as DownloadCallback;
       options = {};
     } else {
-      options = optionsOrCallback as DownloadOptions;
+      options = Object.assign({}, optionsOrCallback);
     }
 
     let called = false;

--- a/test/file.ts
+++ b/test/file.ts
@@ -2596,11 +2596,22 @@ describe('File', () => {
       file.download({}, assert.ifError);
     });
 
+    it('should not mutate options object after use', done => {
+      const optionsObject = {destination: './unknown.jpg'};
+      fileReadStream._read = () => {
+        assert.strictEqual(optionsObject.destination, './unknown.jpg');
+        assert.deepStrictEqual(optionsObject, {destination: './unknown.jpg'});
+        done();
+      };
+      file.download(optionsObject, assert.ifError);
+    });
+
     it('should pass the provided options to createReadStream', done => {
-      const readOptions = {start: 100, end: 200};
+      const readOptions = {start: 100, end: 200, destination: './unknown.jpg'};
 
       file.createReadStream = (options: {}) => {
-        assert.deepStrictEqual(options, readOptions);
+        assert.deepStrictEqual(options, {start: 100, end: 200});
+        assert.deepStrictEqual(readOptions, {start: 100, end: 200, destination: './unknown.jpg'});
         done();
         return fileReadStream;
       };

--- a/test/file.ts
+++ b/test/file.ts
@@ -2611,7 +2611,11 @@ describe('File', () => {
 
       file.createReadStream = (options: {}) => {
         assert.deepStrictEqual(options, {start: 100, end: 200});
-        assert.deepStrictEqual(readOptions, {start: 100, end: 200, destination: './unknown.jpg'});
+        assert.deepStrictEqual(readOptions, {
+          start: 100,
+          end: 200,
+          destination: './unknown.jpg',
+        });
         done();
         return fileReadStream;
       };


### PR DESCRIPTION
Resolves the issue #2667 

## Description

Instead of assigning argument passed to download to options doing Object.assing({}, options) before to copy the values.

## Impact

Fixes bug.

## Testing

It would be good to cover this with tests as it is trivial to test for this. So I added one for this method, and fixed one faulty one, that should have captured this before.

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [x] Appropriate docs were updated
- [x] Appropriate comments were added, particularly in complex areas or places that require background
- [x] No new warnings or issues will be generated from this change

Fixes #2667 🦕
