### PR TITLE
refactor: Remove abort controller dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   "dependencies": {
     "@google-cloud/paginator": "^6.0.0",
     "@google-cloud/promisify": "^5.0.0",
-    "abort-controller": "^3.0.0",
     "async-retry": "^1.3.3",
     "duplexify": "^4.1.3",
     "fast-xml-parser": "^5.2.0",

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import AbortController from 'abort-controller';
 import {createHash} from 'crypto';
 import {
   GaxiosOptions,

--- a/test/resumable-upload.ts
+++ b/test/resumable-upload.ts
@@ -99,7 +99,6 @@ describe('resumable-upload', () => {
   const keyFile = path.join(getDirName(), '../../../test/fixtures/keys.json');
 
   before(() => {
-    mockery.registerMock('abort-controller', AbortController);
     mockery.enable({useCleanCache: true, warnOnUnregistered: false});
     upload = require('../src/resumable-upload').upload;
   });
@@ -1807,7 +1806,7 @@ describe('resumable-upload', () => {
     it('should pass a signal from the abort controller', done => {
       up.authClient = {
         request: (reqOpts: GaxiosOptions) => {
-          assert(reqOpts.signal instanceof AbortController);
+          assert(reqOpts.signal instanceof AbortSignal);
           done();
         },
       };

--- a/test/resumable-upload.ts
+++ b/test/resumable-upload.ts
@@ -45,14 +45,6 @@ import {getDirName} from '../src/util.js';
 
 nock.disableNetConnect();
 
-class AbortController {
-  aborted = false;
-  signal = this;
-  abort() {
-    this.aborted = true;
-  }
-}
-
 const RESUMABLE_INCOMPLETE_STATUS_CODE = 308;
 /** 256 KiB */
 const CHUNK_SIZE_MULTIPLE = 2 ** 18;
@@ -1816,11 +1808,10 @@ describe('resumable-upload', () => {
     it('should abort on an error', done => {
       up.on('error', () => {});
 
-      let abortController: AbortController;
+      let abortSignal: AbortSignal;
       up.authClient = {
         request: (reqOpts: GaxiosOptions) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          abortController = reqOpts.signal as any;
+          abortSignal = reqOpts.signal as AbortSignal;
         },
       };
 
@@ -1828,7 +1819,7 @@ describe('resumable-upload', () => {
       up.emit('error', new Error('Error.'));
 
       setImmediate(() => {
-        assert.strictEqual(abortController.aborted, true);
+        assert.strictEqual(abortSignal.aborted, true);
         done();
       });
     });


### PR DESCRIPTION
## Description

This pull request focuses on refactoring the project to eliminate the `abort-controller` dependency. By transitioning to the native `AbortController` and `AbortSignal` APIs, the change streamlines the codebase, reduces the overall dependency footprint, and leverages modern JavaScript features for handling abortable operations, resulting in a cleaner and potentially more performant application.

## Impact

The external `abort-controller` npm package has been successfully removed from the project's dependencies.

## Testing

Unit tests have been updated to reflect the change, specifically asserting against `AbortSignal` instances and removing the `abort-controller` mock.

## Additional Information

The codebase now utilizes the native `AbortController` and `AbortSignal` interfaces, leveraging modern Node.js capabilities.

## Checklist

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes #2211
