### PR TITLE
chore: replace old nodejs teams with cloud-sdk-nodejs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # Unless specified, the jsteam is the default owner for nodejs repositories.
-*     @googleapis/gcs-sdk-team @googleapis/jsteam
+*     @googleapis/gcs-sdk-team @googleapis/cloud-sdk-nodejs-team


### PR DESCRIPTION
b/479541676