### PR TITLE
feat: Enable full object checksum validation on JSON path

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2155,6 +2155,16 @@ class File extends ServiceObject<File, FileMetadata> {
             return pipelineCallback(e);
           }
 
+          // If this is a partial upload, we don't expect final metadata yet.
+          if (options.isPartialUpload) {
+            // Emit CRC32c for this completed chunk if hash validation is active.
+            if (hashCalculatingStream?.crc32c) {
+              writeStream.emit('crc32c', hashCalculatingStream.crc32c);
+            }
+            // Resolve the pipeline for this *partial chunk*.
+            return pipelineCallback();
+          }
+
           // We want to make sure we've received the metadata from the server in order
           // to properly validate the object's integrity. Depending on the type of upload,
           // the stream could close before the response is returned.

--- a/src/hash-stream-validator.ts
+++ b/src/hash-stream-validator.ts
@@ -92,7 +92,7 @@ class HashStreamValidator extends Transform {
   }
 
   _flush(callback: (error?: Error | null | undefined) => void) {
-    if (this.#md5Hash) {
+    if (this.#md5Hash && !this.#md5Digest) {
       this.#md5Digest = this.#md5Hash.digest('base64');
     }
 

--- a/src/hash-stream-validator.ts
+++ b/src/hash-stream-validator.ts
@@ -81,6 +81,16 @@ class HashStreamValidator extends Transform {
     return this.#crc32cHash?.toString();
   }
 
+  /**
+   * Return the calculated MD5 value, if available.
+   */
+  get md5Digest(): string | undefined {
+    if (this.#md5Hash && !this.#md5Digest) {
+      this.#md5Digest = this.#md5Hash.digest('base64');
+    }
+    return this.#md5Digest;
+  }
+
   _flush(callback: (error?: Error | null | undefined) => void) {
     if (this.#md5Hash) {
       this.#md5Digest = this.#md5Hash.digest('base64');

--- a/src/hash-stream-validator.ts
+++ b/src/hash-stream-validator.ts
@@ -93,7 +93,7 @@ class HashStreamValidator extends Transform {
 
   _flush(callback: (error?: Error | null | undefined) => void) {
     if (this.#md5Hash && !this.#md5Digest) {
-      void this.#md5Digest;
+      this.#md5Digest = this.#md5Hash.digest('base64');
     }
 
     if (this.updateHashesOnly) {

--- a/src/hash-stream-validator.ts
+++ b/src/hash-stream-validator.ts
@@ -93,7 +93,7 @@ class HashStreamValidator extends Transform {
 
   _flush(callback: (error?: Error | null | undefined) => void) {
     if (this.#md5Hash && !this.#md5Digest) {
-      this.#md5Digest = this.#md5Hash.digest('base64');
+      void this.#md5Digest;
     }
 
     if (this.updateHashesOnly) {

--- a/src/hash-stream-validator.ts
+++ b/src/hash-stream-validator.ts
@@ -92,9 +92,8 @@ class HashStreamValidator extends Transform {
   }
 
   _flush(callback: (error?: Error | null | undefined) => void) {
-    if (this.#md5Hash && !this.#md5Digest) {
-      this.#md5Digest = this.#md5Hash.digest('base64');
-    }
+    // Triggers the getter logic to finalize and cache the MD5 digest
+    this.md5Digest;
 
     if (this.updateHashesOnly) {
       callback();

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -36,10 +36,11 @@ import {
   getUserAgentString,
 } from './util.js';
 import {GCCL_GCS_CMD_KEY} from './nodejs-common/util.js';
-import {FileMetadata} from './file.js';
+import {FileExceptionMessages, FileMetadata, RequestError} from './file.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import {getPackageJSON} from './package-json-helper.cjs';
+import {HashStreamValidator} from './hash-stream-validator.js';
 
 const NOT_FOUND_STATUS_CODE = 404;
 const RESUMABLE_INCOMPLETE_STATUS_CODE = 308;
@@ -148,6 +149,19 @@ export interface UploadConfig extends Pick<WritableOptions, 'highWaterMark'> {
    * @see {@link checkUploadStatus} for checking the status of an existing upload.
    */
   isPartialUpload?: boolean;
+
+  clientCrc32c?: string;
+  clientMd5Hash?: string;
+  /**
+   * Enables CRC32C calculation on the client side.
+   * The calculated hash will be sent in the final PUT request if `clientCrc32c` is not provided.
+   */
+  crc32c?: boolean;
+  /**
+   * Enables MD5 calculation on the client side.
+   * The calculated hash will be sent in the final PUT request if `clientMd5Hash` is not provided.
+   */
+  md5?: boolean;
 
   /**
    * A customer-supplied encryption key. See
@@ -334,6 +348,11 @@ export class Upload extends Writable {
    */
   private writeBuffers: Buffer[] = [];
   private numChunksReadInRequest = 0;
+
+  #hashValidator?: HashStreamValidator;
+  #clientCrc32c?: string;
+  #clientMd5Hash?: string;
+
   /**
    * An array of buffers used for caching the most recent upload chunk.
    * We should not assume that the server received all bytes sent in the request.
@@ -428,6 +447,20 @@ export class Upload extends Writable {
     this.retryOptions = cfg.retryOptions;
     this.isPartialUpload = cfg.isPartialUpload ?? false;
 
+    this.#clientCrc32c = cfg.clientCrc32c;
+    this.#clientMd5Hash = cfg.clientMd5Hash;
+
+    const calculateCrc32c = !cfg.clientCrc32c && cfg.crc32c;
+    const calculateMd5 = !cfg.clientMd5Hash && cfg.md5;
+
+    if (calculateCrc32c || calculateMd5) {
+      this.#hashValidator = new HashStreamValidator({
+        crc32c: calculateCrc32c,
+        md5: calculateMd5,
+        updateHashesOnly: true,
+      });
+    }
+
     if (cfg.key) {
       if (typeof cfg.key === 'string') {
         const base64Key = Buffer.from(cfg.key).toString('base64');
@@ -518,9 +551,19 @@ export class Upload extends Writable {
     // Backwards-compatible event
     this.emit('writing');
 
-    this.writeBuffers.push(
-      typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk
-    );
+    const bufferChunk =
+      typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk;
+
+    if (this.#hashValidator) {
+      try {
+        this.#hashValidator.write(bufferChunk);
+      } catch (e) {
+        this.destroy(e as Error);
+        return;
+      }
+    }
+
+    this.writeBuffers.push(bufferChunk);
 
     this.once('readFromChunkBuffer', readCallback);
 
@@ -535,6 +578,36 @@ export class Upload extends Writable {
   #addLocalBufferCache(buf: Buffer) {
     this.localWriteCache.push(buf);
     this.localWriteCacheByteLength += buf.byteLength;
+  }
+
+  /**
+   * Compares the client's calculated or provided hash against the server's
+   * returned hash for a specific checksum type. Destroys the stream on mismatch.
+   * @param clientHash The client's calculated or provided hash (Base64).
+   * @param serverHash The hash returned by the server (Base64).
+   * @param hashType The type of hash ('CRC32C' or 'MD5').
+   */
+  #validateChecksum(
+    clientHash: string | undefined,
+    serverHash: string | undefined,
+    hashType: 'CRC32C' | 'MD5'
+  ): boolean {
+    // Only validate if both client and server hashes are present.
+    if (clientHash && serverHash) {
+      if (clientHash !== serverHash) {
+        const detailMessage = `${hashType} checksum mismatch. Client calculated: ${clientHash}, Server returned: ${serverHash}`;
+        const code = 'FILE_NO_UPLOAD';
+        const primaryMessage = FileExceptionMessages.UPLOAD_MISMATCH;
+        const detailError = new Error(detailMessage);
+        const error = new RequestError(primaryMessage);
+        error.code = code;
+        error.errors = [detailError];
+
+        this.destroy(error);
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -929,6 +1002,10 @@ export class Upload extends Writable {
       // unshifting data back into the queue. This way we will know if this is the last request or not.
       const isLastChunkOfUpload = !(await this.waitForNextChunk());
 
+      if (isLastChunkOfUpload && this.#hashValidator) {
+        this.#hashValidator.end();
+      }
+
       // Important: put the data back in the queue for the actual upload
       this.prependLocalBufferToUpstream();
 
@@ -951,8 +1028,66 @@ export class Upload extends Writable {
       headers['Content-Length'] = bytesToUpload;
       headers['Content-Range'] =
         `bytes ${this.offset}-${endingByte}/${totalObjectSize}`;
+
+      // Apply X-Goog-Hash header ONLY on the final chunk (WriteObject call)
+      if (isLastChunkOfUpload) {
+        const checksums: string[] = [];
+
+        if (this.#hashValidator) {
+          if (this.#hashValidator.crc32cEnabled) {
+            // CRC32C value is final after all updates
+            checksums.push(`crc32c=${this.#hashValidator.crc32c!}`);
+          }
+          if (this.#hashValidator.md5Enabled) {
+            // MD5 digest is either ready on _flush (if stream is ending) or can be accessed now via getter
+            checksums.push(`md5=${this.#hashValidator.md5Digest!}`);
+          }
+        } else {
+          if (this.#clientCrc32c) {
+            checksums.push(`crc32c=${this.#clientCrc32c}`);
+          }
+          if (this.#clientMd5Hash) {
+            checksums.push(`md5=${this.#clientMd5Hash}`);
+          }
+        }
+
+        if (checksums.length > 0) {
+          headers['X-Goog-Hash'] = checksums.join(',');
+        }
+      }
     } else {
       headers['Content-Range'] = `bytes ${this.offset}-*/${this.contentLength}`;
+
+      // In single chunk mode, if contentLength is set, the entire upload is the final chunk.
+      const isSingleFinalUpload = !!this.contentLength;
+
+      if (isSingleFinalUpload && this.#hashValidator) {
+        this.#hashValidator.end();
+      }
+
+      if (isSingleFinalUpload) {
+        const checksums: string[] = [];
+
+        if (this.#hashValidator) {
+          if (this.#hashValidator.crc32cEnabled) {
+            checksums.push(`crc32c=${this.#hashValidator.crc32c!}`);
+          }
+          if (this.#hashValidator.md5Enabled) {
+            checksums.push(`md5=${this.#hashValidator.md5Digest!}`);
+          }
+        } else {
+          if (this.#clientCrc32c) {
+            checksums.push(`crc32c=${this.#clientCrc32c}`);
+          }
+          if (this.#clientMd5Hash) {
+            checksums.push(`md5=${this.#clientMd5Hash}`);
+          }
+        }
+
+        if (checksums.length > 0) {
+          headers['X-Goog-Hash'] = checksums.join(',');
+        }
+      }
     }
 
     const reqOpts: GaxiosOptions = {
@@ -1047,6 +1182,24 @@ export class Upload extends Writable {
 
       this.destroy(err);
     } else {
+      const serverCrc32c = resp.data.crc32c;
+      const serverMd5 = resp.data.md5Hash;
+
+      const clientCrc32cToValidate =
+        this.#hashValidator?.crc32c || this.#clientCrc32c;
+      const clientMd5HashToValidate =
+        this.#hashValidator?.md5Digest || this.#clientMd5Hash;
+
+      if (
+        this.#validateChecksum(clientCrc32cToValidate, serverCrc32c, 'CRC32C')
+      ) {
+        return;
+      }
+
+      if (this.#validateChecksum(clientMd5HashToValidate, serverMd5, 'MD5')) {
+        return;
+      }
+
       // no need to keep the cache
       this.#resetLocalBuffersCache();
 

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -620,20 +620,16 @@ export class Upload extends Writable {
   #applyChecksumHeaders(headers: GaxiosOptions['headers']) {
     const checksums: string[] = [];
 
-    if (this.#hashValidator) {
-      if (this.#hashValidator.crc32cEnabled) {
-        checksums.push(`crc32c=${this.#hashValidator.crc32c!}`);
-      }
-      if (this.#hashValidator.md5Enabled) {
-        checksums.push(`md5=${this.#hashValidator.md5Digest!}`);
-      }
-    } else {
-      if (this.#clientCrc32c) {
-        checksums.push(`crc32c=${this.#clientCrc32c}`);
-      }
-      if (this.#clientMd5Hash) {
-        checksums.push(`md5=${this.#clientMd5Hash}`);
-      }
+    if (this.#hashValidator?.crc32cEnabled) {
+      checksums.push(`crc32c=${this.#hashValidator.crc32c!}`);
+    } else if (this.#clientCrc32c) {
+      checksums.push(`crc32c=${this.#clientCrc32c}`);
+    }
+
+    if (this.#hashValidator?.md5Enabled) {
+      checksums.push(`md5=${this.#hashValidator.md5Digest!}`);
+    } else if (this.#clientMd5Hash) {
+      checksums.push(`md5=${this.#clientMd5Hash}`);
     }
 
     if (checksums.length > 0) {
@@ -1070,11 +1066,10 @@ export class Upload extends Writable {
       // In single chunk mode, if contentLength is set, the entire upload is the final chunk.
       const isSingleFinalUpload = typeof this.contentLength === 'number';
 
-      if (isSingleFinalUpload && this.#hashValidator) {
-        this.#hashValidator.end();
-      }
-
       if (isSingleFinalUpload) {
+        if (this.#hashValidator) {
+          this.#hashValidator.end();
+        }
         this.#applyChecksumHeaders(headers);
       }
     }

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -596,11 +596,9 @@ export class Upload extends Writable {
     if (clientHash && serverHash) {
       if (clientHash !== serverHash) {
         const detailMessage = `${hashType} checksum mismatch. Client calculated: ${clientHash}, Server returned: ${serverHash}`;
-        const code = 'FILE_NO_UPLOAD';
-        const primaryMessage = FileExceptionMessages.UPLOAD_MISMATCH;
         const detailError = new Error(detailMessage);
-        const error = new RequestError(primaryMessage);
-        error.code = code;
+        const error = new RequestError(FileExceptionMessages.UPLOAD_MISMATCH);
+        error.code = 'FILE_NO_UPLOAD';
         error.errors = [detailError];
 
         this.destroy(error);

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -1066,7 +1066,7 @@ export class Upload extends Writable {
       // In single chunk mode, if contentLength is set, the entire upload is the final chunk.
       const isSingleFinalUpload = typeof this.contentLength === 'number';
 
-      if (isSingleFinalUpload) {
+      if (isSingleFinalUpload && this.upstreamEnded) {
         if (this.#hashValidator) {
           this.#hashValidator.end();
         }
@@ -1168,6 +1168,10 @@ export class Upload extends Writable {
     } else if (this.isSuccessfulResponse(resp.status)) {
       const serverCrc32c = resp.data.crc32c;
       const serverMd5 = resp.data.md5Hash;
+
+      if (this.#hashValidator) {
+        this.#hashValidator.end();
+      }
 
       const clientCrc32cToValidate =
         this.#hashValidator?.crc32c || this.#clientCrc32c;

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -1066,7 +1066,7 @@ export class Upload extends Writable {
       // In single chunk mode, if contentLength is set, the entire upload is the final chunk.
       const isSingleFinalUpload = typeof this.contentLength === 'number';
 
-      if (isSingleFinalUpload && this.upstreamEnded) {
+      if (isSingleFinalUpload) {
         if (this.#hashValidator) {
           this.#hashValidator.end();
         }

--- a/src/resumable-upload.ts
+++ b/src/resumable-upload.ts
@@ -1063,12 +1063,6 @@ export class Upload extends Writable {
     } else {
       headers['Content-Range'] = `bytes ${this.offset}-*/${this.contentLength}`;
 
-      // Buffer the entire upload to calculate the hash before sending.
-      for await (const chunk of this.upstreamIterator(expectedUploadSize)) {
-        this.#addLocalBufferCache(chunk);
-      }
-      this.prependLocalBufferToUpstream();
-
       if (this.#hashValidator) {
         this.#hashValidator.end();
       }

--- a/system-test/kitchen.ts
+++ b/system-test/kitchen.ts
@@ -37,7 +37,7 @@ import {
 } from '../src/storage.js';
 import {CRC32C} from '../src/crc32c.js';
 
-const bucketName = process.env.BUCKET_NAME || 'gcs-resumable-upload-test';
+const bucketName = process.env.BUCKET_NAME || 'gcs-resumable-upload-test-121';
 
 /**
  * The known multiple chunk upload size, in bytes
@@ -59,6 +59,7 @@ describe('resumable-upload', () => {
   let filePath: string;
 
   before(async () => {
+    await bucket.create();
     tmp.setGracefulCleanup();
     filePath = path.join(os.tmpdir(), '20MB.zip');
 

--- a/system-test/kitchen.ts
+++ b/system-test/kitchen.ts
@@ -37,7 +37,7 @@ import {
 } from '../src/storage.js';
 import {CRC32C} from '../src/crc32c.js';
 
-const bucketName = process.env.BUCKET_NAME || 'gcs-resumable-upload-test-121';
+const bucketName = process.env.BUCKET_NAME || 'gcs-resumable-upload-test';
 
 /**
  * The known multiple chunk upload size, in bytes
@@ -59,7 +59,6 @@ describe('resumable-upload', () => {
   let filePath: string;
 
   before(async () => {
-    await bucket.create();
     tmp.setGracefulCleanup();
     filePath = path.join(os.tmpdir(), '20MB.zip');
 


### PR DESCRIPTION
## Description

> This pull request significantly enhances data integrity for object uploads by introducing comprehensive client-side checksum validation. It ensures that data uploaded through the JSON API path remains consistent by verifying both client-provided and client-calculated CRC32C and MD5 hashes against the server's reported hashes. This mechanism proactively detects and prevents silent data corruption, providing a more reliable upload experience.

## Impact

>The primary impact is a **substantial improvement in data integrity and reliability** for object uploads, particularly those utilizing the JSON API path (e.g., small single-chunk uploads).
>
>* **Prevents Silent Data Corruption:** By validating client-side hashes (calculated or user-provided) against the server's reported hashes, the SDK proactively detects and stops data corruption that might otherwise go unnoticed.
>* **Enhanced Reliability:** The stream is immediately destroyed upon hash mismatch, preventing the client from assuming a corrupted file upload was successful.
>* **Feature Parity:** Enables the use of the `X-Goog-Hash` header, which is essential for ensuring the integrity of the data payload sent to the server.
>* **API Usage:** Introduces new configuration options (`clientCrc32c`, `clientMd5Hash`, `crc32c`, `md5`) that allow users fine-grained control over checksum validation behavior.

## Testing

> * **Unit and Integration Tests Added?** **Yes.** Extensive test coverage was added and expanded in `test/resumable-upload.ts` and `system-test/kitchen.ts`. This includes:
>    * Verification of `X-Goog-Hash` header injection with calculated and client-provided hashes in single and multi-chunk uploads.
>   * Validation tests to confirm that the stream is correctly destroyed on both **CRC32C** and **MD5** checksum mismatches between the client and server.
>    * A dedicated `describe` block for **Validation of Client Checksums Against Server Response** with various success and failure scenarios.
>
>* **Were any tests changed?** **Yes.** Tests were expanded and refactored (e.g., checksum application logic tests).
>
>* **Are any breaking changes necessary?** **No.** This change introduces new features and configuration options but does not appear to break existing functionality. The changes are largely additive and internal refactoring of hash handling and validation logic.

## Additional Information

> * **Refactoring for Robustness:** The `HashStreamValidator` was improved by adding the `md5Digest` getter, which centralizes the MD5 calculation and caching logic. The related fix in `_flush` prevents a potential race condition where calling `digest()` multiple times would cause a runtime error.
>* **Internal Consistency:** Private helper methods (`#validateChecksum`, `#applyChecksumHeaders`) were introduced in `resumable-upload.ts` to simplify and clarify the hash handling logic, especially ensuring checksum headers are applied correctly across different upload paths.
>* **Dependency on Configuration:** Proper client-side validation requires users to explicitly enable calculation (`crc32c: true`, `md5: true`) or provide the pre-calculated hashes. 

## Checklist

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes #