### PR TITLE
deps: update fast-xml-parser to 5.3.4 due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "abort-controller": "^3.0.0",
     "async-retry": "^1.3.3",
     "duplexify": "^4.1.3",
-    "fast-xml-parser": "^4.4.1",
+    "fast-xml-parser": "^5.3.4",
     "gaxios": "^6.0.2",
     "google-auth-library": "^9.6.3",
     "html-entities": "^2.5.2",


### PR DESCRIPTION
Fixes [GHSA-37qj-frw5-hhjh CVE](https://nvd.nist.gov/vuln/detail/CVE-2026-25128), which affects versions 4.3.6 through 5.3.3. The vulnerability causes a RangeError when parsing numeric XML entities with out-of-range code points, which affects audit checks.

Fixes #2709

> Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

## Description
Update fast-xml-parser version to ^5.3.4 because of the CVE above

> Please provide a detailed description for the change.
> As much as possible, please try to keep changes separate by purpose. For example, try not to make a one-line bug fix in a feature request, or add an irrelevant README change to a bug fix.

## Impact

> What's the impact of this change?
There is a vulnerability in fast-xml-parser when parsing numeric XML entities. I have updated fast-xml-parser from ^4.4.1 to ^5.3.4. This will allow audit checks to succeed.

## Testing

> Have you added unit and integration tests if necessary? no
> Were any tests changed? Are any breaking changes necessary? no

## Additional Information

> Any additional details that we should be aware of?

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [x] Appropriate docs were updated
- [x] Appropriate comments were added, particularly in complex areas or places that require background
- [x] No new warnings or issues will be generated from this change

Fixes #2709 🦕
