### PR TITLE
chore: replace old teams with cloud-sdk-nodejs-team and gcs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # Unless specified, the jsteam is the default owner for nodejs repositories.
-*     @googleapis/gcs-sdk-team @googleapis/cloud-sdk-nodejs-team
+*     @googleapis/gcs-team @googleapis/cloud-sdk-nodejs-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # Unless specified, the jsteam is the default owner for nodejs repositories.
-*     @googleapis/gcs-team @googleapis/cloud-sdk-nodejs-team @googleapis/cloud-sdk-nodejs-team
+*     @googleapis/gcs-team @googleapis/cloud-sdk-nodejs-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # Unless specified, the jsteam is the default owner for nodejs repositories.
-*     @googleapis/gcs-team @googleapis/cloud-sdk-nodejs-team
+*     @googleapis/gcs-team @googleapis/cloud-sdk-nodejs-team @googleapis/cloud-sdk-nodejs-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,7 +10,7 @@
   "distribution_name": "@google-cloud/storage",
   "api_id": "storage-api.googleapis.com",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/gcs-team @googleapis/cloud-sdk-nodejs-team",
+  "codeowner_team": "@googleapis/gcs-team",
   "api_shortname": "storage",
   "library_type": "GAPIC_MANUAL"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,7 +10,7 @@
   "distribution_name": "@google-cloud/storage",
   "api_id": "storage-api.googleapis.com",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/gcs-sdk-team",
+  "codeowner_team": "@googleapis/gcs-team @googleapis/cloud-sdk-nodejs-team",
   "api_shortname": "storage",
   "library_type": "GAPIC_MANUAL"
 }


### PR DESCRIPTION
This PR replaces the old gcs-sdk-team with gcs-team and ensures cloud-sdk-nodejs-team is in .repo-metadata.json.

b/478003109