### PR TITLE
fix: append bucket name to V4 policy URL in emulator mode

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -2937,7 +2937,11 @@ class File extends ServiceObject<File, FileMetadata> {
 
         let url: string;
 
-        if (this.storage.customEndpoint) {
+        const EMULATOR_HOST = process.env.STORAGE_EMULATOR_HOST;
+
+        if (this.storage.customEndpoint && typeof EMULATOR_HOST === 'string') {
+          url = `${this.storage.apiEndpoint}/${this.bucket.name}`;
+        } else if (this.storage.customEndpoint) {
           url = this.storage.apiEndpoint;
         } else if (options.virtualHostedStyle) {
           url = `https://${this.bucket.name}.storage.${universe}/`;

--- a/test/file.ts
+++ b/test/file.ts
@@ -3580,6 +3580,9 @@ describe('File', () => {
 
     it('should append bucket name to the URL when using the emulator', done => {
       const emulatorHost = 'http://127.0.0.1:9199';
+      const originalApiEndpoint = STORAGE.apiEndpoint;
+      const originalCustomEndpoint = STORAGE.customEndpoint;
+      const originalEnvHost = process.env.STORAGE_EMULATOR_HOST;
 
       process.env.STORAGE_EMULATOR_HOST = emulatorHost;
       STORAGE.apiEndpoint = emulatorHost;
@@ -3588,6 +3591,14 @@ describe('File', () => {
       file.generateSignedPostPolicyV4(
         CONFIG,
         (err: Error, res: SignedPostPolicyV4Output) => {
+          STORAGE.apiEndpoint = originalApiEndpoint;
+          STORAGE.customEndpoint = originalCustomEndpoint;
+          if (originalEnvHost) {
+            process.env.STORAGE_EMULATOR_HOST = originalEnvHost;
+          } else {
+            delete process.env.STORAGE_EMULATOR_HOST;
+          }
+
           assert.ifError(err);
           assert.strictEqual(res.url, `${emulatorHost}/${BUCKET.name}`);
           done();

--- a/test/file.ts
+++ b/test/file.ts
@@ -3578,6 +3578,23 @@ describe('File', () => {
       );
     });
 
+    it('should append bucket name to the URL when using the emulator', done => {
+      const emulatorHost = 'http://127.0.0.1:9199';
+
+      process.env.STORAGE_EMULATOR_HOST = emulatorHost;
+      STORAGE.apiEndpoint = emulatorHost;
+      STORAGE.customEndpoint = true;
+
+      file.generateSignedPostPolicyV4(
+        CONFIG,
+        (err: Error, res: SignedPostPolicyV4Output) => {
+          assert.ifError(err);
+          assert.strictEqual(res.url, `${emulatorHost}/${BUCKET.name}`);
+          done();
+        }
+      );
+    });
+
     describe('expires', () => {
       it('should accept Date objects', done => {
         const expires = new Date(Date.now() + 1000 * 60);


### PR DESCRIPTION
> Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

## Description

> This PR fixes a bug where generateSignedPostPolicyV4 returns an incorrect URL (missing the bucket name) when the STORAGE_EMULATOR_HOST environment variable is set.
> This change is scoped strictly to this method and does not modify the global apiEndpoint or Service configuration.

## Impact

> Updated generateSignedPostPolicyV4 in src/file.ts to explicitly append the bucket name to the URL if the client is running in emulator mode and the bucket path is missing.

## Testing

> Added a new test case in test/file.ts to verify that the bucket name is correctly appended to the URL when STORAGE_EMULATOR_HOST is active.
> Ran existing tests: Verified that all existing tests pass (npm test) to ensure no regressions.
> No breaking changes are introduced.

## Additional Information

> This PR is somewhat related `https://github.com/googleapis/nodejs-storage/issues/2092`.
> But This PR avoids those issues by applying a localized fix solely for the V4 Post Policy generation instead of modifying the global service configuration.

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [x] Appropriate comments were added, particularly in complex areas or places that require background
- [x] No new warnings or issues will be generated from this change

Fixes #issue_number_goes_here 🦕

issue: https://github.com/googleapis/nodejs-storage/issues/2715